### PR TITLE
gitlint: make subject regex more specific

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -31,7 +31,7 @@ line-length=80
 # commit-msg title must be matched to.
 # Note that the regex can contradict with other rules if not used correctly
 # (e.g. title-must-not-contain-word).
-regex=^[^:]+: .*
+regex=^[^:]+: [^:]+ .*$
 
 #[body-changed-file-mention]
 # List of files that need to be explicitly mentioned in the body when they are changed


### PR DESCRIPTION
In particular, do not allow something like "libs: somelib: message".

This should avoid further instances of the commit subject issue in #75.