### PR TITLE
buildkite: update merged-pr build plugin to 0.0.7

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 merged-pr-plugin: &merged-pr-plugin
-  seek-oss/github-merged-pr#v0.0.6:
+  seek-oss/github-merged-pr#v0.0.7:
     mode: checkout
 
 steps:
@@ -31,9 +31,9 @@ steps:
       docker#v1.4.0:
         image: fawkesrobotics/fawkes-builder:fedora28-kinetic
         always-pull: true
+        debug: true
         mounts:
           - /var/lib/buildkite-agent/ccache_fedora:/var/cache/ccache
-        debug: true
 
   - label: ":ubuntu: Ubuntu"
     command: .buildkite/build
@@ -42,7 +42,7 @@ steps:
       docker#v1.4.0:
         image: fawkesrobotics/fawkes-builder:ubuntu1804-melodic
         always-pull: true
+        debug: true
         mounts:
           - /var/lib/buildkite-agent/ccache_ubuntu:/var/cache/ccache
-        debug: true
 


### PR DESCRIPTION
Adds a small patch (seek-oss/github-merged-pr-buildkite-plugin#13) that ensures that the merge is performed non-interactive.