### PR TITLE
Always protect mongodb client access with a mutex

### DIFF
--- a/src/plugins/robot-memory/event_trigger_manager.cpp
+++ b/src/plugins/robot-memory/event_trigger_manager.cpp
@@ -81,6 +81,7 @@ void EventTriggerManager::check_events()
 
   for(EventTrigger *trigger : triggers)
   {
+    bool ok = true;
     try {
       while (trigger->oplog_cursor->more()) {
         BSONObj change = trigger->oplog_cursor->next();
@@ -90,8 +91,9 @@ void EventTriggerManager::check_events()
       }
     } catch (mongo::DBException &e) {
       logger_->log_error(name.c_str(), "Error while reading the oplog");
+      ok = false;
     }
-    if(trigger->oplog_cursor->isDead())
+    if(!ok || trigger->oplog_cursor->isDead())
     {
       if (cfg_debug_)
         logger_->log_debug(name.c_str(), "Tailable Cursor is dead, requerying");

--- a/src/plugins/robot-memory/robot_memory.cpp
+++ b/src/plugins/robot-memory/robot_memory.cpp
@@ -797,7 +797,7 @@ RobotMemory::mutex_create(const std::string& name)
 	insert_doc.append("_id", name);
 	insert_doc.append("locked", false);
 	try {
-		MutexLocker locker(mutex_);
+		MutexLocker lock(mutex_);
 		client->insert(cfg_coord_mutex_collection_, insert_doc.obj(),
 		               0, &mongo::WriteConcern::majority);
 		return true;
@@ -820,7 +820,7 @@ RobotMemory::mutex_destroy(const std::string& name)
 		distributed_ ? mongodb_client_distributed_ : mongodb_client_local_;
 	mongo::BSONObj destroy_doc{BSON("_id" << name)};
 	try {
-		MutexLocker locker(mutex_);
+		MutexLocker lock(mutex_);
 		client->remove(cfg_coord_mutex_collection_, destroy_doc,
 		               true, &mongo::WriteConcern::majority);
 		return true;
@@ -868,7 +868,7 @@ RobotMemory::mutex_try_lock(const std::string& name,
 	update_doc.append("$set", update_set.obj());
 
 	try {
-		MutexLocker locker(mutex_);
+		MutexLocker lock(mutex_);
 		BSONObj new_doc =
 			client->findAndModify(cfg_coord_mutex_collection_,
 			                      filter_doc.obj(), update_doc.obj(),
@@ -886,7 +886,7 @@ RobotMemory::mutex_try_lock(const std::string& name,
 			check_doc.append("_id", name);
 			check_doc.append("locked", true);
 			check_doc.append("locked-by", identity);
-			MutexLocker locker(mutex_);
+			MutexLocker lock(mutex_);
 			BSONObj res_doc  =
 			  client->findOne(cfg_coord_mutex_collection_, check_doc.obj());
 			logger_->log_info(name_,
@@ -954,7 +954,7 @@ RobotMemory::mutex_unlock(const std::string& name,
 	                                                "lock-time" << true))};
 
 	try {
-		MutexLocker locker(mutex_);
+		MutexLocker lock(mutex_);
 		BSONObj new_doc =
 			client->findAndModify(cfg_coord_mutex_collection_,
 			                      filter_doc, update_doc,
@@ -1005,7 +1005,7 @@ RobotMemory::mutex_renew_lock(const std::string& name,
 	update_doc.append("$set", update_set.obj());
 
 	try {
-		MutexLocker locker(mutex_);
+		MutexLocker lock(mutex_);
 		BSONObj new_doc =
 			client->findAndModify(cfg_coord_mutex_collection_,
 			                      filter_doc, update_doc.obj(),
@@ -1081,7 +1081,7 @@ RobotMemory::mutex_expire_locks(float max_age_sec)
 	                               "lock-time" << mongo::LT << expire_before_mdb)};
 
 	try {
-		MutexLocker locker(mutex_);
+		MutexLocker lock(mutex_);
 		client->remove(cfg_coord_mutex_collection_, filter_doc,
 		               true, &mongo::WriteConcern::majority);
 

--- a/src/plugins/robot-memory/robot_memory.cpp
+++ b/src/plugins/robot-memory/robot_memory.cpp
@@ -866,6 +866,7 @@ RobotMemory::mutex_try_lock(const std::string& name,
 	update_doc.append("$set", update_set.obj());
 
 	try {
+		MutexLocker locker(mutex_);
 		BSONObj new_doc =
 			client->findAndModify(cfg_coord_mutex_collection_,
 			                      filter_doc.obj(), update_doc.obj(),
@@ -883,6 +884,7 @@ RobotMemory::mutex_try_lock(const std::string& name,
 			check_doc.append("_id", name);
 			check_doc.append("locked", true);
 			check_doc.append("locked-by", identity);
+			MutexLocker locker(mutex_);
 			BSONObj res_doc  =
 			  client->findOne(cfg_coord_mutex_collection_, check_doc.obj());
 			logger_->log_info(name_,
@@ -950,6 +952,7 @@ RobotMemory::mutex_unlock(const std::string& name,
 	                                                "lock-time" << true))};
 
 	try {
+		MutexLocker locker(mutex_);
 		BSONObj new_doc =
 			client->findAndModify(cfg_coord_mutex_collection_,
 			                      filter_doc, update_doc,
@@ -1000,6 +1003,7 @@ RobotMemory::mutex_renew_lock(const std::string& name,
 	update_doc.append("$set", update_set.obj());
 
 	try {
+		MutexLocker locker(mutex_);
 		BSONObj new_doc =
 			client->findAndModify(cfg_coord_mutex_collection_,
 			                      filter_doc, update_doc.obj(),
@@ -1075,6 +1079,7 @@ RobotMemory::mutex_expire_locks(float max_age_sec)
 	                               "lock-time" << mongo::LT << expire_before_mdb)};
 
 	try {
+		MutexLocker locker(mutex_);
 		client->remove(cfg_coord_mutex_collection_, filter_doc,
 		               true, &mongo::WriteConcern::majority);
 

--- a/src/plugins/robot-memory/robot_memory.cpp
+++ b/src/plugins/robot-memory/robot_memory.cpp
@@ -797,6 +797,7 @@ RobotMemory::mutex_create(const std::string& name)
 	insert_doc.append("_id", name);
 	insert_doc.append("locked", false);
 	try {
+		MutexLocker locker(mutex_);
 		client->insert(cfg_coord_mutex_collection_, insert_doc.obj(),
 		               0, &mongo::WriteConcern::majority);
 		return true;
@@ -819,6 +820,7 @@ RobotMemory::mutex_destroy(const std::string& name)
 		distributed_ ? mongodb_client_distributed_ : mongodb_client_local_;
 	mongo::BSONObj destroy_doc{BSON("_id" << name)};
 	try {
+		MutexLocker locker(mutex_);
 		client->remove(cfg_coord_mutex_collection_, destroy_doc,
 		               true, &mongo::WriteConcern::majority);
 		return true;


### PR DESCRIPTION
The mongodb is not thread-safe and access must always be protected with a mutex. Add some missing mutex locks. This should protect every access to the mongodb client.

Also fix an issue with an apparently dead oplog cursor that would not be re-queried if an exception occurred.