### PR TITLE
clips-executive: cancel skiller if action disappeared

### DIFF
--- a/src/plugins/clips-executive/clips/skills-actions.clp
+++ b/src/plugins/clips-executive/clips/skills-actions.clp
@@ -101,9 +101,9 @@
 )
 
 (defrule skill-action-retract-execinfo-without-action
-	?pe <- (skill-action-execinfo (goal-id ?goal-id) (plan-id ?plan-id)
-																(action-id ?id))
-  (not (skill (status S_RUNNING)))
+  ?pe <- (skill-action-execinfo (goal-id ?goal-id) (plan-id ?plan-id)
+                                (action-id ?id) (skill-id ?skill-id))
+  (not (skill (status S_RUNNING) (id ?skill-id)))
   (not (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (id ?action-id)))
   =>
   (retract ?pe)

--- a/src/plugins/clips-executive/clips/skills-actions.clp
+++ b/src/plugins/clips-executive/clips/skills-actions.clp
@@ -85,3 +85,17 @@
 	(modify ?pa (status EXECUTION-FAILED))
 	(retract ?sf ?pe)
 )
+
+(defrule skill-action-cancel-if-action-does-not-exist
+  ?pe <- (skill-action-execinfo (goal-id ?goal-id) (plan-id ?plan-id)
+                                (action-id ?id) (skill-id ?skill-id))
+  (skill (id ?skill-id) (status S_RUNNING))
+  (not (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (id ?id)))
+  =>
+  (printout warn
+    "Cancelling Skill Execution, corresponding action does not exist" crlf)
+  (bind ?m
+    (blackboard-create-msg "SkillerInterface::Skiller" "StopExecMessage"))
+  (blackboard-send-msg ?m)
+  (retract ?pe)
+)

--- a/src/plugins/clips-executive/clips/skills-actions.clp
+++ b/src/plugins/clips-executive/clips/skills-actions.clp
@@ -99,3 +99,12 @@
   (blackboard-send-msg ?m)
   (retract ?pe)
 )
+
+(defrule skill-action-retract-execinfo-without-action
+	?pe <- (skill-action-execinfo (goal-id ?goal-id) (plan-id ?plan-id)
+																(action-id ?id))
+  (not (skill (status S_RUNNING)))
+  (not (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (id ?action-id)))
+  =>
+  (retract ?pe)
+)


### PR DESCRIPTION
If we're currently executing a skill but the respective plan-action does not exist anymore, skill execution should be canceled.