### PR TITLE
pcl_utils: fix broken format string in exception

### DIFF
--- a/src/libs/pcl_utils/pointcloud_manager.h
+++ b/src/libs/pcl_utils/pointcloud_manager.h
@@ -82,7 +82,7 @@ PointCloudManager::add_pointcloud(const char *id, RefPtr<pcl::PointCloud<PointT>
 	if (clouds_.find(id) == clouds_.end()) {
 		clouds_[id] = new pcl_utils::PointCloudStorageAdapter<PointT>(cloud);
 	} else {
-		throw Exception("Cloud %s already registered");
+		throw Exception("Cloud %s already registered", id);
 	}
 }
 


### PR DESCRIPTION
pretty trivial, I wonder why no compiler or any of the supposedly thorough linters warned about this...