### PR TITLE
robot-memory: remove collection name check

### DIFF
--- a/src/plugins/robot-memory/robot_memory.h
+++ b/src/plugins/robot-memory/robot_memory.h
@@ -103,7 +103,6 @@ class RobotMemory
     template<typename T>
     EventTrigger* register_trigger(mongo::Query query, const std::string& collection, void(T::*callback)(mongo::BSONObj), T *_obj)
     {
-      check_collection_name(collection);
       return trigger_manager_->register_trigger(query, collection, callback, _obj);
     }
     /**
@@ -117,7 +116,6 @@ class RobotMemory
     template<typename T>
     EventTrigger* register_trigger(const std::string& query_str, const std::string& collection, void(T::*callback)(mongo::BSONObj), T *_obj)
     {
-      check_collection_name(collection);
       return register_trigger(mongo::fromjson(query_str), collection, callback, _obj);
     }
     void remove_trigger(EventTrigger* trigger);
@@ -138,7 +136,6 @@ class RobotMemory
                                     const std::string& collection,
                                     std::list<mongo::BSONObj>(T::*compute_func)(const mongo::BSONObj&, const std::string&), T *obj, double caching_time = 0.0, int priority = 0)
     {
-      check_collection_name(collection);
       return computables_manager_->register_computable(query_to_compute, collection, compute_func, obj, caching_time, priority);
     }
     void remove_computable(Computable* computable);
@@ -185,7 +182,6 @@ class RobotMemory
     void set_fields(mongo::Query &q, const std::string& what);
     void remove_field(mongo::Query &q, const std::string& what);
 
-    std::string check_collection_name(const std::string& collection);
     mongo::DBClientBase* get_mongodb_client(const std::string& collection);
 };
 


### PR DESCRIPTION
As discovered in https://github.com/carologistics/fawkes-robotino/issues/9, check_collection_name was called in a lot of places without actually making use of the return value. The function used to check if the collection name started with a hardcoded prefix ("robmem"). Since the collection names are configurable, there is no need for enforcing robmem as a prefix for collection names. 
895c0e434 changed the behaviour of some functions, that then actually used the return value of check_collection_name, which caused some problems.

Therefore, I suggest the removal of the check completely, since it serves no real purpose.