### PR TITLE
mongodb_log: Support Debian's mongo/version.h move

### DIFF
--- a/src/plugins/mongodb/mongodb.mk
+++ b/src/plugins/mongodb/mongodb.mk
@@ -18,7 +18,7 @@ include $(BUILDSYSDIR)/boost.mk
 MONGO_CXX_DRIVER_BOOST_LIBS = thread system
 
 ifneq ($(wildcard /usr/include/mongo/client/dbclient.h /usr/local/include/mongo/client/dbclient.h),)
-  ifneq ($(wildcard $(SYSROOT)/usr/include/mongo/version.h $(SYSROOT)/usr/local/include/mongo/version.h),)
+  ifneq ($(wildcard $(SYSROOT)/usr/include/mongo/version.h $(SYSROOT)/usr/include/*/mongo/version.h $(SYSROOT)/usr/local/include/mongo/version.h),)
     CFLAGS_MONGODB_VERSION_H += -DHAVE_MONGODB_VERSION_H
     ifeq ($(OS),FreeBSD)
       MONGO_CXX_DRIVER_BOOST_LIBS += regex


### PR DESCRIPTION
This commit fixes the build under Ubuntu 18.10. The `version.h` header in Debian's `libmongoclient-dev` package has been moved from `/usr/include/mongo` to `/usr/include/$ARCHITECTURE/mongo`.

It looks like the move happened in https://salsa.debian.org/mongodb-team/mongo-cxx-driver-legacy/commit/4d1c761a451b20c2c643380aee00ef49c34b66fb.