### PR TITLE
fvutils: fix underscores in __asm__ and __volatile__ modifiers

### DIFF
--- a/src/libs/fvutils/cpu/mmx.h
+++ b/src/libs/fvutils/cpu/mmx.h
@@ -46,25 +46,25 @@ typedef        union {
 
 
 #define         mmx_i2r(op,imm,reg) \
-        asm___ volatile___ (#op " %0, %%" #reg \
+        __asm__ __volatile__ (#op " %0, %%" #reg \
                               : /* nothing */ \
                               : "i" (imm) )
 
 #define         mmx_m2r(op,mem,reg) \
-        asm___ volatile___ (#op " %0, %%" #reg \
+        __asm__ __volatile__ (#op " %0, %%" #reg \
                               : /* nothing */ \
                               : "m" (mem))
 
 #define         mmx_r2m(op,reg,mem) \
-        asm___ volatile___ (#op " %%" #reg ", %0" \
+        __asm__ __volatile__ (#op " %%" #reg ", %0" \
                               : "=m" (mem) \
                               : /* nothing */ )
 
 #define         mmx_r2r(op,regs,regd) \
-        asm___ volatile___ (#op " %" #regs ", %" #regd)
+        __asm__ __volatile__ (#op " %" #regs ", %" #regd)
 
 
-#define         emms() asm___ volatile___ ("emms")
+#define         emms() __asm__ __volatile__ ("emms")
 
 #define         movd_m2r(var,reg)           mmx_m2r (movd, var, reg)
 #define         movd_r2m(reg,var)           mmx_r2m (movd, reg, var)
@@ -203,16 +203,16 @@ typedef        union {
 
 
 #define         mmx_m2ri(op,mem,reg,imm) \
-        asm___ volatile___ (#op " %1, %0, %%" #reg \
+        __asm__ __volatile__ (#op " %1, %0, %%" #reg \
                               : /* nothing */ \
                               : "m" (mem), "i" (imm))
 #define         mmx_r2ri(op,regs,regd,imm) \
-        asm___ volatile___ (#op " %0, %%" #regs ", %%" #regd \
+        __asm__ __volatile__ (#op " %0, %%" #regs ", %%" #regd \
                               : /* nothing */ \
                               : "i" (imm) )
 
 #define         mmx_fetch(mem,hint) \
-        asm___ volatile___ ("prefetch" #hint " %0" \
+        __asm__ __volatile__ ("prefetch" #hint " %0" \
                               : /* nothing */ \
                               : "m" (mem))
 
@@ -243,7 +243,7 @@ typedef        union {
 #define         pminub_r2r(regs,regd)       mmx_r2r (pminub, regs, regd)
 
 #define         pmovmskb(mmreg,reg) \
-        asm___ volatile___ ("movmskps %" #mmreg ", %" #reg)
+        __asm__ __volatile__ ("movmskps %" #mmreg ", %" #reg)
 
 #define         pmulhuw_m2r(var,reg)        mmx_m2r (pmulhuw, var, reg)
 #define         pmulhuw_r2r(regs,regd)      mmx_r2r (pmulhuw, regs, regd)
@@ -259,7 +259,7 @@ typedef        union {
 #define         pshufw_m2r(var,reg,imm)     mmx_m2ri(pshufw, var, reg, imm)
 #define         pshufw_r2r(regs,regd,imm)   mmx_r2ri(pshufw, regs, regd, imm)
 
-#define         sfence() asm___ volatile___ ("sfence\n\t")
+#define         sfence() __asm__ __volatile__ ("sfence\n\t")
 
 /* SSE2 */
 #define         pshufhw_m2r(var,reg,imm)    mmx_m2ri(pshufhw, var, reg, imm)


### PR DESCRIPTION
Those modifiers are not private members but instructions to the compiler
and should not have been converted in commit c6b48abfdf0371b9d13265d8b4f9908cb175a469.