### PR TITLE
realsense: null rs_error_ field after free

### DIFF
--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -215,6 +215,7 @@ RealsenseThread::log_error()
 	if (rs_error_) {
 		logger->log_warn(name(), "Realsense Error: %s", rs_get_error_message(rs_error_));
 		rs_free_error(rs_error_);
+		rs_error_ = nullptr;
 	}
 }
 


### PR DESCRIPTION
In principle, it's a very obvious fix: If the boolean value of `rs_error_` is the guard for dereferencing it, then it **must** be set to `nullptr` after being freed. I *suppose* this fixes the realsense errors on Fedora 29, but haven't been able to test this fully. It definitely fixes a bunch of realsense-related segfaults, but I'm not yet sure whether that was the only thing preventing the realsense plugin from working on F29.