### PR TITLE
googletest: avoid copying files twice

### DIFF
--- a/src/libs/googletest/Makefile
+++ b/src/libs/googletest/Makefile
@@ -44,7 +44,8 @@ $(SRCDIR)/src/%.h: /usr/src/googletest/googletest/src/%.h
 	$(SILENT)mkdir -p $(@D)
 	$(SILENT)cp -af $< $@
 
-$(OBJS_all): | $(SRCDIR)/gtest $(addprefix $(SRCDIR)/,$(SRCS_libfawkesgtest) $(SRCS_libfawkesgtest_main))
+$(OBJS_all): | $(SRCDIR)/gtest
+$(OBJS_all): %.o: $(SRCDIR)/%.cpp
 
 $(SRCDIR)/gtest: /usr/src/googletest/googletest/include/gtest
 	$(eval BUILT_PARTS += $@)


### PR DESCRIPTION
By being more specific in the dependencies we can avoid copying the same file twice, in turn preventing the race condition on copying which may fail in some rare cases (but especially on a loaded system such as a build host).

Fixes #62.