### PR TITLE
laser: fix type error

### DIFF
--- a/src/plugins/laser/sick_tim55x_common_aqt.cpp
+++ b/src/plugins/laser/sick_tim55x_common_aqt.cpp
@@ -302,8 +302,9 @@ SickTiM55xCommonAcquisitionThread::parse_datagram(const unsigned char *datagram,
 
   // 22: Scaling offset (00000000) -- always 0
   // 23: Starting angle (FFF92230)
-  unsigned int starting_angle_val = 0;
-  sscanf(fields[23].c_str(), "%x", &starting_angle_val);
+  unsigned int starting_angle_hexval = 0;
+  sscanf(fields[23].c_str(), "%x", &starting_angle_hexval);
+  int starting_angle_val = static_cast<int>(starting_angle_hexval);
   float angle_min = (starting_angle_val / 10000.0) / 180.0 * M_PI - M_PI / 2;
 
   // 24: Angular step width (2710)


### PR DESCRIPTION
This was introduced in 3765f31 when fixing a Codacy error. This was
raised for good reason: we are using sscanf() to read a "%x" format. The
documentation (man sscanf) states that this must be read into an
unsigned integer. The Sick TiM protocol documentation indeed states the
type "Uint_32" for the starting angle field, however, the range is
declared as -450000d to +2250000d.

So we need to read an unsigned int and then interpret it as a signed
integer to be compliant with sscanf and the device protocol.

Thanks to @vmatare for reporting this issue.