### PR TITLE
ROS Navigator: allow tolerances in CartesianGotoMessages

### DIFF
--- a/src/libs/interfaces/NavigatorInterface.xml
+++ b/src/libs/interfaces/NavigatorInterface.xml
@@ -131,12 +131,31 @@
     <field type="float" name="y">Y-coordinate of the target, in the robot's coordinate system.</field>
     <field type="float" name="orientation">The desired orientation of the robot at the target.</field>
   </message>
+  <message name="CartesianGotoWithTolerance">
+    <comment>States the next target to navigate to.
+    Specify a certain translational and angular tolerance.</comment>
+    <field type="float" name="x">X-coordinate of the target, in the robot's coordinate system.</field>
+    <field type="float" name="y">Y-coordinate of the target, in the robot's coordinate system.</field>
+    <field type="float" name="orientation">The desired orientation of the robot at the target.</field>
+    <field type="float" name="translation_tolerance">The translation tolerance of the target, in meters.</field>
+    <field type="float" name="orientation_tolerance">The orientation tolerance of the target, in radians.</field>
+  </message>
   <message name="CartesianGotoWithFrame">
     <comment>States the next target to navigate to.</comment>
     <field type="float" name="x">X-coordinate of the target, in the robot's coordinate system.</field>
     <field type="float" name="y">Y-coordinate of the target, in the robot's coordinate system.</field>
     <field type="float" name="orientation">The desired orientation of the robot at the target.</field>
     <field type="string" length="64" name="target_frame">The target frame to plan in.</field>
+  </message>
+  <message name="CartesianGotoWithFrameWithTolerance">
+    <comment>States the next target to navigate to.
+    Specify a certain translational and angular tolerance.</comment>
+    <field type="float" name="x">X-coordinate of the target, in the robot's coordinate system.</field>
+    <field type="float" name="y">Y-coordinate of the target, in the robot's coordinate system.</field>
+    <field type="float" name="orientation">The desired orientation of the robot at the target.</field>
+    <field type="string" length="64" name="target_frame">The target frame to plan in.</field>
+    <field type="float" name="translation_tolerance">The translation tolerance of the target, in meters.</field>
+    <field type="float" name="orientation_tolerance">The orientation tolerance of the target, in radians.</field>
   </message>
   <message name="PolarGoto">
     <comment>States the next target to navigate to.</comment>

--- a/src/plugins/ros/navigator_thread.h
+++ b/src/plugins/ros/navigator_thread.h
@@ -120,6 +120,9 @@ private:
 	float                      goal_position_x;
 	float                      goal_position_y;
 	float                      goal_position_yaw;
+
+	float goal_tolerance_trans;
+	float goal_tolerance_yaw;
 };
 
 #endif /* ROS_NAVIGATOR_THREAD_H__ */


### PR DESCRIPTION
This PR adds two new messages to the NavigatorInterface to allow sending CartesianGoto messages with a translation and an orientation tolerance.
The `ros-navigator` uses these new messages but it will stick with the tolerance set by the configuration in case any of the messages of type `CartesianGoto`, `CartesianGotoWithFrame` or `PolarGotoMessage` are sent.