### PR TITLE
clips-executive: fix action timeout on nowait action

### DIFF
--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -737,7 +737,7 @@
 (defrule domain-effects-ignore-sensed
   "Do not wait for sensed effects if the operator is not a waiting operator."
   (declare (salience ?*SALIENCE-DOMAIN-APPLY*))
-  ?pa <- (plan-action	(id ?id) (action-name ?op) (state EXECUTION-SUCCEEDED))
+  ?pa <- (plan-action	(id ?id) (action-name ?op) (state SENSED-EFFECTS-WAIT))
 	(domain-operator (name ?op) (wait-sensed FALSE))
 	=>
 	(modify ?pa (state SENSED-EFFECTS-HOLD))


### PR DESCRIPTION
Switch any nowait action that is in the state `SENSED-EFFECTS-WAIT` to
`SENSED-EFFECTS-HOLD`.

This fixes a bug introduced by merge 1cf063f6b5442e93185019f5054dca1ce1ea4cba which would cause all nowait
actions to block and then eventually timeout.

This restores the behavior introduced with commit f486472151e334d8813b812c448b86b3dfb7ef98.