### PR TITLE
Laser Filter: Fix projection calculation for default case

### DIFF
--- a/src/plugins/laser-filter/filters/projection.cpp
+++ b/src/plugins/laser-filter/filters/projection.cpp
@@ -168,7 +168,7 @@ LaserProjectionDataFilter::filter()
 				if (inbuf[i] == 0.)
 					continue;
 
-				float a = deg2rad(360.f / (float)i);
+				float a = deg2rad((float)i / ((float)in_data_size / 360.f));
 				p.setValue((btScalar)inbuf[i] * cos(a), (btScalar)inbuf[i] * sin(a), 0.);
 				p = t * p;
 


### PR DESCRIPTION
Fixes a faulty calculation of the angle of the ith beam for laser sensors that uses a different amount of beams than 360 or 720.