### PR TITLE
Fix builds for when there are no other topic branches

### DIFF
--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -168,7 +168,8 @@ check_branch_name () {
 
 check_commit_authors () {
 
-	git_repo_clone "$(git config --get remote.origin.url)" ".barerepo" "--reference . --bare"
+	rm -rf .barerepo
+	git_repo_clone "$BUILDKITE_REPO" .barerepo "--reference . --bare"
 	pushd .barerepo >/dev/null
 
 	OTHER_BRANCHES=$(git for-each-ref --format='%(refname)' refs/heads/ | grep -F -v "refs/heads/${BUILDKITE_BRANCH:-}" || :)

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -171,11 +171,11 @@ check_commit_authors () {
 	git_repo_clone "$(git config --get remote.origin.url)" ".barerepo" "--reference . --bare"
 	pushd .barerepo >/dev/null
 
-	OTHER_BRANCHES=$(git for-each-ref --format='%(refname)' refs/heads/ | grep -F -v "refs/heads/${BUILDKITE_BRANCH-}")
+	OTHER_BRANCHES=$(git for-each-ref --format='%(refname)' refs/heads/ | grep -F -v "refs/heads/${BUILDKITE_BRANCH:-}" || :)
 
 	OIFSN=$IFS
 	IFS=$'\n'
-	git rev-parse --not $OTHER_BRANCHES |
+	git rev-parse ${OTHER_BRANCHES:+--not "$OTHER_BRANCHES" } |
 	git rev-list --stdin $MERGE_BASE..HEAD |
 	while read onerev
 	do

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -174,8 +174,6 @@ check_commit_authors () {
 
 	OTHER_BRANCHES=$(git for-each-ref --format='%(refname)' refs/heads/ | grep -F -v "refs/heads/${BUILDKITE_BRANCH:-}" || :)
 
-	OIFSN=$IFS
-	IFS=$'\n'
 	git rev-parse ${OTHER_BRANCHES:+--not "$OTHER_BRANCHES" } |
 	git rev-list --stdin $MERGE_BASE..HEAD |
 	while read onerev

--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -174,8 +174,8 @@ check_commit_authors () {
 
 	OTHER_BRANCHES=$(git for-each-ref --format='%(refname)' refs/heads/ | grep -F -v "refs/heads/${BUILDKITE_BRANCH:-}" || :)
 
-	git rev-parse ${OTHER_BRANCHES:+--not "$OTHER_BRANCHES" } |
-	git rev-list --stdin $MERGE_BASE..HEAD |
+	git rev-parse ${OTHER_BRANCHES:+--not $OTHER_BRANCHES} |
+	git rev-list --stdin $MERGE_BASE..$BUILDKITE_BRANCH |
 	while read onerev
 	do
 	  l=$(git log --pretty="format:%h:%ae:%ce:%an:%cn" -n1 $onerev)


### PR DESCRIPTION
We have such a steady flow of topic branches that we did not have any instance of a build without one since the introduction of buildkite. Now, if there were indeed no topic branches, builds failed, for an example see https://buildkite.com/fawkesrobotics/fawkes-build/builds/376 (the failed linter steps).

This branches addresses this issue. I have made local tests reconstruction that situation and am confident that the issue is fixed. Only this PT without other topic branches will really tell.