### PR TITLE
Upgrade build pipeline images to Fedora 29

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 merged-pr-plugin: &merged-pr-plugin
-  seek-oss/github-merged-pr#v1.0.0:
+  seek-oss/github-merged-pr#v1.0.1:
     mode: checkout
 
 docker-plugin-base: &docker-plugin-base

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ merged-pr-plugin: &merged-pr-plugin
     mode: checkout
 
 docker-plugin-base: &docker-plugin-base
-  image: fawkesrobotics/fawkes-builder:fedora28-kinetic
+  image: fawkesrobotics/fawkes-builder:fedora29-kinetic
   always-pull: true
   debug: true
   workdir: /workdir

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
     command: .buildkite/lint
     plugins:
       <<: *merged-pr-plugin
-      docker#v2.0.0:
+      docker#v2.2.0:
         <<: *docker-plugin-base
         environment:
           - BUILDKITE
@@ -35,7 +35,7 @@ steps:
     command: .buildkite/build
     plugins:
       <<: *merged-pr-plugin
-      docker#v2.0.0:
+      docker#v2.2.0:
         <<: *docker-plugin-base
         volumes:
           - .:/workdir
@@ -45,7 +45,7 @@ steps:
     command: .buildkite/build
     plugins:
       <<: *merged-pr-plugin
-      docker#v2.0.0:
+      docker#v2.2.0:
         <<: *docker-plugin-base
         image: fawkesrobotics/fawkes-builder:ubuntu1804-melodic
         volumes:

--- a/.buildkite/steps.d/20-webview-frontend.yml
+++ b/.buildkite/steps.d/20-webview-frontend.yml
@@ -2,7 +2,7 @@
     command: .buildkite/build-webview-frontend
     plugins:
       <<: *merged-pr-plugin
-      docker#v2.0.0:
+      docker#v2.2.0:
         <<: *docker-plugin-base
         volumes:
           - .:/workdir


### PR DESCRIPTION
This upgrades docker Fedora build images to Fedora 29. It seems to suffice to build on Fedora 29 only, and not build on both, F28 and F29. All relevant systems are expected to be upgraded by now or shortly.

Along the image this also performs minor upgrades to the github-merged-pr and docker buildkite plugins.

Thanks to @morxa for some Fedora package fixes and rebuilds for F29 compatibility.