### PR TITLE
asp: add API to get and set debug level

### DIFF
--- a/src/plugins/asp/aspect/clingo_access.cpp
+++ b/src/plugins/asp/aspect/clingo_access.cpp
@@ -503,6 +503,25 @@ ClingoAccess::num_threads(void) const noexcept
 	return num_threads_;
 }
 
+
+/** Get current debug level.
+ * @return current debug level
+ */
+ClingoAccess::DebugLevel_t
+ClingoAccess::debug_level() const
+{
+	return debug_level_.load();
+}
+
+/** Set debug level.
+ * @param log_level new debug level
+ */
+void
+ClingoAccess::set_debug_level(ClingoAccess::DebugLevel_t log_level)
+{
+	return debug_level_.store(log_level);
+}
+
 /** Returns a copy of the last symbols found.
  * @return copy of last symbols found
  */

--- a/src/plugins/asp/aspect/clingo_access.h
+++ b/src/plugins/asp/aspect/clingo_access.h
@@ -92,6 +92,9 @@ public:
 	bool assign_external(const Clingo::Symbol& atom, const Clingo::TruthValue value);
 	bool release_external(const Clingo::Symbol& atom);
 
+	DebugLevel_t debug_level() const;
+	void         set_debug_level(DebugLevel_t log_level);
+
 private:
 	bool on_model(Clingo::Model& model) override;
 	void on_finish(Clingo::SolveResult result) override;


### PR DESCRIPTION
This is a minor commit required for merging the ASP planner in fawkes-robotino. The debug level is no longer a public value, since it is an atomic value it must be treated with special care. Hence, encapsulate it in a proper API.