### PR TITLE
clang-format: adapt RawStringFormats config to new file format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -94,9 +94,10 @@ PenaltyExcessCharacter: 1000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
+  - Language:        TextProto
     BasedOnStyle:    google
+    Delimiters:
+      - pb
 ReflowComments: false
 SortIncludes:    true
 SortUsingDeclarations: true


### PR DESCRIPTION
The option RawStringFormats now expects a list of delimiters for each
language.