### PR TITLE
clips-executive: fix bug in goal rejection of run-one goals.

### DIFF
--- a/src/plugins/clips-executive/clips/goals/run-one.clp
+++ b/src/plugins/clips-executive/clips/goals/run-one.clp
@@ -57,7 +57,7 @@
 (defrule run-one-goal-reject
 	?gf <- (goal (id ?id) (type ACHIEVE) (sub-type RUN-ONE-OF-SUBGOALS) (mode EXPANDED))
 	(forall (goal (id ?sub-goal) (parent ?id) (type ACHIEVE))
-		(goal (id ?sub-goal) (mode EVALUATED) (outcome REJECTED)))
+		(goal (id ?sub-goal) (mode RETRACTED) (outcome REJECTED)))
 	=>
 	(modify ?gf (mode FINISHED) (outcome REJECTED) (committed-to nil)
 	        (error SUB-GOALS-REJECTED))


### PR DESCRIPTION
This PR fixes a bug that causes goals of sub-type `RUN-ONE-OF-SUBGOALS` to to not fail with outcome  `REJECTED` when all sub-goals are rejected.

Evaluated sub-goals of RUN-ONE-OF-SUBGOALS goals are retracted automatically after evaluation, therefore run-one goals have to be rejected if all sub-goals are `RETRACTED` with the outcome `REJECTED`.