### PR TITLE
laser-filter: fix double free in filter buffer

### DIFF
--- a/src/plugins/laser-filter/filters/filter.cpp
+++ b/src/plugins/laser-filter/filters/filter.cpp
@@ -95,13 +95,11 @@ LaserDataFilter::~LaserDataFilter()
 {
   if (own_in_) {
     for (unsigned int i = 0; i < in.size(); ++i) {
-      free(in[i]->values);
       delete in[i];
     }
   }
   if (own_out_) {
     for (unsigned int i = 0; i < out.size(); ++i) {
-      free(out[i]->values);
       delete out[i];
     }
   }
@@ -135,7 +133,6 @@ LaserDataFilter::set_out_vector(std::vector<Buffer *> &out)
 
   if (own_out_) {
     for (unsigned int i = 0; i < this->out.size(); ++i) {
-      free(this->out[i]->values);
       delete this->out[i];
     }
   }
@@ -159,8 +156,7 @@ LaserDataFilter::set_out_data_size(unsigned int data_size)
   if (out_data_size != data_size) {
     if (own_out_) {
       for (unsigned int i = 0; i < out.size(); ++i) {
-	free(out[i]->values);
-	out[i]->values = (float *)malloc(data_size * sizeof(float));
+	      out[i]->resize(data_size);
       }
     }
   }
@@ -241,4 +237,20 @@ LaserDataFilter::Buffer::~Buffer()
   if (values) {
 	  free(values);
   }
+}
+
+/** Resize buffer size.
+ * Free data array and create a new one. All values are invalidated.
+ * @param num_values if not zero allocates the values arrays with the
+ */
+void
+LaserDataFilter::Buffer::resize(unsigned int num_values)
+{
+	if (values) {
+		free(values);
+		values = NULL;
+	}
+	if (num_values > 0) {
+		values = (float *)malloc(num_values * sizeof(float));
+	}
 }

--- a/src/plugins/laser-filter/filters/filter.h
+++ b/src/plugins/laser-filter/filters/filter.h
@@ -36,7 +36,8 @@ class LaserDataFilter
    public:
     Buffer(size_t num_values = 0);
     ~Buffer();
-    std::string   name; ///< name of the input buffer
+	  void resize(unsigned int num_values);
+	  std::string   name; ///< name of the input buffer
     std::string   frame;		///< reference coordinate frame ID
     float        *values;	///< values
     fawkes::Time *timestamp;	///< timestamp of data


### PR DESCRIPTION
We recently fixed a missing free reported by https://lgtm.com. Turns out
this was actually a false positive. However, we use a really strange
allocation scheme, where we allocate and free memory from the outside,
even though the member is directly tied to the lifetime of the Buffer
object.

Fix by moving memory management into Buffer where it belongs.

Confirmed in RCLL simulation to fix a crash on start. Fixes carologistics/fawkes-robotino#26.