### PR TITLE
buildsys: install git pre-push hook into TOP_BASEDIR for submodules

### DIFF
--- a/etc/buildsys/root/git-hooks.mk
+++ b/etc/buildsys/root/git-hooks.mk
@@ -17,8 +17,9 @@ ifndef __buildsys_config_mk_
 $(error config.mk must be included before check.mk)
 endif
 
-.git/hooks/pre-push: etc/git-hooks/pre-push
+$(TOP_BASEDIR)/.git/hooks/pre-push: $(FAWKES_BASEDIR)/etc/git-hooks/pre-push
+	$(SILENT)mkdir -p $(TOP_BASEDIR)/.git/hooks
 	$(SILENTSYMB) echo -e "$(INDENT_PRINT)[GIT] installing pre-push hook $@"
 	$(SILENT)install -m 0755 $< $@
 
-all: .git/hooks/pre-push
+all: $(TOP_BASEDIR)/.git/hooks/pre-push


### PR DESCRIPTION
If fawkes is a submodule, the pre-hook script should be installed in
TOP_BASEDIR, not in the current directory. Also create the hooks
directory if it does not exist yet.

This fixes a build error currently occurring in carologistics/fawkes-robotino:
```
[GIT] installing pre-push hook .git/hooks/pre-push
install: failed to access '.git/hooks/pre-push': Not a directory
```