### PR TITLE
clips-executive: properly populate error-msg of plan-action

### DIFF
--- a/src/plugins/clips-executive/clips/skills-actions.clp
+++ b/src/plugins/clips-executive/clips/skills-actions.clp
@@ -82,7 +82,7 @@
 	?sf <- (skill (id ?skill-id) (status S_FAILED) (error-msg ?error))
 	=>
 	(printout warn "Execution of " ?action-name " FAILED (" ?error ")" crlf)
-	(modify ?pa (state EXECUTION-FAILED))
+	(modify ?pa (state EXECUTION-FAILED) (error-msg ?error))
 	(retract ?sf ?pe)
 )
 


### PR DESCRIPTION
If a skill fails, the error-msg field of the SkillerInterface is set to a string which describes the error. The plan action already had a error-msg field, but it wasnt used. On failure, set the error-msg field to the error-msg of the string