### PR TITLE
katana: fix format strings

### DIFF
--- a/src/plugins/katana/goto_openrave_thread.cpp
+++ b/src/plugins/katana/goto_openrave_thread.cpp
@@ -334,7 +334,7 @@ KatanaGotoOpenRaveThread::once()
       try {
         final = _katana->final();
       } catch (fawkes::KatanaMotorCrashedException &e) {
-        _logger->log_warn("KatanaGotoThread", e.what());
+        _logger->log_warn("KatanaGotoThread", "Motor crashed: %s", e.what());
         _error_code = fawkes::KatanaInterface::ERROR_MOTOR_CRASHED;
         break;
       }

--- a/src/plugins/katana/goto_thread.cpp
+++ b/src/plugins/katana/goto_thread.cpp
@@ -111,7 +111,7 @@ KatanaGotoThread::once()
     try {
       final = _katana->final();
     } catch (fawkes::KatanaMotorCrashedException &e) {
-      _logger->log_warn("KatanaMotorControlTrhead", e.what());
+      _logger->log_warn("KatanaMotorControlTrhead", "Motor crashed: %s", e.what());
       _error_code = fawkes::KatanaInterface::ERROR_MOTOR_CRASHED;
       break;
     }

--- a/src/plugins/katana/gripper_thread.cpp
+++ b/src/plugins/katana/gripper_thread.cpp
@@ -101,7 +101,7 @@ KatanaGripperThread::once()
     try {
       final = _katana->final();
     } catch (fawkes::KatanaMotorCrashedException &e) {
-      _logger->log_warn("KatanaMotorControlTrhead", e.what());
+      _logger->log_warn("KatanaMotorControlTrhead", "Motor crashed: %s", e.what());
       _error_code = fawkes::KatanaInterface::ERROR_MOTOR_CRASHED;
       break;
     }

--- a/src/plugins/katana/motor_control_thread.cpp
+++ b/src/plugins/katana/motor_control_thread.cpp
@@ -132,7 +132,7 @@ KatanaMotorControlThread::once()
     try {
       final = _katana->final();
     } catch (fawkes::KatanaMotorCrashedException &e) {
-      _logger->log_warn("KatanaMotorControlTrhead", e.what());
+      _logger->log_warn("KatanaMotorControlThread", "Motor crashed: %s", e.what());
       _error_code = fawkes::KatanaInterface::ERROR_MOTOR_CRASHED;
       break;
     }

--- a/src/plugins/katana/sensacq_thread.cpp
+++ b/src/plugins/katana/sensacq_thread.cpp
@@ -72,7 +72,7 @@ KatanaSensorAcquisitionThread::loop()
     try {
       katana_->read_sensor_data();
     } catch (Exception &e) {
-      logger_->log_warn(name(), e.what());
+      logger_->log_warn(name(), "Exception while reading sensor data: %s", e.what());
     }
   }
 }


### PR DESCRIPTION
Fix invalid format strings in Katana that cause build failures on Fedora 30/rawhide.