### PR TITLE
update of include cv.h to opencv/cv.hpp in order to compile with opencv3.0

### DIFF
--- a/src/libs/fvfilters/gauss.cpp
+++ b/src/libs/fvfilters/gauss.cpp
@@ -27,7 +27,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/hipass.cpp
+++ b/src/libs/fvfilters/hipass.cpp
@@ -26,7 +26,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/laplace.cpp
+++ b/src/libs/fvfilters/laplace.cpp
@@ -30,7 +30,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/median.cpp
+++ b/src/libs/fvfilters/median.cpp
@@ -27,7 +27,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/morphology/dilation.cpp
+++ b/src/libs/fvfilters/morphology/dilation.cpp
@@ -31,7 +31,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/morphology/erosion.cpp
+++ b/src/libs/fvfilters/morphology/erosion.cpp
@@ -30,7 +30,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/or.cpp
+++ b/src/libs/fvfilters/or.cpp
@@ -29,7 +29,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/sharpen.cpp
+++ b/src/libs/fvfilters/sharpen.cpp
@@ -27,7 +27,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/sobel.cpp
+++ b/src/libs/fvfilters/sobel.cpp
@@ -27,7 +27,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif

--- a/src/libs/fvfilters/threshold.cpp
+++ b/src/libs/fvfilters/threshold.cpp
@@ -32,7 +32,7 @@
 #ifdef HAVE_IPP
 #  include <ippi.h>
 #elif defined(HAVE_OPENCV)
-#  include <cv.h>
+#  include <opencv/cv.hpp>
 #else
 #  error "Neither IPP nor OpenCV available"
 #endif


### PR DESCRIPTION
In opencv 3.0.0 is /usr/include/opencv not in CFLAGS anymore. It is necessary add path into include (e.g. #include ) or include related module (e.g. #include ) which seems to be recommended.
