### PR TITLE
Restart realsense if polling fails too often

### DIFF
--- a/cfg/conf.d/realsense.yaml
+++ b/cfg/conf.d/realsense.yaml
@@ -10,6 +10,10 @@ realsense:
   # ID of the PointCloud
   pcl_id: "/camera/depth/points"
 
+  # If true, the camera will be enabled/disabled on incoming Enable/Disable
+  # messages. If false, switch messages will be ignored.
+  # use_switch: true
+
   # Number of retries after unsuccessful polling before restarting the camera
   # restart_after_num_errors: 50
 

--- a/cfg/conf.d/realsense.yaml
+++ b/cfg/conf.d/realsense.yaml
@@ -10,6 +10,9 @@ realsense:
   # ID of the PointCloud
   pcl_id: "/camera/depth/points"
 
+  # Number of retries after unsuccessful polling before restarting the camera
+  # restart_after_num_errors: 50
+
   # Section to set the Realsense device options
   device_options:
     # Laser power from 0 - 15 as integer

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -154,6 +154,7 @@ RealsenseThread::connect_and_start_camera()
 	logger->log_info(name(), "No. of cameras: %i ", num_of_cameras_);
 	if (num_of_cameras_ < 1) {
 		logger->log_error(name(), "No camera detected!");
+		rs_delete_context(rs_context_, &rs_error_);
 		camera_running_ = false;
 		return camera_running_;
 	}

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -151,7 +151,9 @@ RealsenseThread::connect_and_start_camera()
 	num_of_cameras_ = rs_get_device_count(rs_context_, &rs_error_);
 	logger->log_info(name(), "No. of cameras: %i ", num_of_cameras_);
 	if (num_of_cameras_ < 1) {
-		throw Exception("No camera detected!");
+		logger->log_error(name(), "No camera detected!");
+		camera_running_ = false;
+		return camera_running_;
 	}
 
 	rs_device_ = get_camera();
@@ -174,7 +176,7 @@ RealsenseThread::connect_and_start_camera()
 	realsense_depth_->height = z_intrinsic_.height;
 	realsense_depth_->resize(z_intrinsic_.width * z_intrinsic_.height);
 	logger->log_info(name(), "Height: %i, Width: %i", z_intrinsic_.height, z_intrinsic_.width);
-	return true;
+	return camera_running_;
 }
 
 /* Get the rs_device pointer and printout camera details

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -92,8 +92,10 @@ RealsenseThread::loop()
 		connect_and_start_camera();
 		// Start reading in the next loop
 		return;
-	} else if (!enable_camera_ && camera_running_) {
-		stop_camera();
+	} else if (!enable_camera_) {
+		if (camera_running_) {
+			stop_camera();
+		}
 		return;
 	}
 	if (rs_poll_for_frames(rs_device_, &rs_error_) == 1) {

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -37,8 +37,7 @@ using namespace fawkes;
 RealsenseThread::RealsenseThread()
 : Thread("RealsenseThread", Thread::OPMODE_WAITFORWAKEUP),
   BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_ACQUIRE),
-  switch_if_(NULL),
-  cfg_use_switch_(true)
+  switch_if_(NULL)
 {
 }
 
@@ -53,10 +52,7 @@ RealsenseThread::init()
 	restart_after_num_errors_ =
 	  config->get_uint_or_default(std::string(cfg_prefix + "restart_after_num_errors").c_str(), 50);
 
-	try {
-		cfg_use_switch_ = config->get_bool((cfg_prefix + "use_switch").c_str());
-	} catch (Exception &e) {
-	} // ignore, use default
+	cfg_use_switch_ = config->get_bool_or_default((cfg_prefix + "use_switch").c_str(), true);
 
 	if (cfg_use_switch_) {
 		logger->log_info(name(), "Switch enabled");

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -51,7 +51,7 @@ RealsenseThread::init()
 	pcl_id_                      = config->get_string(cfg_prefix + "pcl_id");
 	laser_power_                 = config->get_int(cfg_prefix + "device_options/laser_power");
 	restart_after_num_errors_ =
-	  config->get_uint_or_default(std::string(cfg_prefix + "restart_after_num_errors").c_str(), 10);
+	  config->get_uint_or_default(std::string(cfg_prefix + "restart_after_num_errors").c_str(), 50);
 
 	try {
 		cfg_use_switch_ = config->get_bool((cfg_prefix + "use_switch").c_str());

--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -105,6 +105,8 @@ private:
 	std::string   pcl_id_;
 	bool          camera_started_ = false;
 	int           laser_power_;
+	uint          restart_after_num_errors_;
+	uint          error_counter_ = 0;
 };
 
 #endif

--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -103,7 +103,8 @@ private:
 	float         camera_scale_;
 	std::string   frame_id_;
 	std::string   pcl_id_;
-	bool          camera_started_ = false;
+	bool          enable_camera_  = true;
+	bool          camera_running_ = false;
 	int           laser_power_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;


### PR DESCRIPTION
This PR makes the handling of the realsense device more robust. In particular, if the device fails intermittently and we cannot poll new frames for a while, restart the camera. In order to do this, restructure the camera initialization so we can initialize the camera in every loop if it has not been initialized. This also allows loading the plugin while the camera is not connected yet.

Note that this requires `librealsense1-1.12.3-b7a6fb9.4` ([F30 update](https://bodhi.fedoraproject.org/updates/FEDORA-2019-dfd4e95abb), [F29 update](https://bodhi.fedoraproject.org/updates/FEDORA-2019-87363450db)). Otherwise, the plugin will still segfault, because the library used to throw an exception in a separate thread.