### PR TITLE
Add yamllint buildkite check

### DIFF
--- a/.buildkite/annotations.d/build_stats.sh
+++ b/.buildkite/annotations.d/build_stats.sh
@@ -41,10 +41,10 @@ else
 	LIBS_total=$(sqlite3 $STATSFILE \
 	             'SELECT count(*) FROM buildstats WHERE type="lib"'); \
 	LIBS_ratio=$(( LIBS_built * 100 / LIBS_total )); \
-	LIBS_color=$(if [ -n "${BUILD_STATS_NO_COLOR:-}" ]; then echo "text-muted"; \
-	             elif [ $LIBS_ratio -ge 90 ]; then echo "text-success"; \
-	             elif [ $LIBS_ratio -ge 80 ]; then echo -e "text-warning"; \
-	             else echo -e "text-danger"; fi)
+	LIBS_color=$(if [ -n "${BUILD_STATS_NO_COLOR:-}" ]; then echo "gray"; \
+	             elif [ $LIBS_ratio -ge 90 ]; then echo "green"; \
+	             elif [ $LIBS_ratio -ge 80 ]; then echo -e "orange"; \
+	             else echo -e "red"; fi)
 	LIBS_skipped=$(sqlite3 $STATSFILE 'SELECT item FROM buildstats WHERE type="lib" AND state="skipped"')
 
 	PLUGINS_built=$(sqlite3 $STATSFILE \
@@ -52,10 +52,10 @@ else
 	PLUGINS_total=$(sqlite3 $STATSFILE \
 	                'SELECT count(*) FROM buildstats WHERE type="plugin"'); \
 	PLUGINS_ratio=$(( PLUGINS_built * 100 / PLUGINS_total )); \
-	PLUGINS_color=$(if [ -n "${BUILD_STATS_NO_COLOR:-}" ]; then echo "text-muted"; \
-	                elif [ $PLUGINS_ratio -ge 90 ]; then echo "text-success"; \
-	                elif [ $PLUGINS_ratio -ge 80 ]; then echo -e "text-warning"; \
-	                else echo -e "text-danger"; fi)
+	PLUGINS_color=$(if [ -n "${BUILD_STATS_NO_COLOR:-}" ]; then echo "gray"; \
+	                elif [ $PLUGINS_ratio -ge 90 ]; then echo "green"; \
+	                elif [ $PLUGINS_ratio -ge 80 ]; then echo -e "orange"; \
+	                else echo -e "red"; fi)
 	PLUGINS_skipped=$(sqlite3 $STATSFILE 'SELECT item FROM buildstats WHERE type="plugin" AND state="skipped"')
 
 	BINS_built=$(sqlite3 $STATSFILE \
@@ -63,18 +63,18 @@ else
 	BINS_total=$(sqlite3 $STATSFILE \
 	             'SELECT count(*) FROM buildstats WHERE type="bin"'); \
 	BINS_ratio=$(( BINS_built * 100 / BINS_total )); \
-	BINS_color=$(if [ -n "${BUILD_STATS_NO_COLOR:-}" ]; then echo "text-muted"; \
-	             elif [ $BINS_ratio -ge 90 ]; then echo "text-success"; \
-	             elif [ $BINS_ratio -ge 80 ]; then echo -e "text-warning"; \
-	             else echo -e "text-danger"; fi)
+	BINS_color=$(if [ -n "${BUILD_STATS_NO_COLOR:-}" ]; then echo "gray"; \
+	             elif [ $BINS_ratio -ge 90 ]; then echo "green"; \
+	             elif [ $BINS_ratio -ge 80 ]; then echo -e "orange"; \
+	             else echo -e "red"; fi)
 	BINS_skipped=$(sqlite3 $STATSFILE 'SELECT item FROM buildstats WHERE type="bin" AND state="skipped"')
 
 	cat <<-EOM
 	<h4>$LABEL Build Coverage</h4>
 	<div class="flex">
-	  <div class="p1 flex-auto">
-	    <div class="my1 h4 text-info"><strong>Libraries</strong></div>
-	    <div class="">
+	  <div class="p1 col-4">
+	    <div class="my1 h4 blue bold">Libraries</div>
+	    <div>
 	      <span class="$LIBS_color"><big><big>$LIBS_ratio</big></big>%</span><br>
 	      Built $LIBS_built of $LIBS_total
 	    </div>
@@ -91,9 +91,9 @@ else
 	fi
 	cat <<-EOM
 	  </div>
-	  <div class="p1 flex-auto">
-	    <div class="my1 h4 text-info"><strong>Plugins</strong></div>
-	    <div class="">
+	  <div class="p1 col-4">
+	    <div class="my1 h4 blue bold">Plugins</div>
+	    <div>
 	      <span class="$PLUGINS_color"><big><big>$PLUGINS_ratio</big></big>%</span><br>
 	      Built $PLUGINS_built of $PLUGINS_total
 	    </div>
@@ -110,9 +110,9 @@ else
 	fi
 	cat <<-EOM
 	  </div>
-	  <div class="p1 flex-auto">
-	    <div class="my1 h4 text-info"><strong>Executables</strong></div>
-	    <div class="">
+	  <div class="p1 col-4">
+	    <div class="my1 h4 blue bold">Executables</div>
+	    <div>
 	      <span class="$BINS_color"><big><big>$BINS_ratio</big></big>%</span><br>
 	      Built $BINS_built of $BINS_total
 	    </div>

--- a/.buildkite/annotations.d/build_stats.sh
+++ b/.buildkite/annotations.d/build_stats.sh
@@ -75,7 +75,7 @@ else
 	  <div class="p1 col-4">
 	    <div class="my1 h4 blue bold">Libraries</div>
 	    <div>
-	      <span class="$LIBS_color"><big><big>$LIBS_ratio</big></big>%</span><br>
+	      <span class="$LIBS_color bold"><big><big>$LIBS_ratio</big></big>%</span><br>
 	      Built $LIBS_built of $LIBS_total
 	    </div>
 	EOM
@@ -94,7 +94,7 @@ else
 	  <div class="p1 col-4">
 	    <div class="my1 h4 blue bold">Plugins</div>
 	    <div>
-	      <span class="$PLUGINS_color"><big><big>$PLUGINS_ratio</big></big>%</span><br>
+	      <span class="$PLUGINS_color bold"><big><big>$PLUGINS_ratio</big></big>%</span><br>
 	      Built $PLUGINS_built of $PLUGINS_total
 	    </div>
 	EOM
@@ -113,7 +113,7 @@ else
 	  <div class="p1 col-4">
 	    <div class="my1 h4 blue bold">Executables</div>
 	    <div>
-	      <span class="$BINS_color"><big><big>$BINS_ratio</big></big>%</span><br>
+	      <span class="$BINS_color bold"><big><big>$BINS_ratio</big></big>%</span><br>
 	      Built $BINS_built of $BINS_total
 	    </div>
 	EOM

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -287,10 +287,11 @@ check_yamllint()
 		>&2 cat <<< $YAMLLINT_OUTPUT
 
 		{
-			echo "<h4>Detected yamllint Errors</h4>"
-			echo '<code><pre class="term">'
-			echo -e $YAMLLINT_OUTPUT
-			echo '</pre></code>'
+			#echo "<h4>Detected yamllint Errors</h4>"
+			#echo '<code><pre class="term">'
+			#echo -e $YAMLLINT_OUTPUT
+			#echo '</pre></code>'
+			echo "Detected yamllint errors, see log."
 		} | buildkite-agent annotate --context yamllint --style error
 		exit $YAMLLINT_ERROR
 	fi

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -287,11 +287,10 @@ check_yamllint()
 		>&2 cat <<< $YAMLLINT_OUTPUT
 
 		{
-			#echo "<h4>Detected yamllint Errors</h4>"
-			#echo '<code><pre class="term">'
-			#echo -e $YAMLLINT_OUTPUT
-			#echo '</pre></code>'
-			echo "Detected yamllint errors, see log."
+			echo "#### Detected yamllint Errors"
+			echo '```terminal'
+			echo -e $YAMLLINT_OUTPUT
+			echo '```'
 		} | buildkite-agent annotate --context yamllint --style error
 		exit $YAMLLINT_ERROR
 	fi

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -315,4 +315,4 @@ echo "-> Running yamllint on configuration files"
 check_yamllint
 
 echo "-> Running 'make check'"
-gmake check
+gmake check YAMLLINT=0

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -42,7 +42,10 @@ if type -p gdiff >/dev/null; then
 	DIFF=gdiff
 fi
 
-MERGE_BASE=$($DIFF --old-line-format='' --new-line-format='' <(git rev-list --first-parent "HEAD") <(git rev-list --first-parent "origin/master") | head -1)
+MERGE_BASE=$($DIFF --old-line-format='' --new-line-format='' \
+             <(git rev-list --first-parent "HEAD") \
+             <(git rev-list --first-parent "origin/master") \
+             | head -1)
 
 error_exit () {
 	MSG="$@"

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -289,7 +289,7 @@ check_yamllint()
 		{
 			echo "#### Detected yamllint Errors"
 			echo '```terminal'
-			echo -e $YAMLLINT_OUTPUT
+			cat <<< $YAMLLINT_OUTPUT
 			echo '```'
 		} | buildkite-agent annotate --context yamllint --style error
 		exit $YAMLLINT_ERROR

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -278,6 +278,23 @@ check_gitlint ()
 	rm -f gitlint-*.txt
 }
 
+check_yamllint()
+{
+	YAMLLINT_ERROR=0
+	YAMLLINT_OUTPUT=$(yamllint -s -f colored cfg/config.yaml cfg/conf.d/) || YAMLLINT_ERROR=$?
+	if [ $YAMLLINT_ERROR -ne 0 ]; then
+		# Print error to log
+		>&2 cat <<< $YAMLLINT_OUTPUT
+
+		{
+			echo "<h4>Detected yamllint Errors</h4>"
+			echo '<code><pre class="term">'
+			echo -e $YAMLLINT_OUTPUT
+			echo '</pre></code>'
+		} | buildkite-agent annotate --context yamllint --style error
+		exit $YAMLLINT_ERROR
+	fi
+}
 
 ### Main Program
 
@@ -293,6 +310,8 @@ check_commit_authors
 echo "-> Running gitlint to check commit messages"
 check_gitlint
 
+echo "-> Running yamllint on configuration files"
+check_yamllint
+
 echo "-> Running 'make check'"
 gmake check
-

--- a/cfg/conf.d/bblogger.yaml
+++ b/cfg/conf.d/bblogger.yaml
@@ -31,7 +31,8 @@ fawkes/bblogreplay:
   # Non-blocking replay in blocked timing mode by default?
   non_blocking: false
 
-  # Grace period for differences in offset and elapsed time to still allow replay
+  # Grace period for differences in offset and elapsed time
+  # to still allow replay
   grace_period: 0.001
 
   qatest:

--- a/cfg/conf.d/bumblebee2.yaml
+++ b/cfg/conf.d/bumblebee2.yaml
@@ -35,7 +35,7 @@ bumblebee2:
     # averaging window size: 5x5..21x21, only for bm
     pre-filter-size: 15
 
-    # the output of pre-filtering is clipped by [- pre-filter-cap,pre-filter-cap]
+    # output of pre-filtering is clipped by [- pre-filter-cap, pre-filter-cap]
     pre-filter-cap: 15
 
     # *** correspondence using Sum of Absolute Difference (SAD)
@@ -60,7 +60,7 @@ bumblebee2:
 
     # disparity variation window
     speckle-window-size: 32
-    
+
     # acceptable range of variation in window
     speckle-range: 32
 
@@ -84,4 +84,3 @@ bumblebee2:
     # left-right disparity check. Set it to non-positive value to
     # disable the check, only sgbm
     sgbm-disp12-max-diff: 1
-

--- a/cfg/conf.d/clips-agent.yaml
+++ b/cfg/conf.d/clips-agent.yaml
@@ -43,7 +43,7 @@ clips-agent:
 
   # Directory where to look for CLIPS files
   clips-dirs: ["@BASEDIR@/src/clips-agents", "@BASEDIR@/testagent"]
-  
+
   # Agent name. On startup the clips-agent will try to resolve a file named
   # <agent name>.clp. It must be in the CLIPS path directories.
   agent: test

--- a/cfg/conf.d/clips-executive.yaml
+++ b/cfg/conf.d/clips-executive.yaml
@@ -73,15 +73,15 @@ clips-executive:
         # and blackboard-init.clp.
         stage-1:
           - name: pddl-parser
-          #- name: pddl-planner
-          #  feature-request: false
-          #  files: ["pddl-init.clp"]
-          #- name: navgraph
-          #- name: robmem-wait
-          #  feature-request: false
-          #  files: ["BATCH|robmem-wait-init.clp"]
-          #  wait-for: robmem-initialized
-          #- name: robot_memory
+          # - name: pddl-planner
+          #   feature-request: false
+          #   files: ["pddl-init.clp"]
+          # - name: navgraph
+          # - name: robmem-wait
+          #   feature-request: false
+          #   files: ["BATCH|robmem-wait-init.clp"]
+          #   wait-for: robmem-initialized
+          # - name: robot_memory
 
         # stage-2 is domain-independent CX initialization
         # It contains a set of fixed items loaded. Custom extensions may
@@ -113,10 +113,10 @@ clips-executive:
           - name: state-estimation
             file: test-scenario/state-estimation.clp
           - name: worldmodel
-            #files: [wm-robmem-sync.clp, test-scenario/worldmodel-facts.clp]
+            # files: [wm-robmem-sync.clp, test-scenario/worldmodel-facts.clp]
             files: [test-scenario/worldmodel-facts.clp]
-          #- name: coordination
-          #  file: coordination-mutex.clp
+          # - name: coordination
+          #   file: coordination-mutex.clp
           - name: goal-reasoner
             files:
               - test-scenario/goal-reasoner.clp
@@ -134,7 +134,7 @@ clips-executive:
             files:
               - skills-actions.clp
               - test-scenario/print-action.clp
-              #- lock-actions.clp
+              # - lock-actions.clp
           - name: execution-monitoring
             file: test-scenario/execution-monitoring.clp
 
@@ -147,48 +147,50 @@ clips-executive:
         say-cleanup: say{text="Cleaning up", wait=true}
 
       # Map domain predicate names to world model fact IDs
-      #wm-remap:
-        #facts:
-          # Map the prefix, i.e., replace the path by /domain/fact and
-          # keep the last element of the path.
-          # Example: /wm/foo -> domain predicate foo
-          # Arguments must be compatible (same names and accepted values).
-          # State as a list of world model fact IDs
-          #id-prefix:
-          #  - /wm/foo
-          #  - /wm/bar
-          # Full mapping from domain predicate name to world model fact
-          # ID path (without arguments).
-          # Example: said -> /wm/spoken
-          # Arguments must be compatible (same names and accepted values).
-          # State as map from predicate names to world model fact ID
-          # path.
-          #name-id:
-          #  said: /wm/spoken
-        #objects:
-          # Map the prefix, i.e., replace the path by /domain/fact and
-          # keep the last element of the path.
-          # Example: /wm/foo -> domain predicate foo
-          #id-prefix:
-          #  - /wm/sometype
-          #  - /wm/anothertype
-          # Full mapping from domain predicate name to world model fact
-          # ID path (without arguments).
-          # Example: objecttype -> /wm/differentobjects
-          # path.
-          #name-id:
-          #  objecttype: /wm/differentobjects
+      # wm-remap:
+      #   facts:
+      #     # Map the prefix, i.e., replace the path by /domain/fact and
+      #     # keep the last element of the path.
+      #     # Example: /wm/foo -> domain predicate foo
+      #     # Arguments must be compatible (same names and accepted values).
+      #     # State as a list of world model fact IDs
+      #     id-prefix:
+      #      - /wm/foo
+      #      - /wm/bar
+      #     # Full mapping from domain predicate name to world model fact
+      #     # ID path (without arguments).
+      #     # Example: said -> /wm/spoken
+      #     # Arguments must be compatible (same names and accepted values).
+      #     # State as map from predicate names to world model fact ID
+      #     # path.
+      #     name-id:
+      #      said: /wm/spoken
+      #   objects:
+      #     # Map the prefix, i.e., replace the path by /domain/fact and
+      #     # keep the last element of the path.
+      #     # Example: /wm/foo -> domain predicate foo
+      #     id-prefix:
+      #      - /wm/sometype
+      #      - /wm/anothertype
+      #     # Full mapping from domain predicate name to world model fact
+      #     # ID path (without arguments).
+      #     # Example: objecttype -> /wm/differentobjects
+      #     # path.
+      #     name-id:
+      #      objecttype: /wm/differentobjects
 
       # Interface _types_ mentioned in the following list will be pre-loaded,
-      # i.e., the fact templates will be created in stage2, before user-specified
-      # code is loaded. That avoid the necessity of splitting interface opening
-      # and processing in user code.
-      #blackboard-preload: ["Position3DInterface"]
+      # i.e., the fact templates will be created in stage2, before
+      # user-specified code is loaded. That avoid the necessity of splitting
+      # interface opening and processing in user code.
+      # blackboard-preload: ["Position3DInterface"]
 
       # Values in the parameters subtree will be added to the "/config" tree
       # in the world model facts. Everything up until and including /parameters/
       # in the configuration path is removed.
-      # Example: /clips-executive/specs/test/parameters/home-pos -> /config/home-pos
+
+      # Example: /clips-executive/specs/test/parameters/home-pos ->
+      # /config/home-pos
       parameters:
         coordination:
           mutex:
@@ -201,7 +203,9 @@ clips-executive:
       goal-reasoner: test-scenario-pddl/goal-reasoner.clp
       goal-expander: test-scenario-pddl/goal-expander-pddl.clp
       action-selection: test-scenario-pddl/action-selection.clp
-      action-execution: ["skills-actions.clp", "test-scenario-pddl/print-action.clp"]
+      action-execution:
+        - "skills-actions.clp"
+        - "test-scenario-pddl/print-action.clp"
       execution-monitoring: test-scenario-pddl/execution-monitoring.clp
       state-estimation: test-scenario-pddl/state-estimation.clp
 

--- a/cfg/conf.d/clips.yaml
+++ b/cfg/conf.d/clips.yaml
@@ -3,8 +3,8 @@
 ---
 doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/clips
 ---
-clips:
-  # Directory where to look for the CLIPS files of the plugin
-  # Leave empty to use default, which is the "clips" subdir
-  # in the source directory
-  #clips-dir: "..."
+# clips:
+#   # Directory where to look for the CLIPS files of the plugin
+#   # Leave empty to use default, which is the "clips" subdir
+#   # in the source directory
+#   # clips-dir: "..."

--- a/cfg/conf.d/colli.yaml
+++ b/cfg/conf.d/colli.yaml
@@ -1,15 +1,17 @@
 %YAML 1.2
 %TAG ! tag:fawkesrobotics.org,cfg/
-
+---
 plugins/colli:
 
-  # Frequency in Hz of how often calli is called (deprecated; this is defined by fawkes main loop)
+  # Frequency in Hz of how often calli is called (deprecated; this is defined by
+  # fawkes main loop)
   frequency: 10
 
   # The maximum robot increasement of laser readings
   max_robo_increase: 0.04
 
-  # If you want to visualize the data continuously and not just when colli receives a new target, set this to true
+  # If you want to visualize the data continuously and not just when colli
+  # receives a new target, set this to true
   visualize_idle: false
 
   # This disables/enales the (spam-) debug msgs
@@ -30,7 +32,8 @@ plugins/colli:
   # Default escaping behaviour (just enabled/disabled)
   escaping_enabled: true
 
-  # Default behaviour, deciding if colli should stop at target (not used in implementation atm though)
+  # Default behaviour, deciding if colli should stop at target (not used in
+  # implementation atm though)
   stop_at_target: true
 
   # Behaviour, deciding how/when colli should adjust orientation
@@ -41,24 +44,28 @@ plugins/colli:
   # The minimum rotation speed (in rad/s). Used for rotating at target
   min_rot: 0.1
 
-  # The minimum distance to target, such that colli decides to drive straight to target.
-  # This is the lowest threshold, anything below this and the colli won't move. This will also
-  # be used to check whether the colli has reached its target position.
+  # The minimum distance to target, such that colli decides to drive straight to
+  # target.  This is the lowest threshold, anything below this and the colli
+  # won't move. This will also be used to check whether the colli has reached
+  # its target position.
   min_drive_distance: 0.1
 
-  # The minimum distance to target in long distance, such that colli decides to drive straight to target.
+  # The minimum distance to target in long distance, such that colli decides to
+  # drive straight to target.
   min_long_dist_drive: 0.15
 
-  # The minimum distance to target in long distance, such that colli drives to a pre-position AND orients
-  # towards the target, so that the robot can approach the target with the front.
+  # The minimum distance to target in long distance, such that colli drives to a
+  # pre-position AND orients towards the target, so that the robot can approach
+  # the target with the front.
   min_long_dist_prepos: 2.1
 
-  # The minimum orientation difference, such that colli rotates when robot is at target position(in rad)
-  # No translation is executed at this point anymore.
+  # The minimum orientation difference, such that colli rotates when robot is at
+  # target position(in rad) No translation is executed at this point anymore.
   min_rot_distance: 0.1
 
-  # If the target is "far" away (>= min_drive_rot_distance), we approach a pre-position to
-  #  already adjust the orientation a little. This defines the distance to that pre-position.
+  # If the target is "far" away (>= min_drive_rot_distance), we approach a
+  # pre-position to already adjust the orientation a little. This defines the
+  # distance to that pre-position.
   pre_position_distance: 0.8
 
   interface:
@@ -70,8 +77,10 @@ plugins/colli:
     laser: Laser laser merged
     # ID of colli target interface
     colli: Colli target
-    # Maximum age (in seconds) of data for reading interfaces. If data is older than this, the colli_thread
-    #  assumes that there main_loop is delayed => abort movement
+
+    # Maximum age (in seconds) of data for reading interfaces. If data is older
+    # than this, the colli_thread assumes that there main_loop is delayed =>
+    # abort movement
     read_timeout: 0.5
 
   frame:
@@ -95,8 +104,8 @@ plugins/colli:
     cell_height: 5
 
   motor_instruct:
-    #set the used motor instruct. This sets the calculation for acc and dec.
-    #You can choose between linear or quadratic
+    # set the used motor instruct. This sets the calculation for acc and dec.
+    # You can choose between linear or quadratic
     mode: "linear"
 
     # Translation acceleration/deceleration
@@ -116,7 +125,9 @@ plugins/colli:
     threshold_velocity: 0.2
     # max velocity if emergency stop triggers
     max_vel: 0.2
-    # number of beams that are used to check for distance (beams in directions of robot)
+
+    # number of beams that are used to check for distance (beams in directions
+    # of robot)
     beams_used: 11
 
   drive_mode:
@@ -126,7 +137,8 @@ plugins/colli:
     # Default drive mode. It's an enum, see NavigatorInterface for details.
     default: "Forward"
 
-    # Default drive mode for escaping. You can choose between potential_field and basic
+    # Default drive mode for escaping. You can choose between potential_field
+    # and basic
     default_escape: "potential_field"
 
     normal:
@@ -139,16 +151,21 @@ plugins/colli:
       max_trans: 0.3
       max_rot: 0.8
 
-    # Modifies the values used to calculate when to start breaking to stop at the target
+    # Modifies the values used to calculate when to start breaking to stop at
+    # the target
     stopping_adjustment:
-      # Add this distance to the calculated distance required for stopping stop, given the current speed.
-      # Higher values mean "stop earlier". Might cause bocking if too high.
+
+      # Add this distance to the calculated distance required for stopping stop,
+      # given the current speed.  Higher values mean "stop earlier". Might cause
+      # bocking if too high.
       distance_addition: 0.0
-      # This value is multiplied with the expected deceleration per loop. Should relate to how
-      #  much the speed actually drops compared to what is desired. So use a value in [0..1], anything
-      #  higher will be cropped to 1.
-      # Lower values mean "breaking effect is delayed more" (or "only x% of deceleration is actually
-      #  noticable in 1 iteration"), so it will "stop earlier".
+
+      # This value is multiplied with the expected deceleration per loop. Should
+      # relate to how much the speed actually drops compared to what is
+      # desired. So use a value in [0..1], anything higher will be cropped to
+      # 1. Lower values mean "breaking effect is delayed more" (or "only x% of
+      # deceleration is actually noticable in 1 iteration"), so it will "stop
+      # earlier".
       deceleration_factor: 1.0
 
   roboshape:
@@ -184,7 +201,8 @@ plugins/colli:
 
 
   laser_occupancy_grid:
-    # This is the distance in which laser readings are ignored for putting a new obstacle into the grid
+    # This is the distance in which laser readings are ignored for putting a new
+    # obstacle into the grid
     distance_account: 0.1
 
     # Define if elipse obsticles shoudl be used with angular robots
@@ -192,19 +210,22 @@ plugins/colli:
 
     history:
       # the history vector size with number of saved elements
-      # Note: This is the initial size. If the history grows bigger, elements have to be appended
-      #  and this costs time. But to many elements result in page faults ;-)
+      # Note: This is the initial size. If the history grows bigger, elements
+      # have to be appended and this costs time. But to many elements result in
+      # page faults ;-)
       initial_size: 500
 
-      # the max time difference of the laser reading history for the search in seconds
+      # the max time difference of the laser reading history for the search in
+      # seconds
       max_length: 6.0
 
-      # the min time difference of the laser reading history for the search in seconds
+      # the min time difference of the laser reading history for the search in
+      # seconds
       min_length: 1.5
 
-      # this enables the compare between old and new laser readings.
-      # if this is enabled, the colli checks if new obstacles can see through old obstacles,
-      # if this is the case, the old obstacles are deleted
+      # this enables the compare between old and new laser readings. If this is
+      # enabled, the colli checks if new obstacles can see through old
+      # obstacles, if this is the case, the old obstacles are deleted
       delete_invisible_old_obstacles:
         enable: true
 
@@ -235,7 +256,8 @@ plugins/colli:
       # The more states the better the search, but the slower the algorithm
       max_states: 15000
 
-    # the line search is executed after a-star and searches for a obstacle free line
+    # the line search is executed after a-star and searches for a obstacle free
+    # lin
     line:
       # this are the maximum allowed costs on this line
       cost_max: 5

--- a/cfg/conf.d/dynamixel.yaml
+++ b/cfg/conf.d/dynamixel.yaml
@@ -29,11 +29,12 @@ dynamixel:
     # via blackboard; rad
     angle_margin: 0.1
 
-    # Echo fix used for faulty firmwares on RX28 which 
+    # Echo fix used for faulty firmwares on RX28 which
     # echo the given command even though ECHO is switched off
     enable_echo_fix: false
 
-    # temperature limit in degrees celsius - set for each servo found in the particular servo chain 
+    # temperature limit in degrees celsius - set for each servo found in the
+    # particular servo chain
     temperature_limit: 70
 
     # prevent alarm shutdown to turn into the direction of the torque
@@ -42,9 +43,6 @@ dynamixel:
 
     # normalized value of torque limit to measure an overload condition
     prevent_alarm_shutdown_threshold: 0.6
-
-    # temperature limit in celsius
-    temperature_limit: 70
 
     # connection stability used to handle connection drops to the servos
     enable_connection_stability: true
@@ -60,11 +58,13 @@ dynamixel:
     # or leave this field empty (servos: []) to discover all available servos
     servos: []
 
-    # Autorecover of servos which disable their torque (by setting torque limit to 0)
-    # after an alarm shutdown. One can set a servo to automatically recover from such a situation
-    # by setting autorecover_enabled.
-    # autorecover_flags is used to specify to recover only on certian errors. This can for example be 0x20 (32)
-    # to recover on overload shutdown. To recover on all errors set autorecover_flags to 127 (7 bits per error)
+    # Autorecover of servos which disable their torque (by setting torque limit
+    # to 0) after an alarm shutdown. One can set a servo to automatically
+    # recover from such a situation by setting autorecover_enabled.
+    # autorecover_flags is used to specify to recover only on certian
+    # errors. This can for example be 0x20 (32) to recover on overload
+    # shutdown. To recover on all errors set autorecover_flags to 127 (7 bits
+    # per error)
     autorecover_enabled: true
     autorecover_flags: 127
 

--- a/cfg/conf.d/eclipse-clp.yaml
+++ b/cfg/conf.d/eclipse-clp.yaml
@@ -4,9 +4,12 @@
 doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/eclipse-clp
 ---
 eclipse-clp:
-  agent: skillexec #name of the ECLiPSe module in which the agent is stored (needs to be placed in plugins/eclipse-clp/interpreter/)
-  
-  #Basedirectory of ECLiPSe
+
+  # name of the ECLiPSe module in which the agent is stored (needs to be placed
+  # in plugins/eclipse-clp/interpreter/)
+  agent: skillexec
+
+  # Base directory of ECLiPSe
   eclipse_dir: /usr/lib64/eclipse-clp-6.1-164-x86_64/
 
   # List of directories to search for included files and modules
@@ -16,13 +19,15 @@ eclipse-clp:
               "@BASEDIR@/src/agents/@AGENT@/"]
 
   gazebo:
-    allow-shutdown: True
+    allow-shutdown: true
     fawkes-path: "~/fawkes_clean/fawkes-athome/"
     simulation-shutdown-script: "bin/gazsim.bash -x kill"
 
   elevator:
-    use_graph: False
+    use_graph: false
+
   skillexec:
-    use_graph: False
+    use_graph: false
+
   indi_elevator:
-    use_graph: False
+    use_graph: false

--- a/cfg/conf.d/firevision.yaml
+++ b/cfg/conf.d/firevision.yaml
@@ -13,4 +13,3 @@ firevision:
       cam0:
         string: v4l2:firstcam:device=/dev/video0
         frame: !frame base_link
-

--- a/cfg/conf.d/gazsim.yaml
+++ b/cfg/conf.d/gazsim.yaml
@@ -5,10 +5,9 @@ doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/gazsim
 ---
 gazsim:
   world-name: "LLSF"
-  #default robot name
+  # default robot name
   robot-name: ""
 
-  
   topics:
     gps: "~/gazsim/gps/"
     laser: "~/hokuyo/link/laser/scan"
@@ -21,13 +20,13 @@ gazsim:
     message: "~/RobotinoSim/String/"
 
   laser:
-    max_range: 5.5 
+    max_range: 5.5
     interface-id: "Laser urg"
     frame-id: !frame base_laser
 
   webcam:
     # list of ids for all cameras to simulate
-    # for each id you need to add entries to the following fields 
+    # for each id you need to add entries to the following fields
     shm-image-ids: ["light_front", "gazsim_puck"]
     topic-suffixes:
       light_front: "/carologistics-robotino-3/webcam/link/webcam_sensor/image"
@@ -47,7 +46,7 @@ gazsim:
     gyro-delay: 0.2
     infrared-sensor-index: 8
 
-    motor:    
+    motor:
       # does the odometry change if the robotino drives against an obstacle?
       slippery-wheels-enabled: true
       slippery-wheels-threshold: 0.8
@@ -56,12 +55,12 @@ gazsim:
 
   comm:
     package-loss: 0.1
-    #all peers which need the comm plugin
+    # all peers which need the comm plugin
     # write down as follows:
     # adrresses:  ["address_1", "address_2", ...]
     # send-ports: [send_port_1, send_port_2, ...]
     # revc-ports: [recv_port_1, recv_port_2, ...]
-    addresses:  []
+    addresses: []
     send-ports: []
     recv-ports: []
   visualization:
@@ -69,9 +68,9 @@ gazsim:
     location-textures: "model://label/materials/textures"
     label-arrow-name: "label/arrowredup"
     localization:
-      #parent model::link to attach visuals on
+      # parent model::link to attach visuals on
       parent-name: "ground_plane::link"
-      update-rate: 5.0 #in Hz
+      update-rate: 5.0  # in Hz
       label-size: 0.3
       label-height: 0.9
 

--- a/cfg/conf.d/gtest.yaml
+++ b/cfg/conf.d/gtest.yaml
@@ -3,7 +3,8 @@
 ---
 doc-url: !url http://trac.fawkesrobotics.org/wiki
 ---
-# This config file specifies how the gtest tool executes unit tests contained in a plugin
+# This config file specifies how the gtest tool executes unit tests contained in
+# a plugin
 gtest:
   # Which plugins contains the Unit tests you want to execute?
   test-plugin: "robot_memory_test"
@@ -11,4 +12,3 @@ gtest:
   plugin-dependencies: "static-transforms,mongodb,robot-memory"
   # Configuration used for the test run (use config.yaml for default)
   config: "gazsim-configurations/default/robotino1.yaml"
-  

--- a/cfg/conf.d/imu.yaml
+++ b/cfg/conf.d/imu.yaml
@@ -14,13 +14,13 @@ hardware/imu:
     # blackboard as soon as it is available, otherwise only once per
     # loop during the sensor hook
     continuous: false
-    
+
     # Configuration is for CruizCore Gyro
     type: CruizCore-XG1010
 
     # Coordinate frame at which origin the IMU is positioned
     frame: !frame imu
-    
+
     # Device file
     device: /dev/ttyUSB0
 

--- a/cfg/conf.d/jaco.yaml
+++ b/cfg/conf.d/jaco.yaml
@@ -7,25 +7,28 @@ hardware/jaco:
   # What arm are we controlling (or what is our library to control the arm)?
   # Currently supported:
   #   libkindrv: use libkindrv to control a real arm
-  #   dummy: control a dummy arm. Not a real arm, but useful for rudimentary "simulation"
+  #   dummy: control a dummy arm. Not a real arm, but useful for rudimentary
+  #          "simulation"
   arm: libkindrv
 
-  # Should arm be automatically initialized after plugin loaded? This puts the arm into
-  #  READY position, only if the arm has just been turned on, which means we cannot
-  #  control it until it is initialized once.
-  #  Note: If arm was initialized once, plugin unloaded -> arm moved by joystick -> plugin loaded
-  #  => arm is still initialized!
+  # Should arm be automatically initialized after plugin loaded? This puts the
+  # arm into READY position, only if the arm has just been turned on, which
+  # means we cannot control it until it is initialized once.  Note: If arm was
+  # initialized once, plugin unloaded -> arm moved by joystick -> plugin loaded
+  # => arm is still initialized!
   auto_initialize: true
 
   # Should arm be automatically put in calibration mode after plugin loaded?
-  #  This should not be confused with auto_initialize. This puts arm into READY
-  #  no matter what state it is in. auto_initialize just makes sure if arm is initialized.
+  # This should not be confused with auto_initialize. This puts arm into READY
+  # no matter what state it is in. auto_initialize just makes sure if arm is
+  # initialized.
   auto_calibrate: false
 
   config:
-    # Do we have a dual_arm setup? This defines whether we work with a dual-arm or single-arm
-    # setup. Setting this to 'true' will fail on single-arm setups. 'false' should still work
-    # with dual-arm setups, although it might be random which arm is actually used on initialization,
+    # Do we have a dual_arm setup? This defines whether we work with a dual-arm
+    # or single-arm setup. Setting this to 'true' will fail on single-arm
+    # setups. 'false' should still work with dual-arm setups, although it might
+    # be random which arm is actually used on initialization,
     dual_arm: false
 
     single:
@@ -36,8 +39,9 @@ hardware/jaco:
       interface: JacoArm
 
     left:
-      # Name of left JacoArm. libkindrv should provide methods to see names of connected arms. Or you
-      # can use Kinova's JacoSoft to check and set a new name
+      # Name of left JacoArm. libkindrv should provide methods to see names of
+      # connected arms. Or you can use Kinova's JacoSoft to check and set a new
+      # name
       name: Jaco 1
 
       # JacoInterface ID string for left arm
@@ -70,7 +74,7 @@ hardware/jaco:
     manipname:
       # manipulator names when using a single arm
       single: fingertip
-      #manipulator names for l/r when using a dual-arm setup
+      # manipulator names for l/r when using a dual-arm setup
       dual_left: arm_left
       dual_right: arm_right
 
@@ -81,7 +85,9 @@ hardware/jaco:
       # plot the planned trajectory of all joints
       planned_joints: false
 
-      # plot the current position of manipulator, while trajectory is being executed.
+      # plot the current position of manipulator, while trajectory is being
+      # executed.
       current_manipulator: false
-      # plot the current position of joints, while trajectory is being executed.
+
+      # plot the current position of joints, while trajectory is being executed
       current_joints: false

--- a/cfg/conf.d/joystick.yaml
+++ b/cfg/conf.d/joystick.yaml
@@ -42,7 +42,7 @@ doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/joystick
     # jstest /dev/input/js0
     # (replace the device path with the device_file configured above)
     # Then move the axis you want to use and note and set its index here
-    axis_forward:  1
+    axis_forward: 1
     axis_sideward: 0
     axis_rotation: 3
 
@@ -53,7 +53,7 @@ doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/joystick
     # commands are executed. As soon as they are released the robot stops.
     # At least one of the two methods must be configured, or the robot
     # won't move at all.
-    
+
     # Deadman axis
     # Configure an axis and a threshold. For a negative threshold,
     # movement is allowed if the axis value is less than the given value.
@@ -117,9 +117,9 @@ doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/joystick
         max_vy: 1.0
         max_omega: 2.36
 
-  # This feature stops the robot from moving forward if an obstacle is
-  # detected up front.
-  # A laser must be present for this feature to work.
+    # This feature stops the robot from moving forward if an obstacle is
+    # detected up front.
+    # A laser must be present for this feature to work.
     collision_safety:
       # True to enable collision safety feature.
       enabled: true
@@ -131,7 +131,6 @@ doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/joystick
       # Given in degrees to the left and right from the front
       # i.e. 20 degrees will have an complete opening angle of 41 degrees
       angle: 20
-  
 
     # Interface ID for MotorInterface to send TransRotMessages to.
     motor_interface_id: Motor

--- a/cfg/conf.d/laser-cluster.yaml
+++ b/cfg/conf.d/laser-cluster.yaml
@@ -10,7 +10,7 @@ laser-cluster:
 
     # If this configuration is active and should be loaded
     active: true
-    
+
     # Automatically start, i.e. set enabled to true?
     auto-start: true
 
@@ -18,7 +18,8 @@ laser-cluster:
     input_cloud: urg-filtered
 
     # How to select the best cluster?
-    # min-angle: minimum angle between forward direction and direction to cluster
+    # min-angle: minimum angle between forward direction and direction to
+    #            cluster
     # min-dist: minimum distance from sensor to cluster centroid
     selection_mode: min-dist
 
@@ -35,18 +36,20 @@ laser-cluster:
 
     line_removal:
       enable: false
-  
+
       # Maximum number of iterations to perform for line segmentation
       segmentation_max_iterations: 250
 
       # Segmentation distance threshold; m
       segmentation_distance_threshold: 0.1
 
-      # Minimum size of fraction of points that must be inliers to consider a table; 0.0..1.0
+      # Minimum size of fraction of points that must be inliers
+      # to consider a table; 0.0..1.0
       segmentation_min_inliers: 30
 
       # Maximum distance between samples drawn from the cloud
-      # This distance is important for the separation of lines if they are close.
+      # This distance is important for the separation of lines if they are
+      # close.
       segmentation_sample_max_dist: 0.08
 
       # Minimum length of line to remove it
@@ -64,10 +67,10 @@ laser-cluster:
 
     bounding-box:
       # not that these values are in the sensor frame!
-      min_x:  0.02
-      max_x:  0.8
+      min_x: 0.02
+      max_x: 0.8
       min_y: -0.7
-      max_y:  0.7
+      max_y: 0.7
 
     # transpose the x-position of the detected cluster by the given offset
     # Note that this is in the result frame

--- a/cfg/conf.d/laser-filter.yaml
+++ b/cfg/conf.d/laser-filter.yaml
@@ -7,7 +7,7 @@ plugins/laser-filter:
   tim5xx-min-sector:
 
     # URG input interface
-    #in/urg: Laser360Interface::Laser urg
+    # in/urg: Laser360Interface::Laser urg
     in/sick-tim55x: Laser1080Interface::Laser tim55x-usb
 
     # URG filtered output interface
@@ -15,7 +15,8 @@ plugins/laser-filter:
 
     filters:
       1-min:
-        # Threshold for minimum value to get rid of erroneous beams on most black surfaces
+        # Threshold for minimum value to get rid of erroneous beams on most
+        # black surfaces
         type: min_circle
 
         # Radius of minimum length; m

--- a/cfg/conf.d/laser-lines.yaml
+++ b/cfg/conf.d/laser-lines.yaml
@@ -33,7 +33,7 @@ laser-lines:
   # must at least remain after clustering of the original line.
   line_cluster_tolerance: 0.2
   line_cluster_quota: 0.1
-  
+
   # Minimum and maximum length of line to consider it. Ignored if less
   # than zero.
   line_min_length: 0.8
@@ -43,7 +43,7 @@ laser-lines:
   # the reference frame origin to consider it. Ignored if less than zero.
   line_min_dist: 0.1
   line_max_dist: -1
-  
+
   # The frame in which the result should be published; frame
   result_frame: !frame base_link
 
@@ -51,8 +51,8 @@ laser-lines:
 
   # input laser cloud
   input_cloud: lase_edl-360
-  #input_cloud: Line-Sector
-  
+  # input_cloud: Line-Sector
+
   # average the laser lines
   moving_avg_enabled: true
   # The size (number of elements) of the moving average window

--- a/cfg/conf.d/laser.yaml
+++ b/cfg/conf.d/laser.yaml
@@ -16,10 +16,10 @@ hardware/laser:
     # Device file
     device: /dev/ttyACM0
 
-    # Date back the data timestamp by the time it takes to acquire a single
-    # scan times the given factor. A factor of 1.0 will thus subtract one
-    # scan time from the time after completing the scan, defaults to 0.0 (no offset)
-    #time_offset_scan_time_factor: 0.0
+    # Date back the data timestamp by the time it takes to acquire a single scan
+    # times the given factor. A factor of 1.0 will thus subtract one scan time
+    # from the time after completing the scan, defaults to 0.0 (no offset)
+    # time_offset_scan_time_factor: 0.0
 
     # Date back time by a fixed time in seconds, defaults to 0.0 (no offset).
     # This setting is added in addition to time_offset_scan_time_factor.
@@ -30,7 +30,7 @@ hardware/laser:
     # Enable this configuration?
     active: false
 
-    # Configuration is for Hokuyo URG laser range finder using the Gearbox library
+    # Hokuyo URG laser range finder using the Gearbox library
     type: urg_gbx
 
     # Device file
@@ -59,7 +59,8 @@ hardware/laser:
     # Store default settings in flash?
     set_default: false
 
-    # Canonical resolution, if set overrides rotation_freq and angle_step; one of low (1 deg, 20 Hz) or high (0/5 deg, 15 Hz)
+    # Canonical resolution, if set overrides rotation_freq and angle_step; one
+    # of low (1 deg, 20 Hz) or high (0/5 deg, 15 Hz)
     canonical_resolution: high
 
     # Maximum rotation frequency; Hz
@@ -101,7 +102,8 @@ hardware/laser:
     # Rotation of the laser towards front; degree
     mount_rotation: 180
 
-    # If true, the fflaser_calibrate tool must be used to gain information about dead spots, which are then extracted with a filter
+    # If true, the fflaser_calibrate tool must be used to gain information about
+    # dead spots, which are then extracted with a filter
     use_dead_spots_filter: false
 
   tim55x-usb:
@@ -112,7 +114,7 @@ hardware/laser:
     type: TiM55x-USB
 
     # Device file
-    #serial: 14200190
+    # serial: 14200190
 
     # Frame ID
     frame: !frame base_laser
@@ -120,7 +122,7 @@ hardware/laser:
     # Offset added to measurement timestamp in interface. Can be used to
     # account for latencies.
     # time_offset: -0.001
-    
+
   tim55x-ethernet:
     # Enable this configuration?
     active: false

--- a/cfg/conf.d/meta_plugins.yaml
+++ b/cfg/conf.d/meta_plugins.yaml
@@ -7,4 +7,3 @@ fawkes/meta_plugins:
 
   # Meta plugin with useful base plugins for the Robotino
   robotino_default: robotino,joystick,robotino-joystick,webview
-

--- a/cfg/conf.d/metrics.yaml
+++ b/cfg/conf.d/metrics.yaml
@@ -4,9 +4,8 @@
 doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/metrics
 ---
 metrics:
-
   internal:
-    # The metrics_requests defines the histogram configuration for the processing
-    # times for metrics retrieval. Values are in seconds.
+    # The metrics_requests defines the histogram configuration for the
+    # processing times for metrics retrieval. Values are in seconds.
     metrics_requests:
       buckets: [0.005, 0.05, 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 5.0]

--- a/cfg/conf.d/mongodb.yaml
+++ b/cfg/conf.d/mongodb.yaml
@@ -47,7 +47,7 @@ plugins/mongodb:
       name: robot-memory-distributed
       hosts:
         - localhost:27022
-      
+
   # The following defines the mongod instances you want
   # the mongodb plugin to run
   instances:
@@ -60,11 +60,11 @@ plugins/mongodb:
       # The following arguments must not be added, they are either configured
       # through other config values, or they interfere with our rs handling.
       # --port, --dbpath, --fork, --logappend, --logpath, --replSet,
-      #--oplogSize, --master, --slave, --source, --only
+      # --oplogSize, --master, --slave, --source, --only
       # You may even reference environment variables in this string, e.g.,
       # $MY_VARIABLE. Use with caution. See "man wordexp" on specifics.
       # Sub-commands have been *disabled*.
-      #args: --bind_ip 0.0.0.0 -vvvvv
+      # args: --bind_ip 0.0.0.0 -vvvvv
       data-path: /tmp/mongodb-local
       log:
         path: /tmp/mongodb-local.log
@@ -74,12 +74,12 @@ plugins/mongodb:
       enabled: false
       termination-grace-period: 15
       clear-data-on-termination: true
-      #port: 27021
+      # port: 27021
       port: 27022
-      #data-path: /tmp/mongodb-rs0
+      # data-path: /tmp/mongodb-rs0
       data-path: /tmp/mongodb-rs0-2
       log:
-        #path: /tmp/mongodb-rs0.log
+        # path: /tmp/mongodb-rs0.log
         path: /tmp/mongodb-rs0-2.log
         append: true
       replica-set: rs0

--- a/cfg/conf.d/mongodb_log.yaml
+++ b/cfg/conf.d/mongodb_log.yaml
@@ -22,7 +22,6 @@ plugins/mongodb-log:
   # in time to a single document.
   enable-transforms: true
 
-  
   pointclouds:
     # GridFS chunk size for point clouds, 2 MB
     chunk-size: 2097152
@@ -37,7 +36,7 @@ plugins/mongodb-log:
     # a longer per-write time, it avoids the problem that there are
     # sometimes long flushing delays
     flush-after-write: true
-    
+
     # Interval in which to store point clouds; sec
     storage-interval: 0.5
 
@@ -61,12 +60,10 @@ plugins/mongodb-log:
     # logging, the latter causes logging of everything in the blackboard
     includes: ["*"]
     excludes: []
- 
 
   transforms:
     collection: tf
-    
+
     # Interval to store at a time, if 0 copy everything currently held by
     # transformer; sec
     storage-interval: 2.0
-

--- a/cfg/conf.d/nao.yaml
+++ b/cfg/conf.d/nao.yaml
@@ -4,6 +4,6 @@
 doc-url: !url http://trac.fawkesrobotics.org/wiki/Platforms/Nao
 ---
 hardware/nao:
-  # If true, triple long click on chest button causes shutdown. This
-  # requires the SetUID bit to be set on /sbin/poweroff (or whatever it links to).
+  # If true, triple long click on chest button causes shutdown. This requires
+  # the SetUID bit to be set on /sbin/poweroff (or whatever it links to).
   chestbut_triple_long_click_shutdown: true

--- a/cfg/conf.d/navgraph-generator.yaml
+++ b/cfg/conf.d/navgraph-generator.yaml
@@ -8,7 +8,7 @@ navgraph-generator:
   map:
     # Line segmentation uses 2 * map-resolution for max inter-sample
     # distance as well as max support distance.
-    
+
     # Maximum number of iterations to perform for line segmentation
     line_segmentation_max_iterations: 250
 
@@ -26,7 +26,7 @@ navgraph-generator:
     # must at least remain after clustering of the original line.
     line_cluster_tolerance: 0.2
     line_cluster_quota: 0.1
-  
+
     # Minimum and maximum length of line to consider it. Ignored if less
     # than zero.
     # Note: we use the cell centers for line detection. That means
@@ -51,7 +51,7 @@ navgraph-generator:
 
 
   # Save a generated navgraph automatically to disk.
-  
+
   # This can be enabled, e.g., for later debugging or during automated
   # experiments.
   save-to-file:

--- a/cfg/conf.d/navgraph.yaml
+++ b/cfg/conf.d/navgraph.yaml
@@ -28,9 +28,10 @@ navgraph:
   # to switch.
   replan_cost_factor: 1.5
 
-  # Update the visualization at this interval. This will trigger a compuation
-  # of all constraints and if any change occurs the graph will be published
-  # again. This is done whether the robot is currently driving or standing still.
+  # Update the visualization at this interval. This will trigger a compuation of
+  # all constraints and if any change occurs the graph will be published
+  # again. This is done whether the robot is currently driving or standing
+  # still.
   visualization_interval: 0.5
 
   # Time to keep moving after the target tolerance has been reached; sec
@@ -111,4 +112,3 @@ navgraph:
   # Publishing of usable data structures to ROS
   ros-publishing:
     enable: true
-

--- a/cfg/conf.d/network.yaml
+++ b/cfg/conf.d/network.yaml
@@ -12,11 +12,11 @@ network:
   # for connections from the local host only
   ipv4:
     enable: true
-    #listen: !ipv4 127.0.0.1
+    # listen: !ipv4 127.0.0.1
 
   ipv6:
     enable: true
-    #listen: !ipv6 "::1"
+    # listen: !ipv6 "::1"
 
   # Fawkes protocol specific settings
   fawkes:
@@ -26,4 +26,3 @@ network:
     # Name for Fawkes service, announced via Avahi,
     # %h is replaced by short hostname
     service_name: "Fawkes on %h"
-

--- a/cfg/conf.d/openprs.yaml
+++ b/cfg/conf.d/openprs.yaml
@@ -20,8 +20,8 @@ openprs:
     # Hostname where the message passer can be reached. Warning,
     # OpenPRS is quite picky about the hostname. Set this only
     # if you run mp-oprs yourself on a _remote_ host.
-    #hostname: some.remote-host.com
-    
+    # hostname: some.remote-host.com
+
     # The TCP port that mp-oprs listens on for connections.
     # If mp-oprs is started by Fawkes it will be instructed to
     # listen on that port. If disabled, this is where we expect
@@ -51,7 +51,7 @@ openprs:
     # Hostname where the oprs-server can be reached. Warning,
     # OpenPRS is quite picky about the hostname. Set this only
     # if you run oprs-server yourself on a _remote_ host.
-    #hostname: some.remote-host.com
+    # hostname: some.remote-host.com
 
     # The TCP port that oprs-server listens on for connections.
     # If oprs-server is started by Fawkes it will be instructed to
@@ -84,4 +84,3 @@ openprs:
     # multiple robot instances for simulation on a single machine.
     # The timeout is given in seconds.
     start-timeout: 30.0
-

--- a/cfg/conf.d/pantilt.yaml
+++ b/cfg/conf.d/pantilt.yaml
@@ -58,9 +58,11 @@ doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/pantilt
     # Maximum tilt for RX28 PTU
     tilt_max: 1.6
 
-    # Tolerance between desired and actual pan value to consider RX28 PTU motion finished; rad
+    # Tolerance between desired and actual pan value to consider RX28 PTU motion
+    # finished; rad
     pan_margin: 0.1
-    # Tolerance between desired and actual tilt value to consider RX28 PTU motion finished; rad
+    # Tolerance between desired and actual tilt value to consider RX28 PTU
+    # motion finished; rad
     tilt_margin: 0.1
 
     # Frame ID base string;

--- a/cfg/conf.d/pcl.yaml
+++ b/cfg/conf.d/pcl.yaml
@@ -7,4 +7,3 @@ pcl:
 
   # Set to true to make PCL quiet and remove all direct messages by PCL.
   shutup: false
-

--- a/cfg/conf.d/pcl_db.yaml
+++ b/cfg/conf.d/pcl_db.yaml
@@ -4,18 +4,18 @@
 doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/tabletop-objects
 ---
 perception/pcl-db:
-  # mongodb-log database from which to read data 
+  # mongodb-log database from which to read data
   database-name: pcl-db
 
   # Maximum age of point clouds restored from database; sec
   pcl-age-tolerance: 5.0
 
   # Transform range to restore from database. Must be a list of two elements.
-  # From the time instructed via the blackboard the values are added to determine
-  # the start and end times of the range; sec
-  # Note that if you use the specialized transform logger of mongodb-log you
-  # should set the values to minus and plus double the storage interval, e.g.
-  # if the storage interval is 5 sec, set the range to [-10, 10].
+  # From the time instructed via the blackboard the values are added to
+  # determine the start and end times of the range; sec Note that if you use the
+  # specialized transform logger of mongodb-log you should set the values to
+  # minus and plus double the storage interval, e.g.  if the storage interval is
+  # 5 sec, set the range to [-10, 10].
   transform-range: [-4.0, 4.0]
 
 perception/pcl-db-merge:
@@ -40,7 +40,7 @@ perception/pcl-db-merge:
   passthrough-filter:
     axis: z
     limits: [0.5, 1.2]
-  
+
   # Voxel grid leaf size for downsampling; m
   downsample-leaf-size: 0.01
 
@@ -61,9 +61,9 @@ perception/pcl-db-merge:
     # The three convergence/abortion criteria
     # Maximum number of iterations of ICP alignment
     max-iterations: 200
-    # Transformation epsilon criterion to assume alignment convergence 
+    # Transformation epsilon criterion to assume alignment convergence
     transformation-epsilon: 1e-7
-    # Euclidean fitness epsilon criterion to assume alignment convergence 
+    # Euclidean fitness epsilon criterion to assume alignment convergence
     euclidean-fitness-epsilon: 1e7
 
 
@@ -89,4 +89,3 @@ perception/pcl-db-retrieve:
 
 perception/pcl-db-roscomm:
   store-pcl-id: pcl-db-store
-

--- a/cfg/conf.d/pddl-planner.yaml
+++ b/cfg/conf.d/pddl-planner.yaml
@@ -11,14 +11,18 @@ plugins/pddl-planner:
 
   # Domain and problem description and location
   # Folder path needs a trailing /
-  description-folder: "@BASEDIR@/src/plugins/clips-executive/clips/test-scenario-pddl/"
+  description-folder: >
+    "@BASEDIR@/src/plugins/clips-executive/clips/test-scenario-pddl/"
   domain-description: domain.pddl
   problem-description: problem.pddl
   # File for intermediate results from planners
   result-file: results.txt
 
   # optional search options for fd planner
-  fd-search-opts: --heuristic "hff=ff()" --heuristic "hcea=cea()" --search "lazy_greedy([hff, hcea], preferred=[hff, hcea])"
+  fd-search-opts: >
+    --heuristic "hff=ff()"
+    --heuristic "hcea=cea()"
+    --search "lazy_greedy([hff, hcea], preferred=[hff, hcea])"
 
   # mongodb collection for robot-memory
   collection: robmem.pddl-plan

--- a/cfg/conf.d/pddl-robot-memory.yaml
+++ b/cfg/conf.d/pddl-robot-memory.yaml
@@ -4,16 +4,19 @@
 doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/pddl-robot-memory
 ---
 plugins/pddl-robot-memory:
-
   # Which collection contains the worldmodel
   collection: "robmem.clipswm"
+
   # Where is the problem file to use as teplate (in src/agents)
-  input-problem-description: clips-executive/test-scenario-pddl/problem-template.pddl
+  input-problem-description: >
+    clips-executive/test-scenario-pddl/problem-template.pddl
+
   # Where to put the generated problem file (in src/agents)
-  output-problem-description: clips-executive/test-scenario-pddl/problem.pddl
+  output-problem-description: >
+    clips-executive/test-scenario-pddl/problem.pddl
 
   # Interface used to start generation with message and show when its final
   interface-name: "pddl-gen"
 
-  #do you want to generate the pddl when the plugin is initialized?
+  # do you want to generate the pddl when the plugin is initialized?
   generate-on-init: false

--- a/cfg/conf.d/plexil.yaml
+++ b/cfg/conf.d/plexil.yaml
@@ -13,47 +13,47 @@ plexil:
 
       enable: true
       markers:
-        #- :Node:transition
-        #- :Node:outcome
-        #- :Node:clock
-        #- :Node:deactivatePair
-        #- :Node:activatePair
-        #- :Node:times
-        #- :Node:getDestState
-        #- :Node:createCommand
-        #- :Node:findVariable
-        #- :Node:createDeclaredVars
-        #- :Node:getVarsFromInterface
-        #- :Node
+        # - :Node:transition
+        # - :Node:outcome
+        # - :Node:clock
+        # - :Node:deactivatePair
+        # - :Node:activatePair
+        # - :Node:times
+        # - :Node:getDestState
+        # - :Node:createCommand
+        # - :Node:findVariable
+        # - :Node:createDeclaredVars
+        # - :Node:getVarsFromInterface
+        # - :Node
 
-        #- :AdapterFactory
-        #- :DynamicLoader
-        #- :ExecApplication
-        #- :ExecListenerFactory
-        #- :ExecListenerFilterFactory
-        #- :InterfaceManager
-        #- :InterfaceAdapter
-        #- :LuvListener
-        #- :UdpAdapter
+        # - :AdapterFactory
+        # - :DynamicLoader
+        # - :ExecApplication
+        # - :ExecListenerFactory
+        # - :ExecListenerFilterFactory
+        # - :InterfaceManager
+        # - :InterfaceAdapter
+        # - :LuvListener
+        # - :UdpAdapter
         - :ProtobufCommAdapter
 
-        #- :ExpressionFactory:registerFactory
-        #- :Expression
-        #- :IdTable
-        #- :ConstRealVariable
-        #- :RealVariable
-        #- :BinaryExpression
-        #- :Test
-        #- :StateCache
-        #- :InternalCondition
+        # - :ExpressionFactory:registerFactory
+        # - :Expression
+        # - :IdTable
+        # - :ConstRealVariable
+        # - :RealVariable
+        # - :BinaryExpression
+        # - :Test
+        # - :StateCache
+        # - :InternalCondition
 
-        #- :PlexilExec
-        #- :PlexilExec:planVerbose
-        #- :PlexilExec:step
-        #- :PlexilExec:printPlan
-        #- :PlexilExec:cycle
-        #- :PlexilExec:handleConditionsChanged
-        #- :PlexilExec:addToResourceContention
+        # - :PlexilExec
+        # - :PlexilExec:planVerbose
+        # - :PlexilExec:step
+        # - :PlexilExec:printPlan
+        # - :PlexilExec:cycle
+        # - :PlexilExec:handleConditionsChanged
+        # - :PlexilExec:addToResourceContention
 
 
     # Adpater configuration
@@ -90,7 +90,8 @@ plexil:
     #   - text (optional): added to the text section of the tag
     #   - attr: attributes added to the XML tag.
     # verbatim-xml:
-    #   Partial XML document which will be inserted as children in the adapter tag.
+    #   Partial XML document which will be inserted as children in the adapter
+    #   tag.
     adapters:
       # Do not use Utility, use FawkesLogging instead!
       # Do not use OSNativeTime, use FawkesTime instead!
@@ -100,9 +101,9 @@ plexil:
       - type: FawkesTimeAdapter
       - type: FawkesLoggingAdapter
       - type: BehaviorEngineAdapter
-      #- type: ProtobufCommAdapter
-      #  attr:
-      #    protos: "@BASEDIR@/src/plugins/plexil/specs/test/msgs"
+      # - type: ProtobufCommAdapter
+      #   attr:
+      #     protos: "@BASEDIR@/src/plugins/plexil/specs/test/msgs"
       - type: GlobalState
         verbatim-args:
           - tag: DefaultLookupAdapter
@@ -119,8 +120,10 @@ plexil:
       #       <Parameter type="bool" bytes="1" desc="send ack flag"/>
       #       <Parameter type="int" bytes="4" desc="num_widgets"/>
       #       <Parameter type="float" bytes="4" desc="arg4"/>
-      #       <Parameter type="int-array" elements="3" bytes="2" desc="16 bit ints"/>
-      #       <Parameter type="float-array" elements="3" bytes="4" desc="32 bit floats"/>
+      #       <Parameter type="int-array" elements="3" bytes="2"
+      #                  desc="16 bit ints"/>
+      #       <Parameter type="float-array" elements="3" bytes="4"
+      #                  desc="32 bit floats"/>
       #       <Parameter type="bool-array" elements="3" bytes="1"/>
       #       <Parameter type="string-array" elements="3" bytes="3"/>
       #     </Message>
@@ -130,10 +133,12 @@ plexil:
       #     <Message name="quit_msg" local_port="8387" peer_port="8387">
       #       <Parameter type="string" bytes="4"/>
       #     </Message>
+      # yamllint enable-rule line-length
 
     # A Listener is an object that reports on node state transitions
     # in the plan, and other execution events.
-    # cf. http://plexil.sourceforge.net/wiki/index.php/Interface_Configuration_File
+    # cf.
+    # http://plexil.sourceforge.net/wiki/index.php/Interface_Configuration_File
     # The configuration supports the same structure as above for adapters.
     # Cf. there for possible values. Some examples are given below.
     listeners:
@@ -143,7 +148,8 @@ plexil:
           Port: 49100
           HostName: 127.0.0.1
           Blocking: false
-    #   # The PlanDebugListener outputs as "Node:clock", make sure to enable it in Debug.cfg
+    #   # The PlanDebugListener outputs as "Node:clock", make sure to enable it
+    #   # in Debug.cfg
     #   - type: PlanDebugListener
 
     # The Behavior Engine adapter provides a generic skill_call, which can
@@ -153,12 +159,12 @@ plexil:
     #
     # However, it may be desirable to have more descriptive names. This is
     # possible with the following configuration. Then, the adapter will register
-    # itself for commands with each of the given names and perform the appropriate
-    # mapping.
+    # itself for commands with each of the given names and perform the
+    # appropriate mapping.
     skills:
       # Allows for a declaration as say(String text)
-      # Note that the order of the arguments is important and must match the order
-      # of the arguments in the Plexil declaration!
+      # Note that the order of the arguments is important and must match the
+      # order of the arguments in the Plexil declaration!
       - name: say
         args:
           - type: String
@@ -183,7 +189,7 @@ plexil:
       plx: plan.plx
 
       # Extra lib path to search for (Plexil) libraries
-      #lib-path: ["@BASEDIR@/src/plexil/specs/common-libs"]
+      # lib-path: ["@BASEDIR@/src/plexil/specs/common-libs"]
 
       compilation:
         enable: true
@@ -192,6 +198,7 @@ plexil:
         # compile if PLX does exist or PLE has been modified after PLX.
         force: false
 
+    # yamllint disable rule:comments-indentation
     # Global states are variables that can be accessed using a Lookup.
     # They allow to share information across libraries, can reduce the
     # number of parameteres passed around, and enables waiting for
@@ -201,6 +208,7 @@ plexil:
     # created on the first set operation. However, you can still declare
     # them here to enforce a specific type (especially useful when
     # changing the type of a global).
-    #global-states:
+    # global-states:
     #  - name: team_name
     #    type: String
+    # yamllint enable rule:comments-indentation

--- a/cfg/conf.d/realsense.yaml
+++ b/cfg/conf.d/realsense.yaml
@@ -4,7 +4,7 @@
 doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/realsense
 ---
 realsense:
-  # Frame ID of the PointCloud 
+  # Frame ID of the PointCloud
   frame_id: "cam_conveyor"
 
   # ID of the PointCloud

--- a/cfg/conf.d/robot-memory.yaml
+++ b/cfg/conf.d/robot-memory.yaml
@@ -25,6 +25,6 @@ plugins/robot-memory:
       priority: 10
       caching-time: 0.3
     transform:
-      collections: ['robmem.blackboard','robmem.transform','robmem.test']
+      collections: ['robmem.blackboard', 'robmem.transform', 'robmem.test']
       priority: -10
       caching-time: 0.3

--- a/cfg/conf.d/robot_state_publisher.yaml
+++ b/cfg/conf.d/robot_state_publisher.yaml
@@ -2,11 +2,10 @@
 %TAG ! tag:fawkesrobotics.org,cfg/
 ---
 robot_state_publisher:
- # path to URDF description of the robot
- # if the path starts with '/', it is absolute
- # otherwise, relative to RESDIR/urdf/
- urdf_file: "caesar.urdf"
- 
- # publish transforms to the future
- postdate_to_future: 0.5
+  # path to URDF description of the robot
+  # if the path starts with '/', it is absolute
+  # otherwise, relative to RESDIR/urdf/
+  urdf_file: "caesar.urdf"
 
+  # publish transforms to the future
+  postdate_to_future: 0.5

--- a/cfg/conf.d/robotino.yaml
+++ b/cfg/conf.d/robotino.yaml
@@ -21,7 +21,8 @@ hardware/robotino:
   # without waiting between receive calls
   cycle-time: 5
 
-  # Time threshold after all motor velocities are set to zero if no new messages arrived inbetween
+  # Time threshold after all motor velocities are set to zero if no new messages
+  # arrived inbetween
   deadman_time_threshold: 0.5
 
   openrobotino:
@@ -79,7 +80,7 @@ hardware/robotino:
     acceleration-limits: [-11500, 11500]
 
     rpm-max: 3000
-  
+
   drive:
     layout:
       # Distance from Robotino center to wheel center in meters
@@ -106,14 +107,14 @@ hardware/robotino:
     estop_enabled: true
 
   gyro:
-    # Enable Gyro publishing? This creates an IMUInterface and publishes
-    # the gyro data if available via OpenRobotino. If enabled and the gyro
-    # is not available, properly writes "-1 invalid indicator" (cf. IMUInterface)
-    # If disabled, no interface will be opened and written. Recommended if you
-    # intend to use the imu plugin for gyro access
-    # If you enable this, you should also set the odometry mode to copy
+    # Enable Gyro publishing? This creates an IMUInterface and publishes the
+    # gyro data if available via OpenRobotino. If enabled and the gyro is not
+    # available, properly writes "-1 invalid indicator" (cf. IMUInterface) If
+    # disabled, no interface will be opened and written. Recommended if you
+    # intend to use the imu plugin for gyro access If you enable this, you
+    # should also set the odometry mode to copy
     enable: true
-    
+
     # Gyro coordinate frame
     frame: !frame gyro
 
@@ -127,7 +128,7 @@ hardware/robotino:
     # robotino plugin and instead use the imu plugin with the gyro connected
     # directly to the Fawkes machine.
     mode: calc
-    #mode: copy
+    # mode: copy
 
     # Odom TF offset. This time is added to the current time when the
     # odometry <- base_link TF is published
@@ -165,5 +166,5 @@ hardware/robotino:
     # application below the set-point when the over current flag had
     # been set
     # Currently not implemented
-    #current-max: 1
-    #current-max-time: 400
+    # current-max: 1
+    # current-max-time: 400

--- a/cfg/conf.d/roomba.yaml
+++ b/cfg/conf.d/roomba.yaml
@@ -20,7 +20,8 @@ hardware/roomba:
   # older RoboDynamics ones are mitsumi (currently untested).
   bttype: firefly
 
-  # If RooTooth is auto-detected, save bluetooth address to config for faster connections
+  # If RooTooth is auto-detected, save bluetooth address
+  # to config for faster connections
   btsave: true
 
   # Try to enable fast mode on startup. Startup takes longer. Disable if
@@ -32,7 +33,8 @@ hardware/roomba:
   # can be disabled for serial connection for slightly better performance.
   query_mode: true
 
-  # Play fanfare when connection has been established. Disable when testing late at night...
+  # Play fanfare when connection has been established.
+  # Disable when testing late at night...
   play_fanfare: true
 
   joystick:
@@ -63,4 +65,3 @@ hardware/roomba:
     max_radius: 1500
     # Maximum linear velocity; mm/sec
     max_velocity: 500
-

--- a/cfg/conf.d/ros-robot-description.yaml
+++ b/cfg/conf.d/ros-robot-description.yaml
@@ -2,11 +2,10 @@
 %TAG ! tag:fawkesrobotics.org,cfg/
 ---
 ros/robot-description:
- # path to URDF description of the robot
- # if the path starts with '/', it is absolute
- # otherwise, relative to RESDIR/urdf/
- urdf_file: "/home/thofmann/athome-fawkes/res/urdf/caesar.urdf"
- 
- # publish the robot description under this ROS param name
- ros_robot_description: "/robot_description"
+  # path to URDF description of the robot
+  # if the path starts with '/', it is absolute
+  # otherwise, relative to RESDIR/urdf/
+  urdf_file: "/home/thofmann/athome-fawkes/res/urdf/caesar.urdf"
 
+  # publish the robot description under this ROS param name
+  ros_robot_description: "/robot_description"

--- a/cfg/conf.d/ros.yaml
+++ b/cfg/conf.d/ros.yaml
@@ -36,7 +36,8 @@ ros:
 
   pcl:
     # The time interval which is used to search for new pointclouds in ROS.
-    # This is the maximum time until a pointcloud from ROS is visible and usable in FAWKES
+    # This is the maximum time until a pointcloud from ROS is visible and usable
+    # in Fawkes.
     ros-search-interval: 2.
 
   tf:

--- a/cfg/conf.d/skiller.yaml
+++ b/cfg/conf.d/skiller.yaml
@@ -13,7 +13,7 @@ skiller:
 
   # Feature-specific configuration
   features:
-    
+
     navgraph:
       # Enable access to navgraph, adds a dependency on the navgraph
       # plugin such that a valid graph must be loaded first

--- a/cfg/conf.d/tabletop_objects.yaml
+++ b/cfg/conf.d/tabletop_objects.yaml
@@ -22,20 +22,23 @@ perception/tabletop-objects:
   # Segmentation distance threshold; m
   table_segmentation_distance_threshold: 0.022
 
-  # Minimum size of fraction of points that must be inliers to consider a table; 0.0..1.0
+  # Minimum size of fraction of points that must be inliers to consider a table;
+  # 0.0..1.0
   table_segmentation_inlier_quota: 0.12
 
   # Table downsampling leaf size; m
   # This is directly related to table_cluster_tolerance
   table_downsample_leaf_size: 0.04
-  
+
   # Max clustering inter-point distance tolerance for table cluster; m
   table_cluster_tolerance: 0.044
 
-  # Quota of (voxelized) plane points which must be in the table cluster to accept it
+  # Quota of (voxelized) plane points which must be in the table cluster to
+  # accept it
   table_min_cluster_quota: 0.5
-  
-  # Maximum angle between Z axis and table normal, takes normal direction into account; rad
+
+  # Maximum angle between Z axis and table normal, takes normal direction into
+  # account; rad
   max_z_angle_deviation: 0.1
 
   # Minimum required height of table; m
@@ -52,7 +55,7 @@ perception/tabletop-objects:
   # object clustering. Disable the table model if you expect not to stand on the
   # long side of the table.
   table_model_enable: false
-  
+
   # Table model width, i.e. if the robot is standing in front of the
   # longer edge of the table the distance between the close and the far edge; m
   table_model_width: 0.8
@@ -76,26 +79,30 @@ perception/tabletop-objects:
   # The frame in which the result should be published; frame
   result_frame: !frame base_link
 
-  # Show the frustrum according to configured horizontal and vertical viewing angle.
+  # Show the frustrum according to configured horizontal and vertical viewing
+  # angle.
   visualization/show_frustrum: true
 
   # Show text with convex hull vertex IDs?
   visualization/show_convex_hull_vertices: true
 
-  # Show highlighted hull lines to understand edge selection? Otherwise plain hull is shown.
+  # Show highlighted hull lines to understand edge selection? Otherwise plain
+  # hull is shown.
   visualization/show_convex_hull_line_highlighting: true
 
   # Show text with convex hull vertex IDs?
   visualization/show_convex_hull_vertex_ids: true
 
-  # Time to show marker elements when not updated. Useful to still analyze
-  # the seen after program has been terminated; sec
+  # Time to show marker elements when not updated. Useful to still analyze the
+  # seen after program has been terminated; sec
   visualization/display_duration: 120
 
-  # Horizontal viewing angle of the camera, used for frustrum, value is for Kinect; deg
+  # Horizontal viewing angle of the camera, used for frustrum, value is for
+  # Kinect; deg
   horizontal_viewing_angle: 57.0
 
-  # Vertical viewing angle of the camera, used for frustrum, value is for Kinect; deg
+  # Vertical viewing angle of the camera, used for frustrum, value is for
+  # Kinect; deg
   vertical_viewing_angle: 43.0
 
   # max number of loops a centroid is saved
@@ -104,7 +111,8 @@ perception/tabletop-objects:
   # max distance an old centroid may have moved
   centroid_max_distance: 0.041
 
-  # min distance between two centroids, old centroids will be deleted if they are closer
+  # min distance between two centroids, old centroids will be deleted if they
+  # are closer
   centroid_min_distance: 0.01
 
   # max height of a centroid relative to the table

--- a/cfg/conf.d/webview-ptzcam.yaml
+++ b/cfg/conf.d/webview-ptzcam.yaml
@@ -18,7 +18,7 @@ webview/ptzcam:
   # mirrored and pan/tilt values will be inverted. Note that vflipping
   # of the image must be configured in /webview/images
   ceiling-mount: true
-  
+
   # Increment for pan and tilt for the respective buttons. The values are
   # scaled with the inverse of the zoom factor for fine grained control
   pan-increment: 0.2
@@ -30,7 +30,7 @@ webview/ptzcam:
   # String name for the webview nav tab entry
   nav-entry: SkyCam
 
-  #Loop interval in which to check for inactivity
+  # Loop interval in which to check for inactivity
   loop-interval: 5.0
 
   # After which time to consider the web interface inactive if no

--- a/cfg/conf.d/webview.yaml
+++ b/cfg/conf.d/webview.yaml
@@ -46,7 +46,7 @@ webview:
       # Allow all access, sets header to '*'
       all: true
       # Allow access only from specific domains
-      #origins: ["http://localhost:4200"]
+      # origins: ["http://localhost:4200"]
 
     # time to allow clients to cache our response
     max-age: 86400
@@ -81,7 +81,7 @@ webview:
   #   jpeg-vflip: true/false
   # J is the JPEG quality balancing file size and quality, range 1-100,
   #   depends on actual compressor used
-  #   For libjpeg 70 or 80 are good values, for MMAL (Raspberry Pi) 5-10 are fine
+  #   For libjpeg 70-80 are good values, for MMAL (Raspberry Pi) 5-10 are fine
   # F Number of frames per second for MJPEG-streams
   # Vertical flipping can be enabled, e.g. for ceiling cameras
   images:
@@ -125,6 +125,7 @@ webview:
   # works out-of-the-box on machines running prometheus, node_exporter,
   # process-exporter, and mongodb-exporter.
   dashboard:
+    # yamllint disable rule:line-length
     charts:
       - name: CPU
         query: avg without (cpu)(irate(node_cpu{job="node",instance="localhost:9100",mode!="idle"}[5m]))
@@ -174,3 +175,5 @@ webview:
         factor: 100
         thresholds: [10, 50]
         query: '(node_memory_SwapTotal_bytes{instance="localhost:9100"} - node_memory_SwapFree_bytes{instance="localhost:9100"})/node_memory_SwapTotal_bytes{instance="localhost:9100"}'
+
+        # yamllint enable rule:line-length

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -24,7 +24,7 @@ fawkes:
 
     # Uncomment the following to get a debug log file each time you
     # run fawkes independent of the log level.
-    #loggers: console;file/debug:debug.log
+    # loggers: console;file/debug:debug.log
 
     # Enable to redirect stderr to the log. If you have mis-behaving
     # third-party code this can come in handy to keep records of what's

--- a/etc/buildsys/root/check.mk
+++ b/etc/buildsys/root/check.mk
@@ -19,9 +19,14 @@ endif
 ifndef __buildsys_config_mk_
 $(error config.mk must be included before check.mk)
 endif
+ifndef __buildsys_root_yamllint_mk_
+$(error yamllint.mk must be included before check.mk)
+endif
 
 ifndef __buildsys_root_check_mk_
 __buildsys_root_check_mk_ := 1
+
+YAMLLINT ?= 1
 
 .PHONY: license-check
 license-check:
@@ -67,8 +72,7 @@ check-parallel:
 	fi
 
 .PHONY: check
-check: quickdoc license-check
+check: quickdoc $(if $(subst 0,,$(YAMLLINT)),yamllint) license-check
 
 
 endif # __buildsys_root_check_mk_
-

--- a/etc/buildsys/root/root.mk
+++ b/etc/buildsys/root/root.mk
@@ -21,6 +21,7 @@ ifndef __buildsys_root_root_mk_
 __buildsys_parts_root_mk_ := 1
 
 include $(BUILDSYSDIR)/root/docs.mk
+include $(BUILDSYSDIR)/root/yamllint.mk
 include $(BUILDSYSDIR)/root/check.mk
 include $(BUILDSYSDIR)/root/format.mk
 include $(BUILDSYSDIR)/root/btmgmt.mk

--- a/etc/buildsys/root/yamllint.mk
+++ b/etc/buildsys/root/yamllint.mk
@@ -1,0 +1,40 @@
+#*****************************************************************************
+#     Makefile Build System for Fawkes: yamllint target
+#                            -------------------
+#   Created on Sat Jan 26 16:31:06 2019 +0100
+#   Copyright (C) 2006-2019 by Tim Niemueller, AllemaniACs RoboCup Team
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+ifndef __buildsys_config_mk_
+$(error config.mk must be included before docs.mk)
+endif
+
+ifndef __buildsys_root_yamllint_mk_
+__buildsys_root_yamllint_mk_ := 1
+
+.PHONY: yamllint
+
+yamllint:
+	$(SILENT) echo -e "$(INDENT_PRINT)[CHK] Checking configuration files"
+	$(SILENT)if type -p yamllint >/dev/null; then \
+		if ! yamllint -s cfg/config.yaml cfg/conf.d/; then \
+			echo -e "$(TRED)--> yamllint reported issues, see above.$(TNORMAL)"; \
+			exit 1; \
+		else \
+			echo -e "$(TGREEN)--> No warnings. Nice job.$(TNORMAL)"; \
+		fi; \
+	else \
+		echo -e "$(TORANGE)--> yamllint could not be found$(TNORMAL)"; \
+		exit 2; \
+	fi
+
+endif # __buildsys_root_yamllint_mk_
+


### PR DESCRIPTION
This branch adds yamllint for configuration files. This ensures consistency, readability, and eliminates several errors (which parsers may or may not ignore). If errors are detected, display the yamllint output in an annotation. By default `make check` will also perform the yamllint run (if yamllint is not available on the host system it also raises an error). When running in buildkite, it is run separately in order to better represent errors, if any.

It also adds some improvements to the representation of build stats to make them easier to read at a glance (colors) and avoid wobbling on opening details (use cols). Thanks to the awesome people at buildkite to be forthcoming to the necessary changes on their end.

There is a minor issue at the moment, that does not handle newlines correctly in colored terminal output, such as in the yamllint error output. Buildkite has been notified and I expect that they will have fixed this in no time. In any case, it's something we do not have anything to do for to fix it, hence this branch is good for review and merging.

Example colored coverage stats:
https://buildkite.com/fawkesrobotics/fawkes-build/builds/282

Example yamllint error output:
https://buildkite.com/fawkesrobotics/fawkes-build/builds/284