### PR TITLE
buildkite: account for domain repos for stats generation

### DIFF
--- a/.buildkite/annotations.d/build_stats.sh
+++ b/.buildkite/annotations.d/build_stats.sh
@@ -29,7 +29,15 @@ source $SCRIPT_PATH/../functions.sh
 # Error out on any error in the script, pipes etc.
 set -euo pipefail
 
-STATSFILE=$(realpath $SCRIPT_PATH/../../buildstats.db)
+BASEDIR=$(realpath $SCRIPT_PATH/../..)
+if [ -e "$(realpath $BASEDIR/../.gitmodules)" -a \
+     -e "$(realpath $BASEDIR/../fawkes)" ];
+then
+	# this fawkes instance is indeed a sub-module!:
+	BASEDIR=$(realpath $BASEDIR/..)
+fi
+	
+STATSFILE=$(realpath $BASEDIR/buildstats.db)
 
 LABEL=${BUILDKITE_LABEL:-:question: Unknown System}
 


### PR DESCRIPTION
The build stats script did not account for domain repos which contain Fawkes as a sub-module.