### PR TITLE
robot memory: fix oplog exception

### DIFF
--- a/src/plugins/robot-memory/event_trigger_manager.cpp
+++ b/src/plugins/robot-memory/event_trigger_manager.cpp
@@ -81,12 +81,16 @@ void EventTriggerManager::check_events()
 
   for(EventTrigger *trigger : triggers)
   {
-    while(trigger->oplog_cursor->more())
-    {
-      BSONObj change = trigger->oplog_cursor->next();
-      //logger_->log_info(name.c_str(), "Triggering: %s", change.toString().c_str());
-      //actually call the callback function
-      trigger->callback(change);
+    try {
+      while(trigger->oplog_cursor->more())
+      {
+        BSONObj change = trigger->oplog_cursor->next();
+        //logger_->log_info(name.c_str(), "Triggering: %s", change.toString().c_str());
+        //actually call the callback function
+        trigger->callback(change);
+      }
+    } catch (mongo::DBException &e) {
+      logger_->log_error(name.c_str(), "Error while reading the oplog");
     }
     if(trigger->oplog_cursor->isDead())
     {

--- a/src/plugins/robot-memory/event_trigger_manager.cpp
+++ b/src/plugins/robot-memory/event_trigger_manager.cpp
@@ -82,8 +82,7 @@ void EventTriggerManager::check_events()
   for(EventTrigger *trigger : triggers)
   {
     try {
-      while(trigger->oplog_cursor->more())
-      {
+      while (trigger->oplog_cursor->more()) {
         BSONObj change = trigger->oplog_cursor->next();
         //logger_->log_info(name.c_str(), "Triggering: %s", change.toString().c_str());
         //actually call the callback function

--- a/src/plugins/robot-memory/robot_memory.cpp
+++ b/src/plugins/robot-memory/robot_memory.cpp
@@ -877,9 +877,32 @@ RobotMemory::mutex_try_lock(const std::string& name,
 		        new_doc.getField("locked").Bool());
 
 	} catch (mongo::OperationException &e) {
-		//if (e.obj()["code"].numberInt() != 11000) {
-		// 11000: Duplicate key exception, occurs if we do not become leader, all fine
+		logger_->log_error(name_, "Mongo OperationException: %s", e.what());
+		try {
+		mongo::BSONObjBuilder check_doc;
+		check_doc.append("_id", name);
+		check_doc.append("locked", true);
+		check_doc.append("locked-by", identity);
+		BSONObj res_doc  =
+		  client->findOne(cfg_coord_mutex_collection_, check_doc.obj());
+		logger_->log_info(name_,
+		  "Checking whether mutex was acquired succeeded");
+		if (!res_doc.isEmpty()) {
+			logger_->log_warn(name_,
+			  "Exception during try-lock for %s, but mutex was still acquired",
+			  name.c_str());
+		} else {
+			logger_->log_info(name_,
+			  "Exception during try-lock for %s, and mutex was not acquired",
+			  name.c_str());
+		}
+		return !res_doc.isEmpty();
+		} catch (mongo::OperationException &e) {
+		logger_->log_error(name_,
+		  "Mongo OperationException while handling the first exception: %s",
+		  e.what());
 		return false;
+		}
 	}
 }
 

--- a/src/plugins/robot-memory/robot_memory.cpp
+++ b/src/plugins/robot-memory/robot_memory.cpp
@@ -879,29 +879,32 @@ RobotMemory::mutex_try_lock(const std::string& name,
 	} catch (mongo::OperationException &e) {
 		logger_->log_error(name_, "Mongo OperationException: %s", e.what());
 		try {
-		mongo::BSONObjBuilder check_doc;
-		check_doc.append("_id", name);
-		check_doc.append("locked", true);
-		check_doc.append("locked-by", identity);
-		BSONObj res_doc  =
-		  client->findOne(cfg_coord_mutex_collection_, check_doc.obj());
-		logger_->log_info(name_,
-		  "Checking whether mutex was acquired succeeded");
-		if (!res_doc.isEmpty()) {
-			logger_->log_warn(name_,
-			  "Exception during try-lock for %s, but mutex was still acquired",
-			  name.c_str());
-		} else {
+			mongo::BSONObjBuilder check_doc;
+			check_doc.append("_id", name);
+			check_doc.append("locked", true);
+			check_doc.append("locked-by", identity);
+			BSONObj res_doc  =
+			  client->findOne(cfg_coord_mutex_collection_, check_doc.obj());
 			logger_->log_info(name_,
-			  "Exception during try-lock for %s, and mutex was not acquired",
-			  name.c_str());
-		}
-		return !res_doc.isEmpty();
+			                  "Checking whether mutex was acquired succeeded");
+			if (!res_doc.isEmpty()) {
+				logger_->log_warn(name_,
+				                  "Exception during try-lock for %s, "
+				                  "but mutex was still acquired",
+				                  name.c_str());
+			} else {
+				logger_->log_info(name_,
+				                  "Exception during try-lock for %s, "
+				                  "and mutex was not acquired",
+				                  name.c_str());
+			}
+			return !res_doc.isEmpty();
 		} catch (mongo::OperationException &e) {
-		logger_->log_error(name_,
-		  "Mongo OperationException while handling the first exception: %s",
-		  e.what());
-		return false;
+			logger_->log_error(name_,
+			                   "Mongo OperationException while handling "
+			                   "the first exception: %s",
+			                   e.what());
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
Add a missing try catch block to catch a possible mongodb exception. Also, if we get an exception while trying to lock, check the database again whether we still acquired the lock. We have seen a several cases where an exception was thrown, but the mutex was actually locked successfully. In that case, we should proceed as if no exception occurred.