### PR TITLE
Merge Clingo ASP solver integration

### DIFF
--- a/src/plugins/Makefile
+++ b/src/plugins/Makefile
@@ -30,7 +30,8 @@ SUBDIRS	= bbsync bblogger webview ttmainloop rrd \
 	  mongodb mongodb_log robot-memory clips-robot-memory pddl-robot-memory \
 	  openrave-robot-memory openni refboxcomm ros player xmlrpc gossip \
 	  robot_state_publisher gazebo dynamixel navgraph-interactive \
-	  pddl-planner stn-generator clips-executive
+	  pddl-planner stn-generator clips-executive \
+	  asp
 
 include $(BUILDSYSDIR)/rules.mk
 

--- a/src/plugins/asp/.gitignore
+++ b/src/plugins/asp/.gitignore
@@ -1,0 +1,1 @@
+*.creator.user

--- a/src/plugins/asp/Makefile
+++ b/src/plugins/asp/Makefile
@@ -31,7 +31,7 @@ CFLAGS_CLINGO = -DWITH_THREADS=1 \
 	-I $(HOME)/clingo/libgringo \
 	-I $(HOME)/clingo/liblp \
 	-I $(HOME)/clingo/libprogram_opts
-LDFLAGS_CLINGO = -L$(HOME)/clingo/build/debug/ -Wl,-rpath=$(HOME)/clingo/build/debug/ -lclingo
+LDFLAGS_CLINGO = -L$(HOME)/clingo-build/bin/ -Wl,-rpath=$(HOME)/clingo-build/bin/ -lclingo
 
 # Extra files for system-wide install, i.e., "make install"
 #FILES_clips_files   = $(subst $(SRCDIR)/,,$(wildcard $(SRCDIR)/clips/*.clp))

--- a/src/plugins/asp/Makefile
+++ b/src/plugins/asp/Makefile
@@ -41,14 +41,14 @@ ifeq ($(HAVE_CPP11),1)
   ifeq ($(HAVE_CLINGO),1)
     PRESUBDIRS += aspect
 
-	CFLAGS  += $(CFLAGS_CLINGO) $(CFLAGS_CPP11)
-	LDFLAGS += $(LDFLAGS_CLINGO) $(LDFLAGS_CPP11)
+    CFLAGS  += $(CFLAGS_CLINGO) $(CFLAGS_CPP11)
+    LDFLAGS += $(LDFLAGS_CLINGO) $(LDFLAGS_CPP11)
 
-	PLUGINS_all = $(PLUGINDIR)/asp.so
+    PLUGINS_all = $(PLUGINDIR)/asp.so
 
-	INSTALL_extra = asp_files
-else
-	WARN_TARGETS += warning_clingo
+    INSTALL_extra = asp_files
+  else
+    WARN_TARGETS += warning_clingo
   endif
 else
   WARN_TARGETS += warning_cpp11

--- a/src/plugins/asp/Makefile
+++ b/src/plugins/asp/Makefile
@@ -2,8 +2,8 @@
 #               Makefile Build System for Fawkes: ASP Plugin
 #                            -------------------
 #   Created on Thu Oct 20 15:00:34 2016
-#   Copyright (C) 2016 by Björn Schäpers
-#
+#   Copyright (C) 2016 Björn Schäpers
+#                 2018 Tim Niemueller [www.niemueller.org]
 #*****************************************************************************
 #
 #   This program is free software; you can redistribute it and/or modify
@@ -15,7 +15,7 @@
 
 BASEDIR = ../../..
 include $(BASEDIR)/etc/buildsys/config.mk
-#include $(BUILDSYSDIR)/clips.mk asp.mk?
+include $(SRCDIR)/clingo.mk
 
 LIBS_asp = fawkescore fawkesutils fawkesaspects fawkesblackboard \
 		   fawkesinterface fawkesaspaspect
@@ -23,30 +23,14 @@ OBJS_asp = asp_plugin.o asp_thread.o
 
 OBJS_all = $(OBJS_asp)
 
-#TODO: export this in .mk and really check
-HAVE_CLINGO = 1
-CFLAGS_CLINGO = -DWITH_THREADS=1 \
-	-I $(HOME)/clingo/libclasp \
-	-I $(HOME)/clingo/libclingo \
-	-I $(HOME)/clingo/libgringo \
-	-I $(HOME)/clingo/liblp \
-	-I $(HOME)/clingo/libprogram_opts
-LDFLAGS_CLINGO = -L$(HOME)/clingo-build/bin/ -Wl,-rpath=$(HOME)/clingo-build/bin/ -lclingo
-
-# Extra files for system-wide install, i.e., "make install"
-#FILES_clips_files   = $(subst $(SRCDIR)/,,$(wildcard $(SRCDIR)/clips/*.clp))
-#DESTDIR_clips_files = $(EXEC_SHAREDIR)/clips/clips
-
 ifeq ($(HAVE_CPP11),1)
   ifeq ($(HAVE_CLINGO),1)
     PRESUBDIRS += aspect
 
-    CFLAGS  += $(CFLAGS_CLINGO) $(CFLAGS_CPP11)
+    CFLAGS  += $(CFLAGS_CLINGO)  $(CFLAGS_CPP11)
     LDFLAGS += $(LDFLAGS_CLINGO) $(LDFLAGS_CPP11)
 
     PLUGINS_all = $(PLUGINDIR)/asp.so
-
-    INSTALL_extra = asp_files
   else
     WARN_TARGETS += warning_clingo
   endif

--- a/src/plugins/asp/Makefile
+++ b/src/plugins/asp/Makefile
@@ -1,0 +1,68 @@
+#*****************************************************************************
+#               Makefile Build System for Fawkes: ASP Plugin
+#                            -------------------
+#   Created on Thu Oct 20 15:00:34 2016
+#   Copyright (C) 2016 by Björn Schäpers
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../..
+include $(BASEDIR)/etc/buildsys/config.mk
+#include $(BUILDSYSDIR)/clips.mk asp.mk?
+
+LIBS_asp = fawkescore fawkesutils fawkesaspects fawkesblackboard \
+		   fawkesinterface fawkesaspaspect
+OBJS_asp = asp_plugin.o asp_thread.o
+
+OBJS_all = $(OBJS_asp)
+
+#TODO: export this in .mk and really check
+HAVE_CLINGO = 1
+CFLAGS_CLINGO = -DWITH_THREADS=1 \
+	-I $(HOME)/clingo/libclasp \
+	-I $(HOME)/clingo/libclingo \
+	-I $(HOME)/clingo/libgringo \
+	-I $(HOME)/clingo/liblp \
+	-I $(HOME)/clingo/libprogram_opts
+LDFLAGS_CLINGO = -L$(HOME)/clingo/build/debug/ -Wl,-rpath=$(HOME)/clingo/build/debug/ -lclingo
+
+# Extra files for system-wide install, i.e., "make install"
+#FILES_clips_files   = $(subst $(SRCDIR)/,,$(wildcard $(SRCDIR)/clips/*.clp))
+#DESTDIR_clips_files = $(EXEC_SHAREDIR)/clips/clips
+
+ifeq ($(HAVE_CPP11),1)
+  ifeq ($(HAVE_CLINGO),1)
+    PRESUBDIRS += aspect
+
+	CFLAGS  += $(CFLAGS_CLINGO) $(CFLAGS_CPP11)
+	LDFLAGS += $(LDFLAGS_CLINGO) $(LDFLAGS_CPP11)
+
+	PLUGINS_all = $(PLUGINDIR)/asp.so
+
+	INSTALL_extra = asp_files
+else
+	WARN_TARGETS += warning_clingo
+  endif
+else
+  WARN_TARGETS += warning_cpp11
+endif
+
+ifeq ($(OBJSSUBMAKE),1)
+all: $(WARN_TARGETS)
+
+.PHONY: warning_clingo warning_cpp11
+warning_clingo:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting ASP Plugin$(TNORMAL) ($(CLINGO_ERROR))"
+warning_cpp11:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting ASP Plugin$(TNORMAL) (C++11 not supported)"
+endif
+
+include $(BUILDSYSDIR)/base.mk
+

--- a/src/plugins/asp/asp.config
+++ b/src/plugins/asp/asp.config
@@ -1,0 +1,2 @@
+// Add predefined macros for your project here. For example:
+// #define THE_ANSWER 42

--- a/src/plugins/asp/asp.creator
+++ b/src/plugins/asp/asp.creator
@@ -1,0 +1,1 @@
+[General]

--- a/src/plugins/asp/asp.files
+++ b/src/plugins/asp/asp.files
@@ -7,5 +7,7 @@ asp_thread.cpp
 aspect/Makefile
 aspect/asp.h
 aspect/asp.cpp
+aspect/clingo_control_manager.h
+aspect/clingo_control_manager.cpp
 aspect/asp_inifin.h
 aspect/asp_inifin.cpp

--- a/src/plugins/asp/asp.files
+++ b/src/plugins/asp/asp.files
@@ -9,6 +9,8 @@ aspect/asp.h
 aspect/asp.cpp
 aspect/asp_inifin.h
 aspect/asp_inifin.cpp
+aspect/clingo_access.h
+aspect/clingo_access.cpp
 aspect/clingo_control_manager.h
 aspect/clingo_control_manager.cpp
 aspect/clingo_manager.h

--- a/src/plugins/asp/asp.files
+++ b/src/plugins/asp/asp.files
@@ -7,7 +7,11 @@ asp_thread.cpp
 aspect/Makefile
 aspect/asp.h
 aspect/asp.cpp
-aspect/clingo_control_manager.h
-aspect/clingo_control_manager.cpp
 aspect/asp_inifin.h
 aspect/asp_inifin.cpp
+aspect/clingo_control_manager.h
+aspect/clingo_control_manager.cpp
+aspect/clingo_manager.h
+aspect/clingo_manager.cpp
+aspect/clingo_manager_inifin.h
+aspect/clingo_manager_inifin.cpp

--- a/src/plugins/asp/asp.files
+++ b/src/plugins/asp/asp.files
@@ -1,0 +1,11 @@
+Makefile
+
+asp_plugin.cpp
+asp_thread.h
+asp_thread.cpp
+
+aspect/Makefile
+aspect/asp.h
+aspect/asp.cpp
+aspect/asp_inifin.h
+aspect/asp_inifin.cpp

--- a/src/plugins/asp/asp.includes
+++ b/src/plugins/asp/asp.includes
@@ -1,0 +1,8 @@
+../../libs
+../../../../src/libs
+.
+~/clingo/libclasp
+~/clingo/libclingo
+~/clingo/libgringo
+~/clingo/liblp
+~/clingo/libprogram_opts

--- a/src/plugins/asp/asp_plugin.cpp
+++ b/src/plugins/asp/asp_plugin.cpp
@@ -1,0 +1,47 @@
+
+/***************************************************************************
+ *  asp_plugin.cpp - Plugin to access ASP features
+ *
+ *  Created: Thu Oct 20 15:49:31 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "asp_thread.h"
+#include <core/plugin.h>
+
+using namespace fawkes;
+
+/** Plugin to access ASP from Fawkes.
+ * This plugin integrates ASP and provides access to the Clingo context to other plugins.
+ * @author Björn Schäpers
+ */
+class ASPPlugin : public fawkes::Plugin
+{
+	public:
+	/** Constructor.
+	 * @param config Fawkes configuration
+	 */
+	ASPPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new ASPThread());
+		return;
+	}
+};
+
+
+PLUGIN_DESCRIPTION("Provides Clingo environments")
+EXPORT_PLUGIN(ASPPlugin)

--- a/src/plugins/asp/asp_plugin.cpp
+++ b/src/plugins/asp/asp_plugin.cpp
@@ -38,7 +38,6 @@ class ASPPlugin : public fawkes::Plugin
 	ASPPlugin(Configuration *config) : Plugin(config)
 	{
 		thread_list.push_back(new ASPThread());
-		return;
 	}
 };
 

--- a/src/plugins/asp/asp_plugin.cpp
+++ b/src/plugins/asp/asp_plugin.cpp
@@ -35,7 +35,7 @@ class ASPPlugin : public fawkes::Plugin
 	/** Constructor.
 	 * @param config Fawkes configuration
 	 */
-	ASPPlugin(Configuration *config) : Plugin(config)
+	explicit ASPPlugin(Configuration *config) : Plugin(config)
 	{
 		thread_list.push_back(new ASPThread());
 	}

--- a/src/plugins/asp/asp_thread.cpp
+++ b/src/plugins/asp/asp_thread.cpp
@@ -43,12 +43,7 @@ using namespace fawkes;
 /** Constructor. */
 ASPThread::ASPThread()
 : Thread("ASPThread", Thread::OPMODE_WAITFORWAKEUP),
-  AspectProviderAspect([this]() {
-	                       std::list<fawkes::AspectIniFin*> ret;
-	                       ret.emplace_back(&asp_inifin_);
-	                       ret.emplace_back(&clingo_mgr_inifin_);
-	                       return ret;
-                       }()),
+  AspectProviderAspect({&asp_inifin_, &clingo_mgr_inifin_}),
   control_mgr_(new ClingoControlManager)
 {
 }

--- a/src/plugins/asp/asp_thread.cpp
+++ b/src/plugins/asp/asp_thread.cpp
@@ -42,6 +42,7 @@ ASPThread::ASPThread(void)
 void
 ASPThread::init(void)
 {
+	ASPIniFin.setLogger(logger);
 	return;
 }
 

--- a/src/plugins/asp/asp_thread.cpp
+++ b/src/plugins/asp/asp_thread.cpp
@@ -1,0 +1,58 @@
+/***************************************************************************
+ *  asp_thread.cpp - ASP environment providing Thread
+ *
+ *  Created: Thu Oct 20 15:49:31 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "asp_thread.h"
+
+#include <clingo.hh>
+
+using namespace fawkes;
+
+/** @class ASPThread "clips_thread.h"
+ * ASP environment thread.
+ *
+ * @author Björn Schäpers
+ */
+
+/** Constructor. */
+ASPThread::ASPThread(void)
+  : Thread("ASPThread", Thread::OPMODE_WAITFORWAKEUP),
+	AspectProviderAspect(std::list<fawkes::AspectIniFin*>(1, &ASPIniFin))
+{
+	return;
+}
+
+void
+ASPThread::init(void)
+{
+	return;
+}
+
+void
+ASPThread::finalize(void)
+{
+	return;
+}
+
+void
+ASPThread::loop(void)
+{
+	return;
+}

--- a/src/plugins/asp/asp_thread.cpp
+++ b/src/plugins/asp/asp_thread.cpp
@@ -30,47 +30,43 @@ using namespace fawkes;
  *
  * @author Björn Schäpers
  *
- * @property ASPThread::ASPIniFin
- * @brief The initi-/finalizer for the ASPAspect.
+ * @property ASPThread::asp_inifin_
+ * @brief The initializer/finalizer for the ASPAspect.
  *
- * @property ASPThread::ClingoIniFin
- * @brief The initi-/finalizer for the ClingoManagerAspect.
+ * @property ASPThread::clingo_mgr_inifin_
+ * @brief The initializer/finalizer for the ClingoManagerAspect.
  *
- * @property ASPThread::CtrlMgr
+ * @property ASPThread::control_mgr_
  * @brief The clingo control manager.
  */
 
 /** Constructor. */
-ASPThread::ASPThread(void)
-  : Thread("ASPThread", Thread::OPMODE_WAITFORWAKEUP),
-	AspectProviderAspect([this](void) {
-		std::list<fawkes::AspectIniFin*> ret;
-		ret.emplace_back(&ASPIniFin);
-		ret.emplace_back(&ClingoIniFin);
-		return ret;
-	}()),
-	CtrlMgr(new ClingoControlManager)
+ASPThread::ASPThread()
+: Thread("ASPThread", Thread::OPMODE_WAITFORWAKEUP),
+  AspectProviderAspect([this]() {
+	                       std::list<fawkes::AspectIniFin*> ret;
+	                       ret.emplace_back(&asp_inifin_);
+	                       ret.emplace_back(&clingo_mgr_inifin_);
+	                       return ret;
+                       }()),
+  control_mgr_(new ClingoControlManager)
 {
-	return;
 }
 
 void
-ASPThread::init(void)
+ASPThread::init()
 {
-	CtrlMgr->setLogger(logger);
-	ASPIniFin.setControlManager(CtrlMgr);
-	ClingoIniFin.setControlManager(CtrlMgr);
-	return;
+	control_mgr_->set_logger(logger);
+	asp_inifin_.set_control_manager(control_mgr_);
+	clingo_mgr_inifin_.set_control_manager(control_mgr_);
 }
 
 void
-ASPThread::finalize(void)
+ASPThread::finalize()
 {
-	return;
 }
 
 void
-ASPThread::loop(void)
+ASPThread::loop()
 {
-	return;
 }

--- a/src/plugins/asp/asp_thread.h
+++ b/src/plugins/asp/asp_thread.h
@@ -4,7 +4,7 @@
  *
  *  Created: Thu Oct 20 15:49:31 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -20,16 +20,16 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#ifndef __PLUGINS_ASP_ASP_THREAD_H_
-#define __PLUGINS_ASP_ASP_THREAD_H_
+#ifndef _PLUGINS_ASP_ASP_THREAD_H_
+#define _PLUGINS_ASP_ASP_THREAD_H_
 
 #include <aspect/aspect_provider.h>
 #include <aspect/logging.h>
 #include <core/threading/thread.h>
 
-#include "aspect/asp_inifin.h"
-#include "aspect/clingo_control_manager.h"
-#include "aspect/clingo_manager_inifin.h"
+#include <plugins/asp/aspect/asp_inifin.h>
+#include <plugins/asp/aspect/clingo_control_manager.h>
+#include <plugins/asp/aspect/clingo_manager_inifin.h>
 
 namespace fawkes {
 	class AspectIniFin;
@@ -40,21 +40,22 @@ class ASPThread
   public fawkes::LoggingAspect,
   public fawkes::AspectProviderAspect
 {
-	private:
-	fawkes::ASPAspectIniFin ASPIniFin;
-	fawkes::ClingoManagerAspectIniFin ClingoIniFin;
-	fawkes::LockPtr<fawkes::ClingoControlManager> CtrlMgr;
+public:
+	ASPThread();
 
-	protected:
+	void init() override;
+	void loop() override;
+	void finalize() override;
+
+protected:
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
-	void run(void) override { Thread::run(); return; }
+	void run() override { Thread::run(); }
 
-	public:
-	ASPThread(void);
+private:
+	fawkes::ASPAspectIniFin asp_inifin_;
+	fawkes::ClingoManagerAspectIniFin clingo_mgr_inifin_;
+	fawkes::LockPtr<fawkes::ClingoControlManager> control_mgr_;
 
-	void init(void) override;
-	void loop(void) override;
-	void finalize(void) override;
 };
 
 #endif

--- a/src/plugins/asp/asp_thread.h
+++ b/src/plugins/asp/asp_thread.h
@@ -24,9 +24,12 @@
 #define __PLUGINS_ASP_ASP_THREAD_H_
 
 #include <aspect/aspect_provider.h>
-#include "aspect/asp_inifin.h"
 #include <aspect/logging.h>
 #include <core/threading/thread.h>
+
+#include "aspect/asp_inifin.h"
+#include "aspect/clingo_control_manager.h"
+#include "aspect/clingo_manager_inifin.h"
 
 namespace fawkes {
 	class AspectIniFin;
@@ -39,6 +42,8 @@ class ASPThread
 {
 	private:
 	fawkes::ASPAspectIniFin ASPIniFin;
+	fawkes::ClingoManagerAspectIniFin ClingoIniFin;
+	fawkes::LockPtr<fawkes::ClingoControlManager> CtrlMgr;
 
 	protected:
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
@@ -50,7 +55,6 @@ class ASPThread
 	void init(void) override;
 	void loop(void) override;
 	void finalize(void) override;
-
 };
 
 #endif

--- a/src/plugins/asp/asp_thread.h
+++ b/src/plugins/asp/asp_thread.h
@@ -25,6 +25,7 @@
 
 #include <aspect/aspect_provider.h>
 #include "aspect/asp_inifin.h"
+#include <aspect/logging.h>
 #include <core/threading/thread.h>
 
 namespace fawkes {
@@ -33,6 +34,7 @@ namespace fawkes {
 
 class ASPThread
 : public fawkes::Thread,
+  public fawkes::LoggingAspect,
   public fawkes::AspectProviderAspect
 {
 	private:

--- a/src/plugins/asp/asp_thread.h
+++ b/src/plugins/asp/asp_thread.h
@@ -1,0 +1,54 @@
+
+/***************************************************************************
+ *  asp_thread.h - ASP aspect provider thread
+ *
+ *  Created: Thu Oct 20 15:49:31 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef __PLUGINS_ASP_ASP_THREAD_H_
+#define __PLUGINS_ASP_ASP_THREAD_H_
+
+#include <aspect/aspect_provider.h>
+#include "aspect/asp_inifin.h"
+#include <core/threading/thread.h>
+
+namespace fawkes {
+	class AspectIniFin;
+}
+
+class ASPThread
+: public fawkes::Thread,
+  public fawkes::AspectProviderAspect
+{
+	private:
+	fawkes::ASPAspectIniFin ASPIniFin;
+
+	protected:
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	void run(void) override { Thread::run(); return; }
+
+	public:
+	ASPThread(void);
+
+	void init(void) override;
+	void loop(void) override;
+	void finalize(void) override;
+
+};
+
+#endif

--- a/src/plugins/asp/aspect/Makefile
+++ b/src/plugins/asp/aspect/Makefile
@@ -1,0 +1,61 @@
+#*****************************************************************************
+#             Makefile Build System for Fawkes: ASP Aspect
+#                            -------------------
+#   Created on Thu Oct 20 15:00:34 2016
+#   Copyright (C) 2016 by Björn Schäpers
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../../..
+
+include $(BASEDIR)/etc/buildsys/config.mk
+include $(LIBSRCDIR)/utils/utils.mk
+#include $(BUILDSYSDIR)/asp.mk
+
+LIBS_libfawkesaspaspect = stdc++ fawkescore fawkesaspects fawkesutils
+OBJS_libfawkesaspaspect = $(patsubst %.cpp,%.o,$(patsubst qa/%,,$(subst $(SRCDIR)/,,$(realpath $(wildcard $(SRCDIR)/*.cpp)))))
+
+OBJS_all    = $(OBJS_libfawkesaspaspect)
+
+#TODO: export this in .mk and really check
+HAVE_CLINGO = 1
+CFLAGS_CLINGO = -DWITH_THREADS=1 \
+	-I $(HOME)/clingo/libclasp \
+	-I $(HOME)/clingo/libclingo \
+	-I $(HOME)/clingo/libgringo \
+	-I $(HOME)/clingo/liblp \
+	-I $(HOME)/clingo/libprogram_opts
+LDFLAGS_CLINGO = -L$(HOME)/clingo/build/debug/ -Wl,-rpath=$(HOME)/clingo/build/debug/ -lclingo
+
+ifeq ($(HAVE_CPP11),1)
+  ifeq ($(HAVE_CLINGO),1)
+	CFLAGS  += $(CFLAGS_CLINGO) $(CFLAGS_CPP11)
+	LDFLAGS += $(LDFLAGS_CLINGO) $(LDFLAGS_CPP11)
+
+	LIBS_all = $(LIBDIR)/libfawkesaspaspect.so
+else
+	WARN_TARGETS += warning_clingo
+  endif
+else
+  WARN_TARGETS += warning_cpp11
+endif
+
+ifeq ($(OBJSSUBMAKE),1)
+all: $(WARN_TARGETS)
+
+.PHONY: warning_clingo warning_cpp11
+warning_clingo:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting ASP Aspect$(TNORMAL) ($(CLINGO_ERROR))"
+warning_cpp11:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting ASP Aspect$(TNORMAL) (C++11 not supported)"
+endif
+
+include $(BUILDSYSDIR)/base.mk
+

--- a/src/plugins/asp/aspect/Makefile
+++ b/src/plugins/asp/aspect/Makefile
@@ -17,26 +17,16 @@ BASEDIR = ../../../..
 
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(LIBSRCDIR)/utils/utils.mk
-#include $(BUILDSYSDIR)/asp.mk
+include $(SRCDIR)/../clingo.mk
 
 LIBS_libfawkesaspaspect = stdc++ fawkescore fawkesaspects fawkesutils pthread
 OBJS_libfawkesaspaspect = $(patsubst %.cpp,%.o,$(patsubst qa/%,,$(subst $(SRCDIR)/,,$(realpath $(wildcard $(SRCDIR)/*.cpp)))))
 
 OBJS_all    = $(OBJS_libfawkesaspaspect)
 
-#TODO: export this in .mk and really check
-HAVE_CLINGO = 1
-CFLAGS_CLINGO = -DWITH_THREADS=1 \
-	-I $(HOME)/clingo/libclasp \
-	-I $(HOME)/clingo/libclingo \
-	-I $(HOME)/clingo/libgringo \
-	-I $(HOME)/clingo/liblp \
-	-I $(HOME)/clingo/libprogram_opts
-LDFLAGS_CLINGO = -L$(HOME)/clingo-build/bin -Wl,-rpath=$(HOME)/clingo-build/bin -lclingo
-
 ifeq ($(HAVE_CPP11),1)
   ifeq ($(HAVE_CLINGO),1)
-    CFLAGS  += $(CFLAGS_CLINGO) $(CFLAGS_CPP11)
+    CFLAGS  += $(CFLAGS_CLINGO)  $(CFLAGS_CPP11)
     LDFLAGS += $(LDFLAGS_CLINGO) $(LDFLAGS_CPP11)
 
     LIBS_all = $(LIBDIR)/libfawkesaspaspect.so

--- a/src/plugins/asp/aspect/Makefile
+++ b/src/plugins/asp/aspect/Makefile
@@ -36,12 +36,12 @@ LDFLAGS_CLINGO = -L$(HOME)/clingo/build/debug/ -Wl,-rpath=$(HOME)/clingo/build/d
 
 ifeq ($(HAVE_CPP11),1)
   ifeq ($(HAVE_CLINGO),1)
-	CFLAGS  += $(CFLAGS_CLINGO) $(CFLAGS_CPP11)
-	LDFLAGS += $(LDFLAGS_CLINGO) $(LDFLAGS_CPP11)
+    CFLAGS  += $(CFLAGS_CLINGO) $(CFLAGS_CPP11)
+    LDFLAGS += $(LDFLAGS_CLINGO) $(LDFLAGS_CPP11)
 
-	LIBS_all = $(LIBDIR)/libfawkesaspaspect.so
-else
-	WARN_TARGETS += warning_clingo
+    LIBS_all = $(LIBDIR)/libfawkesaspaspect.so
+  else
+    WARN_TARGETS += warning_clingo
   endif
 else
   WARN_TARGETS += warning_cpp11

--- a/src/plugins/asp/aspect/Makefile
+++ b/src/plugins/asp/aspect/Makefile
@@ -19,7 +19,7 @@ include $(BASEDIR)/etc/buildsys/config.mk
 include $(LIBSRCDIR)/utils/utils.mk
 #include $(BUILDSYSDIR)/asp.mk
 
-LIBS_libfawkesaspaspect = stdc++ fawkescore fawkesaspects fawkesutils
+LIBS_libfawkesaspaspect = stdc++ fawkescore fawkesaspects fawkesutils pthread
 OBJS_libfawkesaspaspect = $(patsubst %.cpp,%.o,$(patsubst qa/%,,$(subst $(SRCDIR)/,,$(realpath $(wildcard $(SRCDIR)/*.cpp)))))
 
 OBJS_all    = $(OBJS_libfawkesaspaspect)

--- a/src/plugins/asp/aspect/Makefile
+++ b/src/plugins/asp/aspect/Makefile
@@ -32,7 +32,7 @@ CFLAGS_CLINGO = -DWITH_THREADS=1 \
 	-I $(HOME)/clingo/libgringo \
 	-I $(HOME)/clingo/liblp \
 	-I $(HOME)/clingo/libprogram_opts
-LDFLAGS_CLINGO = -L$(HOME)/clingo/build/debug/ -Wl,-rpath=$(HOME)/clingo/build/debug/ -lclingo
+LDFLAGS_CLINGO = -L$(HOME)/clingo-build/bin -Wl,-rpath=$(HOME)/clingo-build/bin -lclingo
 
 ifeq ($(HAVE_CPP11),1)
   ifeq ($(HAVE_CLINGO),1)

--- a/src/plugins/asp/aspect/asp.cpp
+++ b/src/plugins/asp/aspect/asp.cpp
@@ -4,7 +4,7 @@
  *
  *  Created: Thu Oct 20 15:49:31 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -21,13 +21,10 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#include "asp.h"
-#include "clingo_access.h"
+#include <plugins/asp/aspect/asp.h>
+#include <plugins/asp/aspect/clingo_access.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 /** @class ASPAspect <plugins/asp/aspect/asp.h>
  * Thread aspect to get access to an ASP solver.
@@ -36,33 +33,30 @@ namespace fawkes {
  * @ingroup Aspects
  * @author Björn Schäpers
  *
- * @property ASPAspect::ControlName
+ * @property ASPAspect::control_name_
  * @brief The name for the control in the manager.
  *
- * @property ASPAspect::LogComponent
+ * @property ASPAspect::log_comp_
  * @brief The component for the logger.
  *
- * @property ASPAspect::ClingoAcc
+ * @property ASPAspect::clingo
  * @brief Clingo Control for exclusive usage.
  */
 
 
-/**
- * Constructor.
- * @param[in] controlName The desired control name.
- * @param[in] logComponent The component for the logger.
+/** Constructor.
+ * @param[in] control_name The desired control name.
+ * @param[in] log_component The component for the logger.
  */
-ASPAspect::ASPAspect(const std::string&& controlName, const std::string&& logComponent) :
-	ControlName(std::move(controlName)), LogComponent(std::move(logComponent))
+ASPAspect::ASPAspect(const std::string&& control_name, const std::string&& log_component)
+: control_name_(std::move(control_name)), log_comp_(std::move(log_component))
 {
 	add_aspect("ASPAspect");
-	return;
 }
 
 /** Virtual empty destructor. */
 ASPAspect::~ASPAspect(void)
 {
-	return;
 }
 
 
@@ -74,8 +68,7 @@ ASPAspect::~ASPAspect(void)
 void
 ASPAspect::init_ASPAspect(const LockPtr<ClingoAccess>& clingo)
 {
-	ClingoAcc = clingo;
-	return;
+	this->clingo = clingo;
 }
 
 /** Finalize ASP aspect.
@@ -84,8 +77,7 @@ ASPAspect::init_ASPAspect(const LockPtr<ClingoAccess>& clingo)
 void
 ASPAspect::finalize_ASPAspect(void)
 {
-	ClingoAcc.clear();
-	return;
+	clingo.clear();
 }
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/asp.cpp
+++ b/src/plugins/asp/aspect/asp.cpp
@@ -22,7 +22,7 @@
  */
 
 #include "asp.h"
-#include <clingo.hh>
+#include "clingo_access.h"
 
 namespace fawkes {
 #if 0 /* just to make Emacs auto-indent happy */
@@ -69,12 +69,12 @@ ASPAspect::~ASPAspect(void)
 /** Init ASP aspect.
  * This sets the Clingo Control.
  * It is guaranteed that this is called for an ASP Thread before start is called (when running regularly inside Fawkes).
- * @param control The Clingo Control
+ * @param[in] clingo The Clingo Control.
  */
 void
-ASPAspect::init_ASPAspect(LockPtr<Clingo::Control> control)
+ASPAspect::init_ASPAspect(const LockPtr<ClingoAccess>& clingo)
 {
-	ClingoControl = control;
+	Clingo = clingo;
 	return;
 }
 
@@ -82,9 +82,9 @@ ASPAspect::init_ASPAspect(LockPtr<Clingo::Control> control)
  * This clears the Clingo Control.
  */
 void
-ASPAspect::finalize_ASPAspect()
+ASPAspect::finalize_ASPAspect(void)
 {
-	ClingoControl.clear();
+	Clingo.clear();
 	return;
 }
 

--- a/src/plugins/asp/aspect/asp.cpp
+++ b/src/plugins/asp/aspect/asp.cpp
@@ -39,6 +39,9 @@ namespace fawkes {
  * @property ASPAspect::ControlName
  * @brief The name for the control in the manager.
  *
+ * @property ASPAspect::LogComponent
+ * @brief The component for the logger.
+ *
  * @property ASPAspect::ClingoControl
  * @brief Clingo Control for exclusive usage.
  */
@@ -47,8 +50,10 @@ namespace fawkes {
 /**
  * Constructor.
  * @param[in] controlName The desired control name.
+ * @param[in] logComponent The component for the logger.
  */
-ASPAspect::ASPAspect(const std::string&& controlName) : ControlName(std::move(controlName))
+ASPAspect::ASPAspect(const std::string&& controlName, const std::string&& logComponent) :
+	ControlName(std::move(controlName)), LogComponent(std::move(logComponent))
 {
 	add_aspect("ASPAspect");
 	return;

--- a/src/plugins/asp/aspect/asp.cpp
+++ b/src/plugins/asp/aspect/asp.cpp
@@ -36,14 +36,19 @@ namespace fawkes {
  * @ingroup Aspects
  * @author Björn Schäpers
  *
- * @property fawkes:LockPtr<Clingo::Control> ASPAspect::ClingoControl
- * Clingo Control for exclusive usage.
+ * @property ASPAspect::ControlName
+ * @brief The name for the control in the manager.
+ *
+ * @property ASPAspect::ClingoControl
+ * @brief Clingo Control for exclusive usage.
  */
 
 
-/** Constructor.
+/**
+ * Constructor.
+ * @param[in] controlName The desired control name.
  */
-ASPAspect::ASPAspect(void)
+ASPAspect::ASPAspect(const std::string&& controlName) : ControlName(std::move(controlName))
 {
 	add_aspect("ASPAspect");
 	return;

--- a/src/plugins/asp/aspect/asp.cpp
+++ b/src/plugins/asp/aspect/asp.cpp
@@ -1,0 +1,81 @@
+
+/***************************************************************************
+ *  asp.cpp - ASP aspect for Fawkes
+ *
+ *  Created: Thu Oct 20 15:49:31 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#include "asp.h"
+#include <clingo.hh>
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+/** @class ASPAspect <plugins/asp/aspect/asp.h>
+ * Thread aspect to get access to an ASP solver.
+ * Give this aspect to your thread to get a Clingo Control for exclusive usage.
+ *
+ * @ingroup Aspects
+ * @author Björn Schäpers
+ *
+ * @property fawkes:LockPtr<Clingo::Control> ASPAspect::ClingoControl
+ * Clingo Control for exclusive usage.
+ */
+
+
+/** Constructor.
+ */
+ASPAspect::ASPAspect(void)
+{
+	add_aspect("ASPAspect");
+	return;
+}
+
+/** Virtual empty destructor. */
+ASPAspect::~ASPAspect(void)
+{
+	return;
+}
+
+
+/** Init ASP aspect.
+ * This sets the Clingo Control.
+ * It is guaranteed that this is called for an ASP Thread before start is called (when running regularly inside Fawkes).
+ * @param control The Clingo Control
+ */
+void
+ASPAspect::init_ASPAspect(LockPtr<Clingo::Control> control)
+{
+	ClingoControl = control;
+	return;
+}
+
+/** Finalize ASP aspect.
+ * This clears the Clingo Control.
+ */
+void
+ASPAspect::finalize_ASPAspect()
+{
+	ClingoControl.clear();
+	return;
+}
+
+} // end namespace fawkes

--- a/src/plugins/asp/aspect/asp.cpp
+++ b/src/plugins/asp/aspect/asp.cpp
@@ -42,7 +42,7 @@ namespace fawkes {
  * @property ASPAspect::LogComponent
  * @brief The component for the logger.
  *
- * @property ASPAspect::ClingoControl
+ * @property ASPAspect::ClingoAcc
  * @brief Clingo Control for exclusive usage.
  */
 
@@ -74,7 +74,7 @@ ASPAspect::~ASPAspect(void)
 void
 ASPAspect::init_ASPAspect(const LockPtr<ClingoAccess>& clingo)
 {
-	Clingo = clingo;
+	ClingoAcc = clingo;
 	return;
 }
 
@@ -84,7 +84,7 @@ ASPAspect::init_ASPAspect(const LockPtr<ClingoAccess>& clingo)
 void
 ASPAspect::finalize_ASPAspect(void)
 {
-	Clingo.clear();
+	ClingoAcc.clear();
 	return;
 }
 

--- a/src/plugins/asp/aspect/asp.h
+++ b/src/plugins/asp/aspect/asp.h
@@ -29,14 +29,12 @@
 
 #include <string>
 
-namespace Clingo {
-  class Control;
-}
-
 namespace fawkes {
 #if 0 /* just to make Emacs auto-indent happy */
 }
 #endif
+
+class ClingoAccess;
 
 class ASPAspect : public virtual Aspect
 {
@@ -44,11 +42,11 @@ class ASPAspect : public virtual Aspect
 	const std::string ControlName;
 	const std::string LogComponent;
 
-	void init_ASPAspect(LockPtr<Clingo::Control> clingoControl);
-	void finalize_ASPAspect();
+	void init_ASPAspect(const LockPtr<ClingoAccess>& clingo);
+	void finalize_ASPAspect(void);
 
 	protected:
-	LockPtr<Clingo::Control> ClingoControl;
+	LockPtr<ClingoAccess> Clingo;
 
 	public:
 	ASPAspect(const std::string&& controlName, const std::string&& logComponent = std::string());

--- a/src/plugins/asp/aspect/asp.h
+++ b/src/plugins/asp/aspect/asp.h
@@ -4,7 +4,7 @@
  *
  *  Created: Thu Oct 20 15:49:31 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#ifndef __PLUGINS_ASP_ASPECT_ASP_H_
-#define __PLUGINS_ASP_ASPECT_ASP_H_
+#ifndef _PLUGINS_ASP_ASPECT_ASP_H_
+#define _PLUGINS_ASP_ASPECT_ASP_H_
 
 #include <aspect/aspect.h>
 #include <core/utils/lockptr.h>
@@ -30,28 +30,28 @@
 #include <string>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 class ClingoAccess;
 
 class ASPAspect : public virtual Aspect
 {
-	private:
-	const std::string ControlName;
-	const std::string LogComponent;
+public:
+	ASPAspect(const std::string&& control_name, const std::string&& log_component = std::string());
+	virtual ~ASPAspect(void);
+
+private:
+	const std::string control_name_;
+	const std::string log_comp_;
 
 	void init_ASPAspect(const LockPtr<ClingoAccess>& clingo);
 	void finalize_ASPAspect(void);
 
 	protected:
-	LockPtr<ClingoAccess> ClingoAcc;
+	LockPtr<ClingoAccess> clingo;
 
-	public:
-	ASPAspect(const std::string&& controlName, const std::string&& logComponent = std::string());
-	virtual ~ASPAspect(void);
-
+	/** Additional access by ASPAspectIniFin
+	 * @relates ASPAspectIniFin
+	 */
 	friend class ASPAspectIniFin;
 };
 

--- a/src/plugins/asp/aspect/asp.h
+++ b/src/plugins/asp/aspect/asp.h
@@ -42,6 +42,7 @@ class ASPAspect : public virtual Aspect
 {
 	private:
 	const std::string ControlName;
+	const std::string LogComponent;
 
 	void init_ASPAspect(LockPtr<Clingo::Control> clingoControl);
 	void finalize_ASPAspect();
@@ -50,7 +51,7 @@ class ASPAspect : public virtual Aspect
 	LockPtr<Clingo::Control> ClingoControl;
 
 	public:
-	ASPAspect(const std::string&& controlName);
+	ASPAspect(const std::string&& controlName, const std::string&& logComponent = std::string());
 	virtual ~ASPAspect(void);
 
 	friend class ASPAspectIniFin;

--- a/src/plugins/asp/aspect/asp.h
+++ b/src/plugins/asp/aspect/asp.h
@@ -46,7 +46,7 @@ class ASPAspect : public virtual Aspect
 	void finalize_ASPAspect(void);
 
 	protected:
-	LockPtr<ClingoAccess> Clingo;
+	LockPtr<ClingoAccess> ClingoAcc;
 
 	public:
 	ASPAspect(const std::string&& controlName, const std::string&& logComponent = std::string());

--- a/src/plugins/asp/aspect/asp.h
+++ b/src/plugins/asp/aspect/asp.h
@@ -1,0 +1,59 @@
+
+/***************************************************************************
+ *  asp.h - ASP aspect for Fawkes
+ *
+ *  Created: Thu Oct 20 15:49:31 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#ifndef __PLUGINS_ASP_ASPECT_ASP_H_
+#define __PLUGINS_ASP_ASPECT_ASP_H_
+
+#include <aspect/aspect.h>
+#include <core/utils/lockptr.h>
+
+#include <string>
+
+namespace Clingo {
+  class Control;
+}
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+class ASPAspect : public virtual Aspect
+{
+	private:
+	void init_ASPAspect(LockPtr<Clingo::Control> clingoControl);
+	void finalize_ASPAspect();
+
+	protected:
+	LockPtr<Clingo::Control> ClingoControl;
+
+	public:
+	ASPAspect(void);
+	virtual ~ASPAspect(void);
+
+	friend class ASPAspectIniFin;
+};
+
+} // end namespace fawkes
+
+#endif

--- a/src/plugins/asp/aspect/asp.h
+++ b/src/plugins/asp/aspect/asp.h
@@ -41,6 +41,8 @@ namespace fawkes {
 class ASPAspect : public virtual Aspect
 {
 	private:
+	const std::string ControlName;
+
 	void init_ASPAspect(LockPtr<Clingo::Control> clingoControl);
 	void finalize_ASPAspect();
 
@@ -48,7 +50,7 @@ class ASPAspect : public virtual Aspect
 	LockPtr<Clingo::Control> ClingoControl;
 
 	public:
-	ASPAspect(void);
+	ASPAspect(const std::string&& controlName);
 	virtual ~ASPAspect(void);
 
 	friend class ASPAspectIniFin;

--- a/src/plugins/asp/aspect/asp_inifin.cpp
+++ b/src/plugins/asp/aspect/asp_inifin.cpp
@@ -21,29 +21,44 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#include "asp.h"
-#include "asp_inifin.h"
 #include <clingo.hh>
 #include <core/threading/thread_finalizer.h>
 #include <logging/logger.h>
+
+#include "asp.h"
+#include "asp_inifin.h"
+#include "clingo_control_manager.h"
 
 namespace fawkes {
 #if 0 /* just to make Emacs auto-indent happy */
 }
 #endif
 
-/** @class ASPAspectIniFin <plugins/asp/aspect/asp_inifin.h>
+/**
+ * @class ASPAspectIniFin <plugins/asp/aspect/asp_inifin.h>
  * ASPAspect initializer/finalizer.
  * This initializer/finalizer will provide the ASP node handle to threads with the ASPAspect.
  * @author Björn Schäpers
  *
  * @property ASPAspectIniFin::Log
  * @brief The logger used for Clingo Output.
+ *
+ * @property ASPAspectIniFin::CtrlMgr
+ * @brief The control manager.
  */
 
-/** Constructor.
+/**
+ * Constructor.
  */
 ASPAspectIniFin::ASPAspectIniFin(void) : AspectIniFin("ASPAspect"), Log(nullptr)
+{
+	return;
+}
+
+/**
+ * @brief Destructor.
+ */
+ASPAspectIniFin::~ASPAspectIniFin(void)
 {
 	return;
 }
@@ -100,6 +115,17 @@ void
 ASPAspectIniFin::setLogger(Logger *logger)
 {
 	Log = logger;
+	return;
+}
+
+/**
+ * @brief Sets the control manager.
+ * @param[in] ctrlMgr The new control manager.
+ */
+void
+ASPAspectIniFin::setControlManager(const LockPtr<ClingoControlManager>& ctrlMgr)
+{
+	CtrlMgr = ctrlMgr;
 	return;
 }
 

--- a/src/plugins/asp/aspect/asp_inifin.cpp
+++ b/src/plugins/asp/aspect/asp_inifin.cpp
@@ -21,12 +21,12 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#include <clingo.hh>
 #include <core/threading/thread_finalizer.h>
 #include <logging/logger.h>
 
 #include "asp.h"
 #include "asp_inifin.h"
+#include "clingo_access.h"
 #include "clingo_control_manager.h"
 
 namespace fawkes {

--- a/src/plugins/asp/aspect/asp_inifin.cpp
+++ b/src/plugins/asp/aspect/asp_inifin.cpp
@@ -1,0 +1,74 @@
+
+/***************************************************************************
+ *  asp_inifin.cpp - Fawkes ASPAspect initializer/finalizer
+ *
+ *  Created: Thu Oct 20 15:49:31 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#include "asp.h"
+#include "asp_inifin.h"
+#include <clingo.hh>
+#include <core/threading/thread_finalizer.h>
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+/** @class ASPAspectIniFin <plugins/asp/aspect/asp_inifin.h>
+ * ASPAspect initializer/finalizer.
+ * This initializer/finalizer will provide the ASP node handle to threads with the ASPAspect.
+ * @author Björn Schäpers
+ */
+
+/** Constructor. */
+ASPAspectIniFin::ASPAspectIniFin(void) : AspectIniFin("ASPAspect")
+{
+	return;
+}
+
+void
+ASPAspectIniFin::init(Thread *thread)
+{
+	ASPAspect *asp_thread = dynamic_cast<ASPAspect*>(thread);
+	if ( asp_thread == nullptr )
+	{
+	throw CannotInitializeThreadException("Thread '%s' claims to have the ASPAspect, but RTTI says it has not.",
+		thread->name());
+	} //if ( asp_thread == nullptr )
+
+	asp_thread->init_ASPAspect(LockPtr<Clingo::Control>(new Clingo::Control));
+	return;
+}
+
+void
+ASPAspectIniFin::finalize(Thread *thread)
+{
+	ASPAspect *asp_thread = dynamic_cast<ASPAspect*>(thread);
+	if ( asp_thread == nullptr )
+	{
+	throw CannotFinalizeThreadException("Thread '%s' claims to have the ASPAspect, but RTTI says it has not.",
+		thread->name());
+	} //if ( asp_thread == nullptr )
+
+	asp_thread->finalize_ASPAspect();
+	return;
+}
+
+} // end namespace fawkes

--- a/src/plugins/asp/aspect/asp_inifin.cpp
+++ b/src/plugins/asp/aspect/asp_inifin.cpp
@@ -4,7 +4,7 @@
  *
  *  Created: Thu Oct 20 15:49:31 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -24,15 +24,12 @@
 #include <core/threading/thread_finalizer.h>
 #include <logging/logger.h>
 
-#include "asp.h"
-#include "asp_inifin.h"
-#include "clingo_access.h"
-#include "clingo_control_manager.h"
+#include <plugins/asp/aspect/asp.h>
+#include <plugins/asp/aspect/asp_inifin.h>
+#include <plugins/asp/aspect/clingo_access.h>
+#include <plugins/asp/aspect/clingo_control_manager.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 /**
  * @class ASPAspectIniFin <plugins/asp/aspect/asp_inifin.h>
@@ -40,63 +37,54 @@ namespace fawkes {
  * This initializer/finalizer will provide the ASP node handle to threads with the ASPAspect.
  * @author Björn Schäpers
  *
- * @property ASPAspectIniFin::CtrlMgr
+ * @property ASPAspectIniFin::ctrl_mgr_
  * @brief The control manager.
  */
 
-/**
- * Constructor.
- */
-ASPAspectIniFin::ASPAspectIniFin(void) : AspectIniFin("ASPAspect")
+/** Constructor. */
+ASPAspectIniFin::ASPAspectIniFin() : AspectIniFin("ASPAspect")
 {
-	return;
 }
 
-/**
- * @brief Destructor.
- */
-ASPAspectIniFin::~ASPAspectIniFin(void)
+/** Destructor. */
+ASPAspectIniFin::~ASPAspectIniFin()
 {
-	return;
 }
 
 void
 ASPAspectIniFin::init(Thread *thread)
 {
 	ASPAspect *asp_thread = dynamic_cast<ASPAspect*>(thread);
-	if ( asp_thread == nullptr )
-	{
-	throw CannotInitializeThreadException("Thread '%s' claims to have the ASPAspect, but RTTI says it has not.",
-		thread->name());
-	} //if ( asp_thread == nullptr )
+	if ( asp_thread == nullptr ) {
+		throw CannotInitializeThreadException("Thread '%s' claims to have the ASPAspect, "
+		                                      "but RTTI says it has not.",
+		                                      thread->name());
+	}
 
-	asp_thread->init_ASPAspect(CtrlMgr->create_control(asp_thread->ControlName, asp_thread->LogComponent));
-	return;
+	asp_thread->init_ASPAspect(ctrl_mgr_->create_control(asp_thread->control_name_,
+	                                                     asp_thread->log_comp_));
 }
 
 void
 ASPAspectIniFin::finalize(Thread *thread)
 {
 	ASPAspect *asp_thread = dynamic_cast<ASPAspect*>(thread);
-	if ( asp_thread == nullptr )
-	{
-	throw CannotFinalizeThreadException("Thread '%s' claims to have the ASPAspect, but RTTI says it has not.",
-		thread->name());
-	} //if ( asp_thread == nullptr )
+	if ( asp_thread == nullptr ) {
+		throw CannotFinalizeThreadException("Thread '%s' claims to have the ASPAspect, "
+		                                    "but RTTI says it has not.",
+		                                    thread->name());
+	}
 
 	asp_thread->finalize_ASPAspect();
-	return;
 }
 
-/**
- * @brief Sets the control manager.
- * @param[in] ctrlMgr The new control manager.
+/** Sets the control manager.
+ * @param[in] ctrl_mgr The new control manager
  */
 void
-ASPAspectIniFin::setControlManager(const LockPtr<ClingoControlManager>& ctrlMgr)
+ASPAspectIniFin::set_control_manager(const LockPtr<ClingoControlManager>& ctrl_mgr)
 {
-	CtrlMgr = ctrlMgr;
-	return;
+	ctrl_mgr_ = ctrl_mgr;
 }
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/asp_inifin.cpp
+++ b/src/plugins/asp/aspect/asp_inifin.cpp
@@ -40,9 +40,6 @@ namespace fawkes {
  * This initializer/finalizer will provide the ASP node handle to threads with the ASPAspect.
  * @author Björn Schäpers
  *
- * @property ASPAspectIniFin::Log
- * @brief The logger used for Clingo Output.
- *
  * @property ASPAspectIniFin::CtrlMgr
  * @brief The control manager.
  */
@@ -50,7 +47,7 @@ namespace fawkes {
 /**
  * Constructor.
  */
-ASPAspectIniFin::ASPAspectIniFin(void) : AspectIniFin("ASPAspect"), Log(nullptr)
+ASPAspectIniFin::ASPAspectIniFin(void) : AspectIniFin("ASPAspect")
 {
 	return;
 }
@@ -73,23 +70,7 @@ ASPAspectIniFin::init(Thread *thread)
 		thread->name());
 	} //if ( asp_thread == nullptr )
 
-	auto clingoLogger = [this](const Clingo::WarningCode code, char const *msg)
-		{
-			fawkes::Logger::LogLevel level = fawkes::Logger::LL_NONE;
-			switch ( code )
-			{
-				case Clingo::WarningCode::AtomUndefined      :
-				case Clingo::WarningCode::OperationUndefined :
-				case Clingo::WarningCode::RuntimeError       : level = fawkes::Logger::LL_ERROR; break;
-				case Clingo::WarningCode::Other              :
-				case Clingo::WarningCode::VariableUnbounded  : level = fawkes::Logger::LL_WARN;
-				case Clingo::WarningCode::FileIncluded       :
-				case Clingo::WarningCode::GlobalVariable     : level = fawkes::Logger::LL_INFO; break;
-			} //switch ( code )
-			Log->log(level, "Clingo", msg);
-			return;
-		};
-	asp_thread->init_ASPAspect(LockPtr<Clingo::Control>(new Clingo::Control({}, clingoLogger, 100)));
+	asp_thread->init_ASPAspect(CtrlMgr->create_control(asp_thread->ControlName, asp_thread->LogComponent));
 	return;
 }
 
@@ -104,17 +85,6 @@ ASPAspectIniFin::finalize(Thread *thread)
 	} //if ( asp_thread == nullptr )
 
 	asp_thread->finalize_ASPAspect();
-	return;
-}
-
-/**
- * @brief Sets the logger to use for Clingo messages.
- * @param[in] logger The new logger.
- */
-void
-ASPAspectIniFin::setLogger(Logger *logger)
-{
-	Log = logger;
 	return;
 }
 

--- a/src/plugins/asp/aspect/asp_inifin.h
+++ b/src/plugins/asp/aspect/asp_inifin.h
@@ -40,7 +40,6 @@ class Logger;
 class ASPAspectIniFin : public AspectIniFin
 {
 	private:
-	Logger *Log;
 	LockPtr<ClingoControlManager> CtrlMgr;
 
 	public:
@@ -50,7 +49,6 @@ class ASPAspectIniFin : public AspectIniFin
 	void init(Thread *thread) override;
 	void finalize(Thread *thread) override;
 
-	void setLogger(Logger *logger);
 	void setControlManager(const LockPtr<ClingoControlManager>& ctrlMgr);
 };
 

--- a/src/plugins/asp/aspect/asp_inifin.h
+++ b/src/plugins/asp/aspect/asp_inifin.h
@@ -4,7 +4,7 @@
  *
  *  Created: Thu Oct 20 15:49:31 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -21,35 +21,32 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#ifndef __PLUGINS_ASP_ASPECT_ASP_INIFIN_H_
-#define __PLUGINS_ASP_ASPECT_ASP_INIFIN_H_
+#ifndef _PLUGINS_ASP_ASPECT_ASP_INIFIN_H_
+#define _PLUGINS_ASP_ASPECT_ASP_INIFIN_H_
 
 #include <aspect/inifins/inifin.h>
 #include <core/utils/lockptr.h>
 
-#include "asp.h"
+#include <plugins/asp/aspect/asp.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 class ClingoControlManager;
 class Logger;
 
 class ASPAspectIniFin : public AspectIniFin
 {
-	private:
-	LockPtr<ClingoControlManager> CtrlMgr;
-
-	public:
+public:
 	ASPAspectIniFin(void);
 	~ASPAspectIniFin(void);
 
 	void init(Thread *thread) override;
 	void finalize(Thread *thread) override;
 
-	void setControlManager(const LockPtr<ClingoControlManager>& ctrlMgr);
+	void set_control_manager(const LockPtr<ClingoControlManager>& ctrl_mgr);
+
+private:
+	LockPtr<ClingoControlManager> ctrl_mgr_;
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/asp_inifin.h
+++ b/src/plugins/asp/aspect/asp_inifin.h
@@ -32,13 +32,20 @@ namespace fawkes {
 }
 #endif
 
+class Logger;
+
 class ASPAspectIniFin : public AspectIniFin
 {
+	private:
+	Logger *Log;
+
 	public:
 	ASPAspectIniFin(void);
 
 	void init(Thread *thread) override;
 	void finalize(Thread *thread) override;
+
+	void setLogger(Logger *logger);
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/asp_inifin.h
+++ b/src/plugins/asp/aspect/asp_inifin.h
@@ -25,6 +25,8 @@
 #define __PLUGINS_ASP_ASPECT_ASP_INIFIN_H_
 
 #include <aspect/inifins/inifin.h>
+#include <core/utils/lockptr.h>
+
 #include "asp.h"
 
 namespace fawkes {
@@ -32,20 +34,24 @@ namespace fawkes {
 }
 #endif
 
+class ClingoControlManager;
 class Logger;
 
 class ASPAspectIniFin : public AspectIniFin
 {
 	private:
 	Logger *Log;
+	LockPtr<ClingoControlManager> CtrlMgr;
 
 	public:
 	ASPAspectIniFin(void);
+	~ASPAspectIniFin(void);
 
 	void init(Thread *thread) override;
 	void finalize(Thread *thread) override;
 
 	void setLogger(Logger *logger);
+	void setControlManager(const LockPtr<ClingoControlManager>& ctrlMgr);
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/asp_inifin.h
+++ b/src/plugins/asp/aspect/asp_inifin.h
@@ -1,0 +1,46 @@
+
+/***************************************************************************
+ *  asp_inifin.h - Fawkes ASPAspect initializer/finalizer
+ *
+ *  Created: Thu Oct 20 15:49:31 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#ifndef __PLUGINS_ASP_ASPECT_ASP_INIFIN_H_
+#define __PLUGINS_ASP_ASPECT_ASP_INIFIN_H_
+
+#include <aspect/inifins/inifin.h>
+#include "asp.h"
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+class ASPAspectIniFin : public AspectIniFin
+{
+	public:
+	ASPAspectIniFin(void);
+
+	void init(Thread *thread) override;
+	void finalize(Thread *thread) override;
+};
+
+} // end namespace fawkes
+
+#endif

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -435,6 +435,11 @@ ClingoAccess::loadFile(const std::string& path)
 bool
 ClingoAccess::ground(const Clingo::PartSpan& parts)
 {
+	if ( parts.empty() )
+	{
+		return true;
+	} //if ( parts.empty() )
+
 	MutexLocker locker(&ControlMutex);
 	if ( Solving )
 	{

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -47,6 +47,9 @@ namespace fawkes {
  *
  * @property ClingoAccess::NumberOfThreads
  * @brief How many threads Clingo should use for solving.
+ *
+ * @property ClingoAccess::Splitting
+ * @brief Wether splitting should be used.
  */
 
 /**
@@ -218,7 +221,7 @@ ClingoAccess::allocControl()
 	if ( NumberOfThreads != 1 )
 	{
 		std::stringstream s("-t ", std::ios_base::ate | std::ios_base::out);
-		s<<NumberOfThreads;
+		s<<NumberOfThreads<<","<<(Splitting ? "split" : "compete");
 		argumentsString.push_back(s.str());
 		argumentsChar.push_back(argumentsString.back().c_str());
 	} //if ( NumberOfThreads != 1 )
@@ -249,7 +252,7 @@ ClingoAccess::allocControl()
  * @param[in] logComponent The logging component.
  */
 ClingoAccess::ClingoAccess(Logger *log, const std::string& logComponent) : Log(log),
-		LogComponent(logComponent.empty() ? "Clingo" : logComponent), NumberOfThreads(1),
+		LogComponent(logComponent.empty() ? "Clingo" : logComponent), NumberOfThreads(1), Splitting(false),
 		Control(nullptr), ModelMutex(Mutex::RECURSIVE), Solving(false), DebugLevel(None)
 {
 	allocControl();
@@ -439,12 +442,13 @@ ClingoAccess::reset(void)
 /**
  * @brief Sets the number of threads Clingo should use.
  * @param[in] threads The number.
+ * @param[in] useSPlitting Wether splitting should be used.
  * @warning This will call reset().
  * @exception Exception If it is called while solving.
  * @exception Exception If it is called with @c threads < 1.
  */
 void
-ClingoAccess::setNumberOfThreads(const int threads)
+ClingoAccess::setNumberOfThreads(const int threads, const bool useSplitting)
 {
 	if ( Solving )
 	{
@@ -454,8 +458,10 @@ ClingoAccess::setNumberOfThreads(const int threads)
 	{
 		throw Exception("Tried to set thread count to %d, only values >= 1 are valid.", threads);
 	} //if ( threads < 1 )
-	Log->log_info(LogComponent.c_str(), "Change # of threads for solving from %d to %d.", NumberOfThreads, threads);
+	Log->log_info(LogComponent.c_str(), "Change # of threads for solving from %d to %d and splitting from %s to %s.",
+		NumberOfThreads, threads, Splitting ? "true" : "false", useSplitting ? "true" : "false");
 	NumberOfThreads = threads;
+	Splitting = useSplitting;
 	reset();
 	return;
 }

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -391,6 +391,7 @@ ClingoAccess::reset(void)
 		cancelSolving();
 		return false;
 	} //if ( Solving )
+	Log->log_warn(LogComponent.c_str(), "Clingo will be resetted.");
 	delete Control;
 	Control = nullptr;
 	allocControl();

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -213,7 +213,7 @@ ClingoAccess::allocControl()
 
 	if ( NumberOfThreads != 1 )
 	{
-		std::stringstream s("-t ");
+		std::stringstream s("-t ", std::ios_base::ate | std::ios_base::out);
 		s<<NumberOfThreads;
 		argumentsString.push_back(s.str());
 		argumentsChar.push_back(argumentsString.back().c_str());

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -1,0 +1,356 @@
+/***************************************************************************
+ *  clingo_access.cpp - Clingo access wrapper for the aspects
+ *
+ *  Created: Mon Oct 31 13:41:07 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#include "clingo_access.h"
+
+#include <algorithm>
+
+#include <core/threading/mutex_locker.h>
+#include <logging/logger.h>
+
+namespace fawkes {
+
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+/**
+ * @class ClingoAccess
+ * @brief A wrapper around the clingo control, to control the solving process.
+ * @author Björn Schäpers
+ *
+ * @property ClingoAccess::Log
+ * @brief The used logger.
+ *
+ * @property ClingoAccess::LogComponent
+ * @brief The log component.
+ *
+ * @property ClingoAccess::ControlMutex
+ * @brief The mutex to protect the clingo control.
+ *
+ * @property ClingoAccess::Control
+ * @brief The clingo control.
+ *
+ * @property ClingoAccess::ModelSymbols
+ * @brief The symbols found in the last model.
+ *
+ * @property ClingoAccess::OldSymbols
+ * @brief The symbols found in the before last model.
+ *
+ * @property ClingoAccess::Solving
+ * @brief Whether the control is in the solving process.
+ *
+ * @property ClingoAccess::CallbackMutex
+ * @brief The mutex to protect the callback vectors.
+ *
+ * @property ClingoAccess::ModelCallbacks
+ * @brief The functions to call on a new model.
+ *
+ * @property ClingoAccess::FinishCallbacks
+ * @brief The functions to call, when the solving process finished.
+ *
+ * @property ClingoAccess::Debug
+ * @brief Whether additional debug output is desired.
+ */
+
+
+/**
+ * @brief Extracts the symbols from the new model and calls the registered functions.
+ * @param[in] model The new model.
+ * @return If the solving process should compute more models (if there are any).
+ */
+bool
+ClingoAccess::newModel(const Clingo::Model& model)
+{
+	MutexLocker locker1(&ControlMutex);
+	ModelSymbols = model.symbols();
+
+	if ( Debug )
+	{
+		Log->log_info(LogComponent.c_str(), "New model found.");
+
+		/* To save (de-)allocations just move found symbols at the end of the vector and move the end iterator to the
+		 * front. After this everything in [begin, end) is in oldSymbols but not in symbols. */
+		auto begin = OldSymbols.begin(), end = OldSymbols.end();
+
+		for ( const Clingo::Symbol& symbol : ModelSymbols )
+		{
+			auto iter = std::find(begin, end, symbol);
+			if ( iter == end )
+			{
+				Log->log_info(LogComponent.c_str(), "New Symbol: %s", symbol.to_string().c_str());
+			} //if ( iter == end )
+			else
+			{
+				std::swap(*iter, *--end);
+			} //else -> if ( iter == end )
+		} //for ( const Clingo::Symbol& symbol : ModelSymbols )
+
+		for ( ; begin != end; ++begin )
+		{
+			Log->log_info(LogComponent.c_str(), "Symbol removed: %s", begin->to_string().c_str());
+		} //for ( ; begin != end; ++begin )
+	} //if ( Debug )
+
+	OldSymbols = ModelSymbols;
+	locker1.unlock();
+
+	bool ret = false;
+
+	MutexLocker locker2(&CallbackMutex);
+	for ( const auto& cb : ModelCallbacks )
+	{
+		ret |= (*cb)();
+	} //for ( const auto& cb : ModelCallbacks )
+
+	return ret;
+}
+
+/**
+ * @brief Calls the callbacks for the end of the solving.
+ * @param[in] result The result of the solving process.
+ */
+void
+ClingoAccess::solvingFinished(const Clingo::SolveResult result)
+{
+	if ( Debug )
+	{
+		Log->log_info(LogComponent.c_str(), "Solving done.");
+	} //if ( Debug )
+	MutexLocker locker1(&ControlMutex);
+	Solving = false;
+
+	MutexLocker locker2(&CallbackMutex);
+	for ( const auto& cb : FinishCallbacks )
+	{
+		(*cb)(result);
+	} //for ( const auto& cb : FinishCallbacks )
+	return;
+}
+
+/**
+ * @brief Constructor.
+ * @param[in] log The used logger.
+ * @param[in] logComponent The logging component.
+ * @param[in] controlArgs... The arguments for the clingo control constructor.
+ */
+ClingoAccess::ClingoAccess(Logger *log, const std::string& logComponent) : Log(log),
+		LogComponent(logComponent.empty() ? "Clingo" : logComponent), Control({},
+			[this](const Clingo::WarningCode code, char const *msg)
+			{
+				fawkes::Logger::LogLevel level = fawkes::Logger::LL_NONE;
+				switch ( code )
+				{
+					case Clingo::WarningCode::AtomUndefined      :
+					case Clingo::WarningCode::OperationUndefined :
+					case Clingo::WarningCode::RuntimeError       : level = fawkes::Logger::LL_ERROR; break;
+					case Clingo::WarningCode::Other              :
+					case Clingo::WarningCode::VariableUnbounded  : level = fawkes::Logger::LL_WARN; break;
+					case Clingo::WarningCode::FileIncluded       :
+					case Clingo::WarningCode::GlobalVariable     : level = fawkes::Logger::LL_INFO; break;
+				} //switch ( code )
+				Log->log(level, LogComponent.c_str(), msg);
+				return;
+			}, 100), Solving(false), Debug(false)
+{
+	return;
+}
+
+/**
+ * @brief Registers a callback for the event of a new model. The callback can control with it's return value if the
+ *        search for models should continue. If one of the callbacks says yes the search is continued.
+ * @param[in] callback The callback to register.
+ */
+void
+ClingoAccess::registerModelCallback(std::shared_ptr<std::function<bool(void)>> callback)
+{
+	MutexLocker locker(&CallbackMutex);
+	ModelCallbacks.emplace_back(callback);
+	return;
+}
+
+/**
+ * @brief Unregisters a callback for the event of a new model.
+ * @param[in] callback The callback to unregister.
+ */
+void
+ClingoAccess::unregisterModelCallback(std::shared_ptr<std::function<bool(void)>> callback)
+{
+	MutexLocker locker(&CallbackMutex);
+	ModelCallbacks.erase(std::find(ModelCallbacks.begin(), ModelCallbacks.end(), callback));
+	return;
+}
+
+/**
+ * @brief Registers a callback for the event of finishing the solving process.
+ * @param[in] callback The callback to register.
+ */
+void
+ClingoAccess::registerFinishCallback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback)
+{
+	MutexLocker locker(&CallbackMutex);
+	FinishCallbacks.emplace_back(callback);
+	return;
+}
+
+/**
+ * @brief Unregisters a callback for the event of finishing the solving process.
+ * @param[in] callback The callback to unregister.
+ */
+void
+ClingoAccess::unregisterFinishCallback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback)
+{
+	MutexLocker locker(&CallbackMutex);
+	FinishCallbacks.erase(std::find(FinishCallbacks.begin(), FinishCallbacks.end(), callback));
+	return;
+}
+
+/**
+ * @brief Returns whether the solving process is running.
+ */
+bool
+ClingoAccess::solving(void) const noexcept
+{
+	return Solving;
+}
+
+/**
+ * @brief Starts the solving process, if it isn't already running.
+ * @return If the process is started.
+ */
+bool
+ClingoAccess::startSolving(void)
+{
+	MutexLocker locker(&ControlMutex);
+	if ( Solving )
+	{
+		return false;
+	} //if ( Solving )
+
+	if ( Debug )
+	{
+		Log->log_info(LogComponent.c_str(), "Start solving.");
+	} //if ( Debug )
+	Control.solve_async([this](const Clingo::Model& model) { return newModel(model); },
+		[this](const Clingo::SolveResult& result) { solvingFinished(result); return; });
+	Solving = true;
+	return true;
+}
+
+/**
+ * @brief Stops the solving process, if it is running.
+ * @return If it was stopped. (Check solving() for actual state!)
+ */
+bool
+ClingoAccess::cancelSolving(void)
+{
+	MutexLocker locker(&ControlMutex);
+	if ( !Solving )
+	{
+		return false;
+	} //if ( !Solving )
+
+	if ( Debug )
+	{
+		Log->log_info(LogComponent.c_str(), "Cancel solving.");
+	} //if ( Debug )
+	Control.interrupt();
+	return true;
+}
+
+/**
+ * @brief Returns a copy of the last symbols found.
+ */
+Clingo::SymbolVector
+ClingoAccess::modelSymbols(void) const
+{
+	MutexLocker locker(&ControlMutex);
+	return ModelSymbols;
+}
+
+/**
+ * @brief Loads a file in the solver.
+ * @param[in] path The path of the file.
+ * @return If the file was loaded.
+ */
+bool
+ClingoAccess::loadFile(const std::string& path)
+{
+	MutexLocker locker(&ControlMutex);
+	if ( Solving )
+	{
+		return false;
+	} //if ( Solving )
+
+	Log->log_info(LogComponent.c_str(), "Loading file program file %s.", path.c_str());
+	Control.load(path.c_str());
+	return true;
+}
+
+/**
+ * @brief Grounds a program part.
+ * @param[in] parts The parts to ground.
+ * @return If the parts could be grounded.
+ */
+bool
+ClingoAccess::ground(const Clingo::PartSpan& parts)
+{
+	MutexLocker locker(&ControlMutex);
+	if ( Solving )
+	{
+		return false;
+	} //if ( Solving )
+
+	if ( Debug )
+	{
+		Log->log_info(LogComponent.c_str(), "Grounding %d parts:", parts.size());
+		auto i = 0;
+		for ( const Clingo::Part& part : parts )
+		{
+			std::string params;
+			bool first = true;
+			for ( const auto& param : part.params() )
+			{
+				if ( first )
+				{
+					first = false;
+				} //if ( first )
+				else
+				{
+					params += ", ";
+				} //else -> if ( first )
+				params += param.to_string();
+			} //for ( const auto& param : part.params() )
+			Log->log_info(LogComponent.c_str(), "Part #%d: %s [%s]", ++i, part.name(), params.c_str());
+		} //for ( const auto& part : parts )
+	} //if ( Debug )
+
+	Control.ground(parts);
+
+	if ( Debug )
+	{
+		Log->log_info(LogComponent.c_str(), "Grounding done.");
+	} //if ( Debug )
+	return true;
+}
+
+} // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -520,7 +520,7 @@ ClingoAccess::ground(const Clingo::PartSpan& parts)
 
 	if ( DebugLevel >= Time )
 	{
-		Log->log_info(LogComponent.c_str(), "Grounding %d parts:", parts.size());
+		Log->log_info(LogComponent.c_str(), "Grounding %zu parts:", parts.size());
 		if ( DebugLevel >= Programs )
 		{
 			auto i = 0;

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -353,4 +353,59 @@ ClingoAccess::ground(const Clingo::PartSpan& parts)
 	return true;
 }
 
+/**
+ * @brief Assigns an external value.
+ * @param[in] atom The atom to assign.
+ * @param[in] value The assigned value.
+ * @return If it could be assigned.
+ */
+bool
+ClingoAccess::assign_external(const Clingo::Symbol atom, const Clingo::TruthValue value)
+{
+	MutexLocker locker(&ControlMutex);
+	if ( Solving )
+	{
+		return false;
+	} //if ( Solving )
+
+	if ( Debug )
+	{
+		Log->log_info(LogComponent.c_str(), "Assigning %s to %s.", [value](void)
+			{
+				const char *ret = "Unknown Value";
+				switch ( value )
+				{
+					case Clingo::TruthValue::Free  : ret = "Free";  break;
+					case Clingo::TruthValue::True  : ret = "True";  break;
+					case Clingo::TruthValue::False : ret = "False"; break;
+				} //switch ( value )
+				return ret;
+			}, atom.string());
+	} //if ( Debug )
+	Control.assign_external(atom, value);
+	return true;
+}
+
+/**
+ * @brief Releases an external value.
+ * @param[in] atom The atom to release.
+ * @return If it could be released.
+ */
+bool
+ClingoAccess::release_external(const Clingo::Symbol atom)
+{
+	MutexLocker locker(&ControlMutex);
+	if ( Solving )
+	{
+		return false;
+	} //if ( Solving )
+
+	if ( Debug )
+	{
+		Log->log_info(LogComponent.c_str(), "Releasing %s.", atom.string());
+	} //if ( Debug )
+	Control.release_external(atom);
+	return true;
+}
+
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -68,6 +68,9 @@ namespace fawkes {
  * @property ClingoAccess::FinishCallbacks
  * @brief The functions to call, when the solving process finished.
  *
+ * @property ClingoAccess::GroundCallback
+ * @brief The callback for the grounding.
+ *
  * @property ClingoAccess::Debug
  * @brief Whether additional debug output is desired.
  */
@@ -246,6 +249,18 @@ ClingoAccess::unregisterFinishCallback(std::shared_ptr<std::function<void(Clingo
 }
 
 /**
+ * @brief Sets the ground callback, to implement custom functions.
+ * @param[in, out] callback The callback, will be moved.
+ */
+void
+ClingoAccess::setGroundCallback(Clingo::GroundCallback&& callback)
+{
+	MutexLocker locker(&CallbackMutex);
+	GroundCallback = std::move(callback);
+	return;
+}
+
+/**
  * @brief Returns whether the solving process is running.
  */
 bool
@@ -415,7 +430,7 @@ ClingoAccess::ground(const Clingo::PartSpan& parts)
 		} //for ( const auto& part : parts )
 	} //if ( Debug )
 
-	Control->ground(parts);
+	Control->ground(parts, GroundCallback);
 
 	if ( Debug )
 	{

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -99,6 +99,9 @@ namespace fawkes {
  * @var ClingoAccess::DebugLevel_t::All
  * @brief Print everything.
  *
+ * @var ClingoAccess::DebugLevel_t::EvenClingo
+ * @brief Activates the --output-debug=text option for clingo. This produces ALOT of output!
+ *
  * @property ClingoAccess::DebugLevel
  * @brief Which debug outputs should be printed.
  */
@@ -189,7 +192,15 @@ void
 ClingoAccess::allocControl()
 {
 	assert(!Control);
-	Control = new Clingo::Control({},
+
+	std::vector<const char*> argumentsChar;
+
+	if ( DebugLevel >= EvenClingo )
+	{
+		argumentsChar.push_back("--output-debug=text");
+	} //if ( DebugLevel >= EvenClingo )
+
+	Control = new Clingo::Control(argumentsChar,
 		[this](const Clingo::WarningCode code, char const *msg)
 		{
 			fawkes::Logger::LogLevel level = fawkes::Logger::LL_NONE;

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -56,6 +56,10 @@ namespace fawkes {
  * @property ClingoAccess::OldSymbols
  * @brief The symbols found in the before last model.
  *
+ * @property ClingoAccess::ModelCounter
+ * @brief Counts how many models we have computed for one solving process.
+ *
+ *
  * @property ClingoAccess::Solving
  * @brief Whether the control is in the solving process.
  *
@@ -89,7 +93,7 @@ ClingoAccess::newModel(const Clingo::Model& model)
 
 	if ( Debug )
 	{
-		Log->log_info(LogComponent.c_str(), "New model found.");
+		Log->log_info(LogComponent.c_str(), "New model found: #%d", ++ModelCounter);
 
 		/* To save (de-)allocations just move found symbols at the end of the vector and move the end iterator to the
 		 * front. After this everything in [begin, end) is in oldSymbols but not in symbols. */
@@ -287,6 +291,7 @@ ClingoAccess::startSolving(void)
 		Log->log_info(LogComponent.c_str(), "Start async solving.");
 	} //if ( Debug )
 	Solving = true;
+	ModelCounter = 0;
 	Control->solve_async([this](const Clingo::Model& model) { return newModel(model); },
 		[this](const Clingo::SolveResult& result) { solvingFinished(result); return; });
 	return true;
@@ -311,6 +316,7 @@ ClingoAccess::startSolvingBlocking(void)
 		Log->log_info(LogComponent.c_str(), "Start sync solving.");
 	} //if ( Debug )
 	Solving = true;
+	ModelCounter = 0;
 	const auto result(Control->solve([this,&locker](const Clingo::Model& model) {
 		locker.unlock();
 		const auto ret = newModel(model);

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -446,7 +446,7 @@ ClingoAccess::ground(const Clingo::PartSpan& parts)
  * @return If it could be assigned.
  */
 bool
-ClingoAccess::assign_external(const Clingo::Symbol atom, const Clingo::TruthValue value)
+ClingoAccess::assign_external(const Clingo::Symbol& atom, const Clingo::TruthValue value)
 {
 	MutexLocker locker(&ControlMutex);
 	if ( Solving )
@@ -478,7 +478,7 @@ ClingoAccess::assign_external(const Clingo::Symbol atom, const Clingo::TruthValu
  * @return If it could be released.
  */
 bool
-ClingoAccess::release_external(const Clingo::Symbol atom)
+ClingoAccess::release_external(const Clingo::Symbol& atom)
 {
 	MutexLocker locker(&ControlMutex);
 	if ( Solving )

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -117,7 +117,8 @@ ClingoAccess::newModel(const Clingo::Model& model)
 
 	if ( DebugLevel >= Time )
 	{
-		Log->log_info(LogComponent.c_str(), "New model found: #%d", ++ModelCounter);
+		Log->log_info(LogComponent.c_str(), "New %smodel found: #%d", model.optimality_proven() ? "optimal " : "",
+			++ModelCounter);
 
 		if ( DebugLevel >= Models )
 		{

--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -380,7 +380,7 @@ ClingoAccess::assign_external(const Clingo::Symbol atom, const Clingo::TruthValu
 					case Clingo::TruthValue::False : ret = "False"; break;
 				} //switch ( value )
 				return ret;
-			}, atom.string());
+			}(), atom.to_string().c_str());
 	} //if ( Debug )
 	Control.assign_external(atom, value);
 	return true;
@@ -402,7 +402,7 @@ ClingoAccess::release_external(const Clingo::Symbol atom)
 
 	if ( Debug )
 	{
-		Log->log_info(LogComponent.c_str(), "Releasing %s.", atom.string());
+		Log->log_info(LogComponent.c_str(), "Releasing %s.", atom.to_string().c_str());
 	} //if ( Debug )
 	Control.release_external(atom);
 	return true;

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -43,6 +43,7 @@ class ClingoAccess
 	private:
 	Logger* const Log;
 	const std::string LogComponent;
+	int NumberOfThreads;
 
 	mutable Mutex ControlMutex;
 	Clingo::Control *Control;
@@ -91,6 +92,9 @@ class ClingoAccess
 	bool cancelSolving(void);
 
 	bool reset(void);
+
+	void setNumberOfThreads(const int threads);
+	int numberOfThreads(void) const noexcept;
 
 	Clingo::SymbolVector modelSymbols(void) const;
 

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -44,6 +44,7 @@ class ClingoAccess
 	Logger* const Log;
 	const std::string LogComponent;
 	int NumberOfThreads;
+	bool Splitting;
 
 	Mutex ControlMutex;
 	Clingo::Control *Control;
@@ -95,7 +96,7 @@ class ClingoAccess
 
 	bool reset(void);
 
-	void setNumberOfThreads(const int threads);
+	void setNumberOfThreads(const int threads, const bool useSplitting = false);
 	int numberOfThreads(void) const noexcept;
 
 	Clingo::SymbolVector modelSymbols(void) const;

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -45,7 +45,7 @@ class ClingoAccess
 	const std::string LogComponent;
 
 	mutable Mutex ControlMutex;
-	Clingo::Control Control;
+	Clingo::Control *Control;
 	Clingo::SymbolVector ModelSymbols, OldSymbols;
 
 	std::atomic_bool Solving;
@@ -56,10 +56,13 @@ class ClingoAccess
 	bool newModel(const Clingo::Model& model);
 	void solvingFinished(const Clingo::SolveResult result);
 
+	void allocControl(void);
+
 	public:
 	std::atomic_bool Debug;
 
 	ClingoAccess(Logger *log, const std::string& logComponent);
+	~ClingoAccess(void);
 
 	void registerModelCallback(std::shared_ptr<std::function<bool(void)>> callback);
 	void unregisterModelCallback(std::shared_ptr<std::function<bool(void)>> callback);
@@ -70,6 +73,8 @@ class ClingoAccess
 	bool startSolving(void);
 	bool startSolvingBlocking(void);
 	bool cancelSolving(void);
+
+	bool reset(void);
 
 	Clingo::SymbolVector modelSymbols(void) const;
 

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -1,0 +1,82 @@
+/***************************************************************************
+ *  clingo_access.h - Clingo access wrapper for the aspects
+ *
+ *  Created: Mon Oct 31 13:41:07 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#ifndef __PLUGINS_ASP_ASPECT_CLINGO_ACCESS_H_
+#define __PLUGINS_ASP_ASPECT_CLINGO_ACCESS_H_
+
+#include <atomic>
+#include <clingo.hh>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include <core/threading/mutex.h>
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+class Logger;
+
+class ClingoAccess
+{
+	private:
+	Logger* const Log;
+	const std::string LogComponent;
+
+	mutable Mutex ControlMutex;
+	Clingo::Control Control;
+	Clingo::SymbolVector ModelSymbols, OldSymbols;
+
+	std::atomic_bool Solving;
+	mutable Mutex CallbackMutex;
+	std::vector<std::shared_ptr<std::function<bool(void)>>> ModelCallbacks;
+	std::vector<std::shared_ptr<std::function<void(Clingo::SolveResult)>>> FinishCallbacks;
+
+	bool newModel(const Clingo::Model& model);
+	void solvingFinished(const Clingo::SolveResult result);
+
+	public:
+	std::atomic_bool Debug;
+
+	ClingoAccess(Logger *log, const std::string& logComponent);
+
+	void registerModelCallback(std::shared_ptr<std::function<bool(void)>> callback);
+	void unregisterModelCallback(std::shared_ptr<std::function<bool(void)>> callback);
+	void registerFinishCallback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback);
+	void unregisterFinishCallback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback);
+
+	bool solving(void) const noexcept;
+	bool startSolving(void);
+	bool cancelSolving(void);
+
+	Clingo::SymbolVector modelSymbols(void) const;
+
+	bool loadFile(const std::string& path);
+
+	bool ground(const Clingo::PartSpan& parts);
+};
+
+} // end namespace fawkes
+
+#endif

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -3,7 +3,7 @@
  *
  *  Created: Mon Oct 31 13:41:07 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,8 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#ifndef __PLUGINS_ASP_ASPECT_CLINGO_ACCESS_H_
-#define __PLUGINS_ASP_ASPECT_CLINGO_ACCESS_H_
+#ifndef _PLUGINS_ASP_ASPECT_CLINGO_ACCESS_H_
+#define _PLUGINS_ASP_ASPECT_CLINGO_ACCESS_H_
 
 #include <atomic>
 #include <clingo.hh>
@@ -32,93 +32,95 @@
 #include <core/threading/mutex.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 class Logger;
 
 class ClingoAccess : public Clingo::SolveEventHandler
 {
-	private:
-	Logger* const Log;
-	const std::string LogComponent;
-	int NumberOfThreads;
-	bool Splitting;
-
-	Mutex ControlMutex;
-	bool ControlIsLocked;
-	Clingo::Control *Control;
-
-	mutable Mutex ModelMutex;
-	Clingo::SymbolVector ModelSymbols, OldSymbols;
-	unsigned int ModelCounter;
-
-	std::atomic_bool Solving;
-	mutable Mutex CallbackMutex;
-	std::vector<std::shared_ptr<std::function<bool(void)>>> ModelCallbacks;
-	std::vector<std::shared_ptr<std::function<void(Clingo::SolveResult)>>> FinishCallbacks;
-	Clingo::GroundCallback GroundCallback;
-	Clingo::SolveHandle AsyncHandle;
-
-	bool on_model(const Clingo::Model& model) override;
-	void on_finish(const Clingo::SolveResult result) override;
-
-	void allocControl(void);
-
-	public:
+public:
+	/** Debug levels, higher levels include the lower values. */
 	enum DebugLevel_t
 	{
-		None = 0,
-		Time = 10,
-		Programs = 20,
-		Externals = 30,
-		Models = 40,
-		AllModelSymbols = 50,
-		All,
-		EvenClingo
+	 None = 0,              ///< No debug output at all.
+	 Time = 10,             ///< Print when starting/finishing grounding/solving for analysis.
+	 Programs = 20,         ///< Print which programs are grounded.
+	 Externals = 30,        ///< Print assignments and releases of externals.
+	 Models = 40,           ///< Print new models.
+	 AllModelSymbols = 50,  ///< Ignore '\#show' statements and print all symbols of a model.
+	 All,                   ///< Print everything.
+	 EvenClingo             ///< Activates the --output-debug=text option for clingo.
 	};
 
-	std::atomic<DebugLevel_t> DebugLevel;
-
-	ClingoAccess(Logger *log, const std::string& logComponent);
+	ClingoAccess(Logger *logger, const std::string& log_component);
 	~ClingoAccess(void);
 
-	void registerModelCallback(std::shared_ptr<std::function<bool(void)>> callback);
-	void unregisterModelCallback(std::shared_ptr<std::function<bool(void)>> callback);
-	void registerFinishCallback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback);
-	void unregisterFinishCallback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback);
+	void register_model_callback(std::shared_ptr<std::function<bool(void)>> callback);
+	void unregister_model_callback(std::shared_ptr<std::function<bool(void)>> callback);
+	void register_finish_callback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback);
+	void unregister_finish_callback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback);
 
-	void setGroundCallback(Clingo::GroundCallback&& callback);
+	void set_ground_callback(Clingo::GroundCallback&& callback);
 
 	bool solving(void) const noexcept;
-	bool startSolving(void);
-	bool startSolvingBlocking(void);
-	bool cancelSolving(void);
+	bool start_solving(void);
+	bool start_solving_blocking(void);
+	bool cancel_solving(void);
 
 	bool reset(void);
 
-	void setNumberOfThreads(const int threads, const bool useSplitting = false);
-	int numberOfThreads(void) const noexcept;
+	void set_num_threads(const int threads, const bool use_splitting = false);
+	int num_threads(void) const noexcept;
 
-	Clingo::SymbolVector modelSymbols(void) const;
+	Clingo::SymbolVector model_symbols(void) const;
 
-	bool loadFile(const std::string& path);
+	bool load_file(const std::string& path);
 
 	bool ground(const Clingo::PartSpan& parts);
 
-	inline bool assign_external(const Clingo::Symbol& atom, const bool value)
+	inline bool
+	assign_external(const Clingo::Symbol& atom, const bool value)
 	{
 		return assign_external(atom, value ? Clingo::TruthValue::True : Clingo::TruthValue::False);
 	}
 
-	inline bool free_exteral(const Clingo::Symbol& atom)
+	inline bool
+	free_external(const Clingo::Symbol& atom)
 	{
 		return assign_external(atom, Clingo::TruthValue::Free);
 	}
 
 	bool assign_external(const Clingo::Symbol& atom, const Clingo::TruthValue value);
 	bool release_external(const Clingo::Symbol& atom);
+
+private:
+	bool on_model(Clingo::Model& model) override;
+	void on_finish(Clingo::SolveResult result) override;
+
+	void alloc_control(void);
+
+private:
+	Logger* const logger_;
+	const std::string log_comp_;
+
+	std::atomic<DebugLevel_t> debug_level_;
+
+	int num_threads_;
+	bool thread_mode_splitting_;
+
+	Mutex control_mutex_;
+	bool control_is_locked_;
+	Clingo::Control *control_;
+
+	mutable Mutex model_mutex_;
+	Clingo::SymbolVector model_symbols_, old_symbols_;
+	unsigned int model_counter_;
+
+	std::atomic_bool solving_;
+	mutable Mutex callback_mutex_;
+	std::vector<std::shared_ptr<std::function<bool(void)>>> model_callbacks_;
+	std::vector<std::shared_ptr<std::function<void(Clingo::SolveResult)>>> finish_callbacks_;
+	Clingo::GroundCallback ground_callback_;
+	Clingo::SolveHandle async_handle_;
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -52,6 +52,7 @@ class ClingoAccess
 	mutable Mutex CallbackMutex;
 	std::vector<std::shared_ptr<std::function<bool(void)>>> ModelCallbacks;
 	std::vector<std::shared_ptr<std::function<void(Clingo::SolveResult)>>> FinishCallbacks;
+	Clingo::GroundCallback GroundCallback;
 
 	bool newModel(const Clingo::Model& model);
 	void solvingFinished(const Clingo::SolveResult result);
@@ -68,6 +69,8 @@ class ClingoAccess
 	void unregisterModelCallback(std::shared_ptr<std::function<bool(void)>> callback);
 	void registerFinishCallback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback);
 	void unregisterFinishCallback(std::shared_ptr<std::function<void(Clingo::SolveResult)>> callback);
+
+	void setGroundCallback(Clingo::GroundCallback&& callback);
 
 	bool solving(void) const noexcept;
 	bool startSolving(void);

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -45,8 +45,10 @@ class ClingoAccess
 	const std::string LogComponent;
 	int NumberOfThreads;
 
-	mutable Mutex ControlMutex;
+	Mutex ControlMutex;
 	Clingo::Control *Control;
+
+	mutable Mutex ModelMutex;
 	Clingo::SymbolVector ModelSymbols, OldSymbols;
 	unsigned int ModelCounter;
 

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -97,6 +97,16 @@ class ClingoAccess
 
 	bool ground(const Clingo::PartSpan& parts);
 
+	inline bool assign_external(const Clingo::Symbol& atom, const bool value)
+	{
+		return assign_external(atom, value ? Clingo::TruthValue::True : Clingo::TruthValue::False);
+	}
+
+	inline bool free_exteral(const Clingo::Symbol& atom)
+	{
+		return assign_external(atom, Clingo::TruthValue::Free);
+	}
+
 	bool assign_external(const Clingo::Symbol& atom, const Clingo::TruthValue value);
 	bool release_external(const Clingo::Symbol& atom);
 };

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -41,14 +41,14 @@ public:
 	/** Debug levels, higher levels include the lower values. */
 	enum DebugLevel_t
 	{
-	 None = 0,              ///< No debug output at all.
-	 Time = 10,             ///< Print when starting/finishing grounding/solving for analysis.
-	 Programs = 20,         ///< Print which programs are grounded.
-	 Externals = 30,        ///< Print assignments and releases of externals.
-	 Models = 40,           ///< Print new models.
-	 AllModelSymbols = 50,  ///< Ignore '\#show' statements and print all symbols of a model.
-	 All,                   ///< Print everything.
-	 EvenClingo             ///< Activates the --output-debug=text option for clingo.
+	 ASP_DBG_NONE = 0,                ///< No debug output at all.
+	 ASP_DBG_TIME = 10,               ///< Print when starting/finishing grounding/solving for analysis.
+	 ASP_DBG_PROGRAMS = 20,           ///< Print which programs are grounded.
+	 ASP_DBG_EXTERNALS = 30,          ///< Print assignments and releases of externals.
+	 ASP_DBG_MODELS = 40,             ///< Print new models.
+	 ASP_DBG_ALL_MODEL_SYMBOLS = 50,  ///< Ignore '\#show' statements and print all symbols of a model.
+	 ASP_DBG_ALL,                     ///< Print everything.
+	 ASP_DBG_EVEN_CLINGO              ///< Activates the --output-debug=text option for clingo.
 	};
 
 	ClingoAccess(Logger *logger, const std::string& log_component);

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -61,7 +61,18 @@ class ClingoAccess
 	void allocControl(void);
 
 	public:
-	std::atomic_bool Debug;
+	enum DebugLevel_t
+	{
+		None = 0,
+		Time = 10,
+		Programs = 20,
+		Models = 30,
+		Externals = 40,
+		AllModelSymbols = 50,
+		All
+	};
+
+	std::atomic<DebugLevel_t> DebugLevel;
 
 	ClingoAccess(Logger *log, const std::string& logComponent);
 	~ClingoAccess(void);

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -58,6 +58,7 @@ class ClingoAccess
 	std::vector<std::shared_ptr<std::function<bool(void)>>> ModelCallbacks;
 	std::vector<std::shared_ptr<std::function<void(Clingo::SolveResult)>>> FinishCallbacks;
 	Clingo::GroundCallback GroundCallback;
+	Clingo::SolveAsync AsyncHandle;
 
 	bool newModel(const Clingo::Model& model);
 	void solvingFinished(const Clingo::SolveResult result);

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -47,6 +47,7 @@ class ClingoAccess
 	mutable Mutex ControlMutex;
 	Clingo::Control *Control;
 	Clingo::SymbolVector ModelSymbols, OldSymbols;
+	unsigned int ModelCounter;
 
 	std::atomic_bool Solving;
 	mutable Mutex CallbackMutex;

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -69,7 +69,8 @@ class ClingoAccess
 		Externals = 30,
 		Models = 40,
 		AllModelSymbols = 50,
-		All
+		All,
+		EvenClingo
 	};
 
 	std::atomic<DebugLevel_t> DebugLevel;

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -85,8 +85,8 @@ class ClingoAccess
 
 	bool ground(const Clingo::PartSpan& parts);
 
-	bool assign_external(const Clingo::Symbol atom, const Clingo::TruthValue value);
-	bool release_external(const Clingo::Symbol atom);
+	bool assign_external(const Clingo::Symbol& atom, const Clingo::TruthValue value);
+	bool release_external(const Clingo::Symbol& atom);
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -68,6 +68,7 @@ class ClingoAccess
 
 	bool solving(void) const noexcept;
 	bool startSolving(void);
+	bool startSolvingBlocking(void);
 	bool cancelSolving(void);
 
 	Clingo::SymbolVector modelSymbols(void) const;

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -38,7 +38,7 @@ namespace fawkes {
 
 class Logger;
 
-class ClingoAccess
+class ClingoAccess : public Clingo::SolveEventHandler
 {
 	private:
 	Logger* const Log;
@@ -47,6 +47,7 @@ class ClingoAccess
 	bool Splitting;
 
 	Mutex ControlMutex;
+	bool ControlIsLocked;
 	Clingo::Control *Control;
 
 	mutable Mutex ModelMutex;
@@ -58,10 +59,10 @@ class ClingoAccess
 	std::vector<std::shared_ptr<std::function<bool(void)>>> ModelCallbacks;
 	std::vector<std::shared_ptr<std::function<void(Clingo::SolveResult)>>> FinishCallbacks;
 	Clingo::GroundCallback GroundCallback;
-	Clingo::SolveAsync AsyncHandle;
+	Clingo::SolveHandle AsyncHandle;
 
-	bool newModel(const Clingo::Model& model);
-	void solvingFinished(const Clingo::SolveResult result);
+	bool on_model(const Clingo::Model& model) override;
+	void on_finish(const Clingo::SolveResult result) override;
 
 	void allocControl(void);
 

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -75,6 +75,9 @@ class ClingoAccess
 	bool loadFile(const std::string& path);
 
 	bool ground(const Clingo::PartSpan& parts);
+
+	bool assign_external(const Clingo::Symbol atom, const Clingo::TruthValue value);
+	bool release_external(const Clingo::Symbol atom);
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -66,8 +66,8 @@ class ClingoAccess
 		None = 0,
 		Time = 10,
 		Programs = 20,
-		Models = 30,
-		Externals = 40,
+		Externals = 30,
+		Models = 40,
 		AllModelSymbols = 50,
 		All
 	};

--- a/src/plugins/asp/aspect/clingo_control_manager.cpp
+++ b/src/plugins/asp/aspect/clingo_control_manager.cpp
@@ -1,0 +1,116 @@
+/***************************************************************************
+ *  clingo_control_manager.cpp - Clingo control manager
+ *
+ *  Created: Thu Oct 27 16:23:32 2016
+ *  Copyright  2016  Björn Schäpers
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#include "clingo_control_manager.h"
+
+#include <core/exception.h>
+#include <logging/logger.h>
+
+#include <clingo.hh>
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+/**
+ * @class ClingoControlManager <plugins/asp/aspect/clingo_control_manager.h>
+ * The Clingo Control Manager creates and maintains Clingo Controls..
+ * @author Björn Schäpers
+ */
+
+/**
+ * Constructor.
+ * @param[in] logger The logger for the controls.
+ */
+ClingoControlManager::ClingoControlManager(Logger *logger) : Log(logger)
+{
+	return;
+}
+
+/** Destructor. */
+ClingoControlManager::~ClingoControlManager(void)
+{
+	return;
+}
+
+/**
+ * Create a new control. The control is registered internally under the specified name.
+ * It must be destroyed when done with it. Only a single control can be created for a particular control name.
+ * @param[in] ctrl_name The Name by which to register the control.
+ * @param[in] log_component_name The Prefix for log entries. If empty it will be set to "Clingo".
+ * @return A new plain Clingo Control.
+ */
+LockPtr<Clingo::Control>
+ClingoControlManager::create_control(const std::string& ctrl_name, const std::string& log_component_name)
+{
+	if ( Controls.count(ctrl_name) != 0 )
+	{
+		throw Exception("Clingo Control '%s' already exists!", ctrl_name.c_str());
+	} //if ( Controls.count(ctrl_name) != 0 )
+
+	auto clingoLogger = [this,log_component_name](const Clingo::WarningCode code, char const *msg)
+		{
+			fawkes::Logger::LogLevel level = fawkes::Logger::LL_NONE;
+			switch ( code )
+			{
+				case Clingo::WarningCode::AtomUndefined      :
+				case Clingo::WarningCode::OperationUndefined :
+				case Clingo::WarningCode::RuntimeError       : level = fawkes::Logger::LL_ERROR; break;
+				case Clingo::WarningCode::Other              :
+				case Clingo::WarningCode::VariableUnbounded  : level = fawkes::Logger::LL_WARN;
+				case Clingo::WarningCode::FileIncluded       :
+				case Clingo::WarningCode::GlobalVariable     : level = fawkes::Logger::LL_INFO; break;
+			} //switch ( code )
+			Log->log(level, log_component_name.empty() ? "Clingo" : log_component_name.c_str(), msg);
+			return;
+		};
+	LockPtr<Clingo::Control> ctrl(new Clingo::Control({}, clingoLogger, 100));
+
+	Controls.emplace(ctrl_name, ctrl);
+
+	return ctrl;
+}
+
+/**
+ * "Destroys" the named control. Only ever destroy controls which you have created yourself.
+ * It will be unregistered, but live as long as there is a LockPtr reference to it.
+ * @param[in] ctrl_name The name of the control to destroy.
+ */
+void
+ClingoControlManager::destroy_control(const std::string& ctrl_name)
+{
+	Controls.erase(ctrl_name);
+	return;
+}
+
+
+/**
+ * Get map of controls.
+ * @return The map from control name to control lock ptr.
+ */
+const std::unordered_map<std::string, LockPtr<Clingo::Control>>&
+ClingoControlManager::controls(void) const
+{
+	return Controls;
+}
+
+} // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_control_manager.cpp
+++ b/src/plugins/asp/aspect/clingo_control_manager.cpp
@@ -3,6 +3,7 @@
  *
  *  Created: Thu Oct 27 16:23:32 2016
  *  Copyright  2016  Björn Schäpers
+ *             2018  Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -19,66 +20,59 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#include "clingo_access.h"
-#include "clingo_control_manager.h"
+#include <plugins/asp/aspect/clingo_access.h>
+#include <plugins/asp/aspect/clingo_control_manager.h>
 
 #include <core/exception.h>
 #include <logging/logger.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
-/**
- * @class ClingoControlManager <plugins/asp/aspect/clingo_control_manager.h>
- * The Clingo Control Manager creates and maintains Clingo Controls..
+/** @class ClingoControlManager <plugins/asp/aspect/clingo_control_manager.h>
+ * The Clingo Control Manager creates and maintains Clingo Controls.
  * @author Björn Schäpers
  */
 
-/**
- * Constructor.
- */
-ClingoControlManager::ClingoControlManager(void) : Log(nullptr)
+/** Constructor. */
+ClingoControlManager::ClingoControlManager(void)
+: logger_(nullptr)
 {
-	return;
 }
 
 /** Destructor. */
 ClingoControlManager::~ClingoControlManager(void)
 {
-	return;
 }
 
 /**
  * @brief Sets the logger for all Clingo Controls.
  * @param[in] logger The logger.
  */
-void ClingoControlManager::setLogger(Logger *logger)
+void ClingoControlManager::set_logger(Logger *logger)
 {
-	Log = logger;
-	return;
+	logger_ = logger;
 }
 
-/**
- * Create a new control. The control is registered internally under the specified name.
- * It must be destroyed when done with it. Only a single control can be created for a particular control name.
+/** Create a new control.
+ * The control is registered internally under the specified name.  It
+ * must be destroyed when done with it. Only a single control can be
+ * created for a particular control name.
  * @param[in] ctrl_name The Name by which to register the control.
  * @param[in] log_component_name The Prefix for log entries. If empty it will be set to "Clingo".
  * @return A new plain Clingo Control.
  */
-LockPtr<ClingoAccess> ClingoControlManager::create_control(const std::string& ctrl_name,
-		const std::string& log_component_name)
+LockPtr<ClingoAccess>
+ClingoControlManager::create_control(const std::string& ctrl_name,
+                                     const std::string& log_component_name)
 {
-	if ( Controls.count(ctrl_name) != 0 )
-	{
+	if ( controls_.count(ctrl_name) != 0 ) {
 		throw Exception("Clingo Control '%s' already exists!", ctrl_name.c_str());
-	} //if ( Controls.count(ctrl_name) != 0 )
+	}
 
 	Clingo::SymbolSpan s;
-	LockPtr<ClingoAccess> ctrl(new ClingoAccess(Log, log_component_name));
+	LockPtr<ClingoAccess> ctrl(new ClingoAccess(logger_, log_component_name));
 
-	Controls.emplace(ctrl_name, ctrl);
+	controls_.emplace(ctrl_name, ctrl);
 
 	return ctrl;
 }
@@ -91,7 +85,7 @@ LockPtr<ClingoAccess> ClingoControlManager::create_control(const std::string& ct
 void
 ClingoControlManager::destroy_control(const std::string& ctrl_name)
 {
-	Controls.erase(ctrl_name);
+	controls_.erase(ctrl_name);
 	return;
 }
 
@@ -102,7 +96,7 @@ ClingoControlManager::destroy_control(const std::string& ctrl_name)
 const std::unordered_map<std::string, LockPtr<ClingoAccess>>&
 ClingoControlManager::controls(void) const
 {
-	return Controls;
+	return controls_;
 }
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_control_manager.cpp
+++ b/src/plugins/asp/aspect/clingo_control_manager.cpp
@@ -39,9 +39,8 @@ namespace fawkes {
 
 /**
  * Constructor.
- * @param[in] logger The logger for the controls.
  */
-ClingoControlManager::ClingoControlManager(Logger *logger) : Log(logger)
+ClingoControlManager::ClingoControlManager(void) : Log(nullptr)
 {
 	return;
 }
@@ -49,6 +48,16 @@ ClingoControlManager::ClingoControlManager(Logger *logger) : Log(logger)
 /** Destructor. */
 ClingoControlManager::~ClingoControlManager(void)
 {
+	return;
+}
+
+/**
+ * @brief Sets the logger for all Clingo Controls.
+ * @param[in] logger The logger.
+ */
+void ClingoControlManager::setLogger(Logger *logger)
+{
+	Log = logger;
 	return;
 }
 

--- a/src/plugins/asp/aspect/clingo_control_manager.h
+++ b/src/plugins/asp/aspect/clingo_control_manager.h
@@ -26,22 +26,19 @@
 
 #include <unordered_map>
 
-namespace Clingo {
-	class Control;
-}
-
 namespace fawkes {
 #if 0 /* just to make Emacs auto-indent happy */
 }
 #endif
 
+class ClingoAccess;
 class Logger;
 
 class ClingoControlManager
 {
 	private:
 	Logger *Log;
-	std::unordered_map<std::string, LockPtr<Clingo::Control>> Controls;
+	std::unordered_map<std::string, LockPtr<ClingoAccess>> Controls;
 
 	public:
 	ClingoControlManager(void);
@@ -49,10 +46,10 @@ class ClingoControlManager
 
 	void setLogger(Logger *logger);
 
-	LockPtr<Clingo::Control> create_control(const std::string& ctrl_name, const std::string& log_component_name);
+	LockPtr<ClingoAccess> create_control(const std::string& ctrl_name, const std::string& log_component_name);
 	void destroy_control(const std::string& ctrl_name);
 
-	const std::unordered_map<std::string, LockPtr<Clingo::Control>>& controls(void) const;
+	const std::unordered_map<std::string, LockPtr<ClingoAccess>>& controls(void) const;
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_control_manager.h
+++ b/src/plugins/asp/aspect/clingo_control_manager.h
@@ -3,6 +3,7 @@
  *
  *  Created: Thu Oct 27 16:23:32 2016
  *  Copyright  2016  Björn Schäpers
+ *             2018  Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -19,38 +20,37 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#ifndef __PLUGINS_ASP_ASPECT_CLINGO_CONTROL_MANAGER_H_
-#define __PLUGINS_ASP_ASPECT_CLINGO_CONTROL_MANAGER_H_
+#ifndef _PLUGINS_ASP_ASPECT_CLINGO_CONTROL_MANAGER_H_
+#define _PLUGINS_ASP_ASPECT_CLINGO_CONTROL_MANAGER_H_
 
 #include <core/utils/lockptr.h>
 
 #include <unordered_map>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 class ClingoAccess;
 class Logger;
 
 class ClingoControlManager
 {
-	private:
-	Logger *Log;
-	std::unordered_map<std::string, LockPtr<ClingoAccess>> Controls;
-
 	public:
 	ClingoControlManager(void);
 	virtual ~ClingoControlManager(void);
 
-	void setLogger(Logger *logger);
+	void set_logger(Logger *logger);
 
-	LockPtr<ClingoAccess> create_control(const std::string& ctrl_name, const std::string& log_component_name);
+	LockPtr<ClingoAccess> create_control(const std::string& ctrl_name,
+	                                     const std::string& log_component_name);
 	void destroy_control(const std::string& ctrl_name);
 
 	const std::unordered_map<std::string, LockPtr<ClingoAccess>>& controls(void) const;
+
+private:
+	Logger *logger_;
+	std::unordered_map<std::string, LockPtr<ClingoAccess>> controls_;
 };
+
 
 } // end namespace fawkes
 

--- a/src/plugins/asp/aspect/clingo_control_manager.h
+++ b/src/plugins/asp/aspect/clingo_control_manager.h
@@ -44,8 +44,10 @@ class ClingoControlManager
 	std::unordered_map<std::string, LockPtr<Clingo::Control>> Controls;
 
 	public:
-	ClingoControlManager(Logger *logger);
+	ClingoControlManager(void);
 	virtual ~ClingoControlManager(void);
+
+	void setLogger(Logger *logger);
 
 	LockPtr<Clingo::Control> create_control(const std::string& ctrl_name, const std::string& log_component_name);
 	void destroy_control(const std::string& ctrl_name);

--- a/src/plugins/asp/aspect/clingo_control_manager.h
+++ b/src/plugins/asp/aspect/clingo_control_manager.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+ *  clingo_control_manager.h - Clingo control manager
+ *
+ *  Created: Thu Oct 27 16:23:32 2016
+ *  Copyright  2016  Björn Schäpers
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#ifndef __PLUGINS_ASP_ASPECT_CLINGO_CONTROL_MANAGER_H_
+#define __PLUGINS_ASP_ASPECT_CLINGO_CONTROL_MANAGER_H_
+
+#include <core/utils/lockptr.h>
+
+#include <unordered_map>
+
+namespace Clingo {
+	class Control;
+}
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+class Logger;
+
+class ClingoControlManager
+{
+	private:
+	Logger *Log;
+	std::unordered_map<std::string, LockPtr<Clingo::Control>> Controls;
+
+	public:
+	ClingoControlManager(Logger *logger);
+	virtual ~ClingoControlManager(void);
+
+	LockPtr<Clingo::Control> create_control(const std::string& ctrl_name, const std::string& log_component_name);
+	void destroy_control(const std::string& ctrl_name);
+
+	const std::unordered_map<std::string, LockPtr<Clingo::Control>>& controls(void) const;
+};
+
+} // end namespace fawkes
+
+#endif

--- a/src/plugins/asp/aspect/clingo_manager.cpp
+++ b/src/plugins/asp/aspect/clingo_manager.cpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+ *  clingo_manager.cpp - Clingo manager aspect for Fawkes
+ *
+ *  Created: Sat Oct 29 11:30:07 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#include "clingo_manager.h"
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+/** @class ClingoManagerAspect <plugins/asp/aspect/clingo_manager.h>
+ * Thread aspect to access the Clingo Control manager.
+
+ * Give this aspect to your thread if you want to access the Clingo control manager.
+ * Use this with extreme care and only if you know what you are doing.
+ * If you want to create a Clingo control to work with use the ASPAspect.
+ *
+ * @ingroup Aspects
+ * @author Björn Schäpers
+ *
+ * @property ClingoManagerAspect::ClingoCtrlMgr
+ * The Clingo control manager.
+ */
+
+/** Constructor. */
+ClingoManagerAspect::ClingoManagerAspect(void)
+{
+	add_aspect("ClingoManagerAspect");
+	return;
+}
+
+/** Virtual empty destructor. */
+ClingoManagerAspect::~ClingoManagerAspect(void)
+{
+	return;
+}
+
+} // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_manager.cpp
+++ b/src/plugins/asp/aspect/clingo_manager.cpp
@@ -3,7 +3,7 @@
  *
  *  Created: Sat Oct 29 11:30:07 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -20,12 +20,9 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#include "clingo_manager.h"
+#include <plugins/asp/aspect/clingo_manager.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 /** @class ClingoManagerAspect <plugins/asp/aspect/clingo_manager.h>
  * Thread aspect to access the Clingo Control manager.
@@ -37,7 +34,7 @@ namespace fawkes {
  * @ingroup Aspects
  * @author Björn Schäpers
  *
- * @property ClingoManagerAspect::ClingoCtrlMgr
+ * @property ClingoManagerAspect::clingo_ctrl_mgr
  * The Clingo control manager.
  */
 
@@ -45,13 +42,30 @@ namespace fawkes {
 ClingoManagerAspect::ClingoManagerAspect(void)
 {
 	add_aspect("ClingoManagerAspect");
-	return;
 }
 
 /** Virtual empty destructor. */
 ClingoManagerAspect::~ClingoManagerAspect(void)
 {
-	return;
+}
+
+/** Init ClingoManagerAspect.
+ * This sets the Clingo Control Manager.
+ * @param[in] clingo_ctrl_mgr The Clingo Control Manager
+ */
+void
+ClingoManagerAspect::init_ClingoManagerAspect(const LockPtr<ClingoControlManager>& clingo_ctrl_mgr)
+{
+	this->clingo_ctrl_mgr = clingo_ctrl_mgr;
+}
+
+/** Finalize ASP aspect.
+ * This clears the Clingo Control.
+ */
+void
+ClingoManagerAspect::finalize_ClingoManagerAspect(void)
+{
+	clingo_ctrl_mgr.clear();
 }
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_manager.h
+++ b/src/plugins/asp/aspect/clingo_manager.h
@@ -3,7 +3,7 @@
  *
  *  Created: Sat Oct 29 11:30:07 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -20,29 +20,27 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#ifndef __PLUGINS_ASP_ASPECT_CLINGO_MANAGER_H_
-#define __PLUGINS_ASP_ASPECT_CLINGO_MANAGER_H_
+#ifndef _PLUGINS_ASP_ASPECT_CLINGO_MANAGER_H_
+#define _PLUGINS_ASP_ASPECT_CLINGO_MANAGER_H_
 
 #include <aspect/aspect.h>
 #include <core/utils/lockptr.h>
 
-#include "clingo_control_manager.h"
+#include <plugins/asp/aspect/clingo_control_manager.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 class ClingoManagerAspect : public virtual Aspect
 {
-	protected:
-	LockPtr<ClingoControlManager> ClingoCtrlMgr;
-
-	public:
+public:
 	ClingoManagerAspect(void);
 	virtual ~ClingoManagerAspect(void);
 
-	friend class ClingoManagerAspectIniFin;
+	void init_ClingoManagerAspect(const LockPtr<ClingoControlManager>& clingo_ctrl_mgr);
+	void finalize_ClingoManagerAspect(void);
+
+protected:
+	LockPtr<ClingoControlManager> clingo_ctrl_mgr;
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_manager.h
+++ b/src/plugins/asp/aspect/clingo_manager.h
@@ -1,0 +1,50 @@
+/***************************************************************************
+ *  clingo_manager.h - Clingo manager aspect for Fawkes
+ *
+ *  Created: Sat Oct 29 11:30:07 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#ifndef __PLUGINS_ASP_ASPECT_CLINGO_MANAGER_H_
+#define __PLUGINS_ASP_ASPECT_CLINGO_MANAGER_H_
+
+#include <aspect/aspect.h>
+#include <core/utils/lockptr.h>
+
+#include "clingo_control_manager.h"
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+class ClingoManagerAspect : public virtual Aspect
+{
+	protected:
+	LockPtr<ClingoControlManager> ClingoCtrlMgr;
+
+	public:
+	ClingoManagerAspect(void);
+	virtual ~ClingoManagerAspect(void);
+
+	friend class ClingoManagerAspectIniFin;
+};
+
+} // end namespace fawkes
+
+#endif

--- a/src/plugins/asp/aspect/clingo_manager_inifin.cpp
+++ b/src/plugins/asp/aspect/clingo_manager_inifin.cpp
@@ -3,7 +3,7 @@
  *
  *  Created: Sat Oct 29 11:30:07 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -20,72 +20,62 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
-#include "clingo_manager.h"
-#include "clingo_manager_inifin.h"
+#include <plugins/asp/aspect/clingo_manager.h>
+#include <plugins/asp/aspect/clingo_manager_inifin.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 /**
  * @class ClingoManagerAspectIniFin <plugins/asp/aspect/clingo_manager_inifin.h>
  * ClingoManagerAspect initializer/finalizer.
  * @author Björn Schäpers
  *
- * @property ClingoManagerAspectIniFin::ClingoCtrlMgr
+ * @property ClingoManagerAspectIniFin::clingo_ctrl_mgr_
  * @brief The Clingo control manager.
  */
 
 /** Constructor. */
-ClingoManagerAspectIniFin::ClingoManagerAspectIniFin(void) : AspectIniFin("ClingoManagerAspect")
+ClingoManagerAspectIniFin::ClingoManagerAspectIniFin(void)
+: AspectIniFin("ClingoManagerAspect")
 {
-	return;
 }
 
 /** Destructor. */
 ClingoManagerAspectIniFin::~ClingoManagerAspectIniFin(void)
 {
-	return;
 }
 
 void
 ClingoManagerAspectIniFin::init(Thread *thread)
 {
 	auto clingo_thread = dynamic_cast<ClingoManagerAspect *>(thread);
-	if ( clingo_thread == nullptr )
-	{
-		throw CannotInitializeThreadException(
-			"Thread '%s' claims to have the ClingoManagerAspect, but RTTI says it has not. ", thread->name());
-	} //if ( clingo_thread == nullptr )
+	if ( clingo_thread == nullptr ) {
+		throw CannotInitializeThreadException("Thread '%s' claims to have the ClingoManagerAspect, "
+		                                      "but RTTI says it has not. ", thread->name());
+	}
 
-	clingo_thread->ClingoCtrlMgr = ClingoCtrlMgr;
-	return;
+	clingo_thread->init_ClingoManagerAspect(clingo_ctrl_mgr_);
 }
 
 void
 ClingoManagerAspectIniFin::finalize(Thread *thread)
 {
 	auto clingo_thread = dynamic_cast<ClingoManagerAspect *>(thread);
-	if ( clingo_thread == nullptr )
-	{
-		throw CannotFinalizeThreadException(
-			"Thread '%s' claims to have the ClingoManagerAspect, but RTTI says it has not. ", thread->name());
-	} //if ( clingo_thread == nullptr )
+	if ( clingo_thread == nullptr )	{
+		throw CannotFinalizeThreadException("Thread '%s' claims to have the ClingoManagerAspect, "
+		                                    "but RTTI says it has not. ", thread->name());
+	}
 
-	clingo_thread->ClingoCtrlMgr.clear();
-	return;
+	clingo_thread->finalize_ClingoManagerAspect();
 }
 
-/**
- * Set Clingo control manger.
- * @param[in] clingoCtrlMgr Clingo control manager
+/** Set Clingo control manger.
+ * @param[in] clingo_ctrl_mgr Clingo control manager
  */
 void
-ClingoManagerAspectIniFin::setControlManager(LockPtr<ClingoControlManager>& clingoCtrlMgr)
+ClingoManagerAspectIniFin::set_control_manager(LockPtr<ClingoControlManager>& clingo_ctrl_mgr)
 {
-	ClingoCtrlMgr = clingoCtrlMgr;
-	return;
+	clingo_ctrl_mgr_ = clingo_ctrl_mgr;
 }
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_manager_inifin.cpp
+++ b/src/plugins/asp/aspect/clingo_manager_inifin.cpp
@@ -1,0 +1,91 @@
+/***************************************************************************
+ *  clingo_manager_inifin.cpp - Fawkes ClingoManagerAspect initializer/finalizer
+ *
+ *  Created: Sat Oct 29 11:30:07 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#include "clingo_manager.h"
+#include "clingo_manager_inifin.h"
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+/**
+ * @class ClingoManagerAspectIniFin <plugins/asp/aspect/clingo_manager_inifin.h>
+ * ClingoManagerAspect initializer/finalizer.
+ * @author Björn Schäpers
+ *
+ * @property ClingoManagerAspectIniFin::ClingoCtrlMgr
+ * @brief The Clingo control manager.
+ */
+
+/** Constructor. */
+ClingoManagerAspectIniFin::ClingoManagerAspectIniFin(void) : AspectIniFin("ClingoManagerAspect")
+{
+	return;
+}
+
+/** Destructor. */
+ClingoManagerAspectIniFin::~ClingoManagerAspectIniFin(void)
+{
+	return;
+}
+
+void
+ClingoManagerAspectIniFin::init(Thread *thread)
+{
+	auto clingo_thread = dynamic_cast<ClingoManagerAspect *>(thread);
+	if ( clingo_thread == nullptr )
+	{
+		throw CannotInitializeThreadException(
+			"Thread '%s' claims to have the ClingoManagerAspect, but RTTI says it has not. ", thread->name());
+	} //if ( clingo_thread == nullptr )
+
+	clingo_thread->ClingoCtrlMgr = ClingoCtrlMgr;
+	return;
+}
+
+void
+ClingoManagerAspectIniFin::finalize(Thread *thread)
+{
+	auto clingo_thread = dynamic_cast<ClingoManagerAspect *>(thread);
+	if ( clingo_thread == nullptr )
+	{
+		throw CannotFinalizeThreadException(
+			"Thread '%s' claims to have the ClingoManagerAspect, but RTTI says it has not. ", thread->name());
+	} //if ( clingo_thread == nullptr )
+
+	clingo_thread->ClingoCtrlMgr.clear();
+	return;
+}
+
+/**
+ * Set Clingo control manger.
+ * @param[in] clingoCtrlMgr Clingo control manager
+ */
+void
+ClingoManagerAspectIniFin::set_manager(LockPtr<ClingoControlManager>& clingoCtrlMgr)
+{
+	ClingoCtrlMgr = clingoCtrlMgr;
+	return;
+}
+
+} // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_manager_inifin.cpp
+++ b/src/plugins/asp/aspect/clingo_manager_inifin.cpp
@@ -82,7 +82,7 @@ ClingoManagerAspectIniFin::finalize(Thread *thread)
  * @param[in] clingoCtrlMgr Clingo control manager
  */
 void
-ClingoManagerAspectIniFin::set_manager(LockPtr<ClingoControlManager>& clingoCtrlMgr)
+ClingoManagerAspectIniFin::setControlManager(LockPtr<ClingoControlManager>& clingoCtrlMgr)
 {
 	ClingoCtrlMgr = clingoCtrlMgr;
 	return;

--- a/src/plugins/asp/aspect/clingo_manager_inifin.h
+++ b/src/plugins/asp/aspect/clingo_manager_inifin.h
@@ -45,7 +45,7 @@ class ClingoManagerAspectIniFin : public AspectIniFin
 	void init(Thread *thread) override;
 	void finalize(Thread *thread) override;
 
-	void set_manager(LockPtr<ClingoControlManager>& clingoCtrlMgr);
+	void setControlManager(LockPtr<ClingoControlManager>& clingoCtrlMgr);
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/aspect/clingo_manager_inifin.h
+++ b/src/plugins/asp/aspect/clingo_manager_inifin.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *  clingo_manager_inifin.h - Fawkes ClingoManagerAspect initializer/finalizer
+ *
+ *  Created: Sat Oct 29 11:30:07 2016
+ *  Copyright  2016 Björn Schäpers
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version. A runtime exception applies to
+ *  this software (see LICENSE.GPL_WRE file mentioned below for details).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
+ */
+
+#ifndef __PLUGINS_ASP_ASPECT_CLINGO_MANAGER_INIFIN_H_
+#define __PLUGINS_ASP_ASPECT_CLINGO_MANAGER_INIFIN_H_
+
+#include <aspect/inifins/inifin.h>
+#include <core/utils/lockptr.h>
+
+namespace fawkes {
+#if 0 /* just to make Emacs auto-indent happy */
+}
+#endif
+
+class ClingoControlManager;
+
+class ClingoManagerAspectIniFin : public AspectIniFin
+{
+	private:
+	LockPtr<ClingoControlManager> ClingoCtrlMgr;
+
+	public:
+	ClingoManagerAspectIniFin(void);
+	~ClingoManagerAspectIniFin(void);
+
+	void init(Thread *thread) override;
+	void finalize(Thread *thread) override;
+
+	void set_manager(LockPtr<ClingoControlManager>& clingoCtrlMgr);
+};
+
+} // end namespace fawkes
+
+#endif

--- a/src/plugins/asp/aspect/clingo_manager_inifin.h
+++ b/src/plugins/asp/aspect/clingo_manager_inifin.h
@@ -3,7 +3,7 @@
  *
  *  Created: Sat Oct 29 11:30:07 2016
  *  Copyright  2016 Björn Schäpers
- *
+ *             2018 Tim Niemueller [www.niemueller.org]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -27,17 +27,11 @@
 #include <core/utils/lockptr.h>
 
 namespace fawkes {
-#if 0 /* just to make Emacs auto-indent happy */
-}
-#endif
 
 class ClingoControlManager;
 
 class ClingoManagerAspectIniFin : public AspectIniFin
 {
-	private:
-	LockPtr<ClingoControlManager> ClingoCtrlMgr;
-
 	public:
 	ClingoManagerAspectIniFin(void);
 	~ClingoManagerAspectIniFin(void);
@@ -45,7 +39,10 @@ class ClingoManagerAspectIniFin : public AspectIniFin
 	void init(Thread *thread) override;
 	void finalize(Thread *thread) override;
 
-	void setControlManager(LockPtr<ClingoControlManager>& clingoCtrlMgr);
+	void set_control_manager(LockPtr<ClingoControlManager>& clingo_ctrl_mgr);
+
+private:
+	LockPtr<ClingoControlManager> clingo_ctrl_mgr_;
 };
 
 } // end namespace fawkes

--- a/src/plugins/asp/clingo.mk
+++ b/src/plugins/asp/clingo.mk
@@ -1,0 +1,39 @@
+#*****************************************************************************
+#              Makefile Build System for Fawkes: Clingo bits
+#                            -------------------
+#   Created on Fri Nov 09 12:44:24 2018 +0100
+#   Copyright (C) 2016 Björn Schäpers
+#                 2018 Tim Niemueller [www.niemueller.org]
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+ifneq ($(CLINGO_DIR),)
+  ifneq ($(wildcard $(CLINGO_DIR)/build/bin/libclingo.so),)
+    ifneq ($(wildcard $(CLINGO_DIR)/libclingo/clingo/clingocontrol.hh),)
+      HAVE_CLINGO=1
+		else
+			CLINGO_ERROR=Clingo not found
+    endif
+	else
+		CLINGO_ERROR=Clingo lib not found
+  endif
+else
+  CLINGO_ERROR=CLINGO_DIR not set
+endif
+
+ifeq ($(HAVE_CLINGO),1)
+	CFLAGS_CLINGO = -DWITH_THREADS=1 \
+		-I $(CLINGO_DIR)/libclasp \
+		-I $(CLINGO_DIR)/libclingo \
+		-I $(CLINGO_DIR)/libgringo \
+		-I $(CLINGO_DIR)/liblp \
+		-I $(CLINGO_DIR)/libprogram_opts
+	LDFLAGS_CLINGO = -L$(CLINGO_DIR)/build/bin/ -Wl,-rpath=$(CLINGO_DIR)/build/bin/ -lclingo
+endif
+

--- a/src/plugins/asp/clingo.mk
+++ b/src/plugins/asp/clingo.mk
@@ -16,24 +16,27 @@
 ifneq ($(CLINGO_DIR),)
   ifneq ($(wildcard $(CLINGO_DIR)/build/bin/libclingo.so),)
     ifneq ($(wildcard $(CLINGO_DIR)/libclingo/clingo/clingocontrol.hh),)
-      HAVE_CLINGO=1
-		else
+      HAVE_CLINGO    = 1
+      CFLAGS_CLINGO  = -DHAVE_CLINGO -DWITH_THREADS=1 \
+        -I$(CLINGO_DIR)/libclasp \
+        -I$(CLINGO_DIR)/libclingo \
+        -I$(CLINGO_DIR)/libgringo \
+        -I$(CLINGO_DIR)/liblp \
+        -I$(CLINGO_DIR)/libprogram_opts
+      LDFLAGS_CLINGO = -L$(CLINGO_DIR)/build/bin/ -Wl,-rpath=$(CLINGO_DIR)/build/bin/ -lclingo
+    else
 			CLINGO_ERROR=Clingo not found
     endif
-	else
+  else
 		CLINGO_ERROR=Clingo lib not found
   endif
 else
-  CLINGO_ERROR=CLINGO_DIR not set
-endif
-
-ifeq ($(HAVE_CLINGO),1)
-	CFLAGS_CLINGO = -DWITH_THREADS=1 \
-		-I $(CLINGO_DIR)/libclasp \
-		-I $(CLINGO_DIR)/libclingo \
-		-I $(CLINGO_DIR)/libgringo \
-		-I $(CLINGO_DIR)/liblp \
-		-I $(CLINGO_DIR)/libprogram_opts
-	LDFLAGS_CLINGO = -L$(CLINGO_DIR)/build/bin/ -Wl,-rpath=$(CLINGO_DIR)/build/bin/ -lclingo
+  ifneq ($(wildcard $(SYSROOT)/usr/include/clingo.hh),)
+    HAVE_CLINGO    = 1
+    CFLAGS_CLINGO  = -DHAVE_CLINGO -DWITH_THREADS=1
+    LDFLAGS_CLINGO = -lclingo
+  else
+    CLINGO_ERROR=Clingo not found and CLINGO_DIR not set
+  endif
 endif
 


### PR DESCRIPTION
This provides the basic integration for the Answer Set Programming (ASP) solver [Clingo](https://github.com/potassco/clingo) (requires a version with [Clingo PR #127](https://github.com/potassco/clingo/pull/127) integrated on recent compilers).

This is the base system part of the paper published at [ICAPS 2018](https://www.aaai.org/ocs/index.php/ICAPS/ICAPS18/paper/view/17777). It has been modified from the original version in terms of commit style and some commits adapt the code style to Fawkes' and enable using a [package-installed Clingo version](https://copr.fedorainfracloud.org/coprs/timn/clingo/) (which is integrated into the [fawkes-builder](https://github.com/fawkesrobotics/docker-robotics/tree/master/fawkes-builder) image (for Fedora), and thus included into CI builds).