### PR TITLE
buildkite: upgrade to docker plugin 3.0.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,18 +15,18 @@ steps:
   - label: ":memo: Linter"
     command: .buildkite/lint
     plugins:
-      <<: *merged-pr-plugin
-      docker#v3.0.1:
-        <<: *docker-plugin-base
-        environment:
-          - BUILDKITE
-          - BUILDKITE_REPO
-          - BUILDKITE_BRANCH
-          - BUILDKITE_LABEL
-          - BUILDKITE_BUILD_CREATOR
-          - BUILDKITE_BUILD_CREATOR_EMAIL
-          # the following is set by the agent environment (ansible)
-          - SSH_DEPLOY_PRIVKEY_COMMITTERS
+      - *merged-pr-plugin
+      - docker#v3.0.1:
+          <<: *docker-plugin-base
+          environment:
+            - BUILDKITE
+            - BUILDKITE_REPO
+            - BUILDKITE_BRANCH
+            - BUILDKITE_LABEL
+            - BUILDKITE_BUILD_CREATOR
+            - BUILDKITE_BUILD_CREATOR_EMAIL
+            # the following is set by the agent environment (ansible)
+            - SSH_DEPLOY_PRIVKEY_COMMITTERS
 
   - wait
 
@@ -35,21 +35,21 @@ steps:
       - .buildkite/build
       - .buildkite/annotate
     plugins:
-      <<: *merged-pr-plugin
-      docker#v3.0.1:
-        <<: *docker-plugin-base
-        volumes:
-          - /var/lib/buildkite-agent/ccache_fedora:/var/cache/ccache
+      - *merged-pr-plugin
+      - docker#v3.0.1:
+          <<: *docker-plugin-base
+          volumes:
+            - /var/lib/buildkite-agent/ccache_fedora:/var/cache/ccache
 
   - label: ":ubuntu: Ubuntu"
     command:
       - .buildkite/build
       - .buildkite/annotate
     plugins:
-      <<: *merged-pr-plugin
-      docker#v3.0.1:
-        <<: *docker-plugin-base
-        image: fawkesrobotics/fawkes-builder:ubuntu1804-melodic
-        volumes:
-          - /var/lib/buildkite-agent/ccache_ubuntu:/var/cache/ccache
+      - *merged-pr-plugin
+      - docker#v3.0.1:
+          <<: *docker-plugin-base
+          image: fawkesrobotics/fawkes-builder:ubuntu1804-melodic
+          volumes:
+            - /var/lib/buildkite-agent/ccache_ubuntu:/var/cache/ccache
 

--- a/.buildkite/steps.d/10-freebsd.yml
+++ b/.buildkite/steps.d/10-freebsd.yml
@@ -7,4 +7,4 @@
     env:
       BUILD_STATS_NO_COLOR: "1"
     plugins:
-      <<: *merged-pr-plugin
+      - *merged-pr-plugin

--- a/.buildkite/steps.d/20-webview-frontend.yml
+++ b/.buildkite/steps.d/20-webview-frontend.yml
@@ -1,8 +1,8 @@
   - label: ":angular: Webview"
     command: .buildkite/build-webview-frontend
     plugins:
-      <<: *merged-pr-plugin
-      docker#v3.0.1:
-        <<: *docker-plugin-base
-        volumes:
-          - /var/lib/buildkite-agent/npm_cacache:/home/builder/.npm/_cacache
+      - *merged-pr-plugin
+      - docker#v3.0.1:
+          <<: *docker-plugin-base
+          volumes:
+            - /var/lib/buildkite-agent/npm_cacache:/home/builder/.npm/_cacache


### PR DESCRIPTION
This restores the previous behavior of mounting the workdir by default.
Hence, remove no longer required config items.