### PR TITLE
buildkite: fix builds from fork repos

### DIFF
--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -175,7 +175,7 @@ check_commit_authors () {
 	OTHER_BRANCHES=$(git for-each-ref --format='%(refname)' refs/heads/ | grep -F -v "refs/heads/${BUILDKITE_BRANCH:-}" || :)
 
 	git rev-parse ${OTHER_BRANCHES:+--not $OTHER_BRANCHES} |
-	git rev-list --stdin $MERGE_BASE..$BUILDKITE_BRANCH |
+	git rev-list --stdin $MERGE_BASE..$BUILDKITE_COMMIT |
 	while read onerev
 	do
 	  l=$(git log --pretty="format:%h:%ae:%ce:%an:%cn" -n1 $onerev)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,7 @@ steps:
             - BUILDKITE
             - BUILDKITE_REPO
             - BUILDKITE_BRANCH
+            - BUILDKITE_COMMIT
             - BUILDKITE_LABEL
             - BUILDKITE_BUILD_CREATOR
             - BUILDKITE_BUILD_CREATOR_EMAIL


### PR DESCRIPTION
When issuing a build for an external fork repo (typically doing a rebuild on a previously rejected build) using BUILDKITE_BRANCH yields something like "user:branch" (we explicitly enabled that in buildkite
and use it for, e.g., branch name verification). This will lead the author information check to fail since it would use a commit range like "MERGE_BASE..user:branch". Fix this by using BUILDKITE_COMMIT. Make sure to add this to the environment passed to the docker containers.

Fixes the build fail in #70.