### PR TITLE
Adapt pcl-db-roscomm to fawkes_msgs

### DIFF
--- a/src/plugins/perception/pcl-db/ros/Makefile
+++ b/src/plugins/perception/pcl-db/ros/Makefile
@@ -29,7 +29,7 @@ OBJS_pcl_db_roscomm = pcl_db_roscomm_plugin.o pcl_db_roscomm_thread.o
 
 OBJS_all    = $(OBJS_pcl_db_roscomm)
 
-REQUIRED_ROS_PKGS = hybris_c1_msgs pcl_conversions
+REQUIRED_ROS_PKGS = fawkes_msgs pcl_conversions
 
 REQ_BOOST_LIBS = system
 HAVE_BOOST_LIBS = $(call boost-have-libs,$(REQ_BOOST_LIBS))
@@ -65,7 +65,7 @@ endif
 ifeq ($(OBJSSUBMAKE),1)
 all: $(WARN_TARGETS) $(WARN_TARGETS_BOOST)
 
-.PHONY: warning_ros warning_hybris_c1_msgs
+.PHONY: warning_ros warning_fawkes_msgs
 warning_ros:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting pcl-db-roscomm$(TNORMAL) (ROS not found)"
 warning_pcl:

--- a/src/plugins/perception/pcl-db/ros/pcl_db_roscomm_thread.cpp
+++ b/src/plugins/perception/pcl-db/ros/pcl_db_roscomm_thread.cpp
@@ -3,7 +3,7 @@
  *  pcl_db_merge_roscomm_thread.cpp - ROS communication for pcl-db-merge
  *
  *  Created: Thu Dec 06 13:54:45 2012
- *  Copyright  2012  Tim Niemueller [www.niemueller.de]
+ *  Copyright  2012-2018  Tim Niemueller [www.niemueller.de]
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -32,7 +32,6 @@
 #include <pcl/pcl_config.h>
 #if PCL_VERSION_COMPARE(>=,1,7,0)
 #  include <pcl/PCLPointCloud2.h>
-#  include <pcl/common/conversions.h>
 #  include <pcl_conversions/pcl_conversions.h>
 #endif
 
@@ -169,8 +168,8 @@ PointCloudDBROSCommThread::loop()
 }
 
 bool
-PointCloudDBROSCommThread::merge_cb(hybris_c1_msgs::MergePointClouds::Request  &req,
-				    hybris_c1_msgs::MergePointClouds::Response &resp)
+PointCloudDBROSCommThread::merge_cb(fawkes_msgs::MergePointClouds::Request  &req,
+                                    fawkes_msgs::MergePointClouds::Response &resp)
 {
   PclDatabaseMergeInterface::MergeMessage *mm =
     new PclDatabaseMergeInterface::MergeMessage();
@@ -224,8 +223,8 @@ PointCloudDBROSCommThread::merge_cb(hybris_c1_msgs::MergePointClouds::Request  &
 
 
 bool
-PointCloudDBROSCommThread::retrieve_cb(hybris_c1_msgs::RetrievePointCloud::Request  &req,
-				       hybris_c1_msgs::RetrievePointCloud::Response &resp)
+PointCloudDBROSCommThread::retrieve_cb(fawkes_msgs::RetrievePointCloud::Request  &req,
+                                       fawkes_msgs::RetrievePointCloud::Response &resp)
 {
   PclDatabaseRetrieveInterface::RetrieveMessage *mm =
     new PclDatabaseRetrieveInterface::RetrieveMessage();
@@ -233,8 +232,8 @@ PointCloudDBROSCommThread::retrieve_cb(hybris_c1_msgs::RetrievePointCloud::Reque
   int64_t timestamp = (int64_t)req.timestamp.sec * 1000L
     + (int64_t)req.timestamp.nsec / 1000000L;
 
-  logger->log_info(name(), "Restoring %lli from %s.%s", timestamp,
-		   req.database.c_str(), req.collection.c_str());
+  logger->log_info(name(), "Restoring %li from %s.%s", timestamp,
+                   req.database.c_str(), req.collection.c_str());
 
   mm->set_timestamp(timestamp);
   mm->set_database(req.database.c_str());
@@ -263,8 +262,8 @@ PointCloudDBROSCommThread::retrieve_cb(hybris_c1_msgs::RetrievePointCloud::Reque
 
 
 bool
-PointCloudDBROSCommThread::store_cb(hybris_c1_msgs::StorePointCloud::Request  &req,
-				    hybris_c1_msgs::StorePointCloud::Response &resp)
+PointCloudDBROSCommThread::store_cb(fawkes_msgs::StorePointCloud::Request  &req,
+                                    fawkes_msgs::StorePointCloud::Response &resp)
 {
 #if PCL_VERSION_COMPARE(>=,1,7,0)
   PclDatabaseStoreInterface::StoreMessage *mm =
@@ -332,8 +331,8 @@ PointCloudDBROSCommThread::store_cb(hybris_c1_msgs::StorePointCloud::Request  &r
 
 
 bool
-PointCloudDBROSCommThread::record_cb(hybris_c1_msgs::RecordData::Request  &req,
-				     hybris_c1_msgs::RecordData::Response &resp)
+PointCloudDBROSCommThread::record_cb(fawkes_msgs::RecordData::Request  &req,
+                                     fawkes_msgs::RecordData::Response &resp)
 {
   logger->log_info(name(), "Recording ordered for %f sec", req.range.toSec());
   ros::Time begin = ros::Time::now();

--- a/src/plugins/perception/pcl-db/ros/pcl_db_roscomm_thread.cpp
+++ b/src/plugins/perception/pcl-db/ros/pcl_db_roscomm_thread.cpp
@@ -194,8 +194,8 @@ PointCloudDBROSCommThread::merge_cb(fawkes_msgs::MergePointClouds::Request  &req
   size_t num_timestamps = mm->maxlenof_timestamps();
   std::vector<int64_t> timestamps(num_timestamps, 0);
   for (size_t i = 0; i < req.timestamps.size(); ++i) {
-    timestamps[i] = (int64_t)req.timestamps[i].sec * 1000L
-      + (int64_t)req.timestamps[i].nsec / 1000000L;
+    timestamps[i] = (int64_t)req.timestamps[i].data.sec * 1000L
+      + (int64_t)req.timestamps[i].data.nsec / 1000000L;
   }
   sort(timestamps.begin(), timestamps.begin() + req.timestamps.size());
   mm->set_timestamps(&timestamps[0]);

--- a/src/plugins/perception/pcl-db/ros/pcl_db_roscomm_thread.h
+++ b/src/plugins/perception/pcl-db/ros/pcl_db_roscomm_thread.h
@@ -30,10 +30,10 @@
 #include <aspect/pointcloud.h>
 #include <plugins/ros/aspect/ros.h>
 
-#include <hybris_c1_msgs/MergePointClouds.h>
-#include <hybris_c1_msgs/RetrievePointCloud.h>
-#include <hybris_c1_msgs/StorePointCloud.h>
-#include <hybris_c1_msgs/RecordData.h>
+#include <fawkes_msgs/MergePointClouds.h>
+#include <fawkes_msgs/RetrievePointCloud.h>
+#include <fawkes_msgs/StorePointCloud.h>
+#include <fawkes_msgs/RecordData.h>
 
 namespace fawkes {
   class PclDatabaseMergeInterface;
@@ -65,14 +65,14 @@ class PointCloudDBROSCommThread
   virtual void finalize();
 
  private:
-  bool merge_cb(hybris_c1_msgs::MergePointClouds::Request  &req,
-		hybris_c1_msgs::MergePointClouds::Response &resp);
-  bool retrieve_cb(hybris_c1_msgs::RetrievePointCloud::Request  &req,
-		   hybris_c1_msgs::RetrievePointCloud::Response &resp);
-  bool store_cb(hybris_c1_msgs::StorePointCloud::Request  &req,
-		hybris_c1_msgs::StorePointCloud::Response &resp);
-  bool record_cb(hybris_c1_msgs::RecordData::Request  &req,
-		 hybris_c1_msgs::RecordData::Response &resp);
+  bool merge_cb(fawkes_msgs::MergePointClouds::Request  &req,
+                fawkes_msgs::MergePointClouds::Response &resp);
+  bool retrieve_cb(fawkes_msgs::RetrievePointCloud::Request  &req,
+                   fawkes_msgs::RetrievePointCloud::Response &resp);
+  bool store_cb(fawkes_msgs::StorePointCloud::Request  &req,
+                fawkes_msgs::StorePointCloud::Response &resp);
+  bool record_cb(fawkes_msgs::RecordData::Request  &req,
+                 fawkes_msgs::RecordData::Response &resp);
 
 
  /** Stub to see name in backtrace for easier debugging. @see Thread::run() */


### PR DESCRIPTION
This plugin enables access and control to pcl-db from ROS. However, so far it depended on hybris_c1_msgs for the service/message types. This, however, is no longer maintained. Move the respective types to [fawkes_msgs](https://github.com/fawkesrobotics/fawkes_msgs), which makes much more sense as a single point of entry to Fawkes-specific ROS types. The fawkes-builder images have already been updated for fawkes_msgs.