### PR TITLE
clips-executive: change lock response field directly

### DIFF
--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -244,13 +244,6 @@
 	(modify ?mf (response ERROR) (error-msg (str-cat "Mutex already locked by " ?lb)))
 )
 
-(defrule mutex-lock-acquired
-	?mf <- (mutex (name ?name) (request LOCK) (response PENDING)
-								(state LOCKED) (locked-by ?lb&:(eq ?lb (cx-identity))))
-	=>
-	(modify ?mf (response ACQUIRED))
-)
-
 (defrule mutex-lock-rejected
 	?mf <- (mutex (name ?name) (request LOCK) (response PENDING)
 								(state LOCKED) (locked-by ?lb&:(neq ?lb (cx-identity))))
@@ -296,14 +289,6 @@
 	(modify ?mf (response ERROR) (error-msg (str-cat "Mutex locked by " ?lb " (not '" (cx-identity) "')")))
 )
 
-(defrule mutex-renew-lock-op-succeeded
-	?mf <- (mutex (name ?name) (request RENEW-LOCK) (response PENDING))
-	?of <- (mutex-op-feedback renew-lock-async OK ?name)
-	=>
-	(retract ?of)
-	(modify ?mf (response ACQUIRED))
-)
-
 (defrule mutex-renew-lock-op-failed
 	?mf <- (mutex (name ?name) (request RENEW-LOCK) (response PENDING))
 	?of <- (mutex-op-feedback renew-lock-async FAIL ?name)
@@ -326,13 +311,6 @@
 								(state LOCKED|UNKNOWN) (locked-by ?lb&:(neq ?lb (cx-identity))))
 	=>
 	(modify ?mf (response ERROR) (error-msg (str-cat "Locked by " ?lb " (and not by us)")))
-)
-
-(defrule mutex-unlock-succeeded
-	?mf <- (mutex (name ?name) (request UNLOCK) (response PENDING)
-								(state OPEN))
-	=>
-	(modify ?mf (response UNLOCKED))
 )
 
 (defrule mutex-unlock-succeeded-already-reacquired
@@ -440,6 +418,19 @@
 			(assert (mutex (name ?id) (state (if ?locked then LOCKED else OPEN))
 			               (locked-by ?locked-by) (lock-time ?lock-time)))
 		)
+		(do-for-fact ((?m mutex)) (eq ?m:name ?id)
+      (if (or (eq ?m:state OPEN) (eq ?m:locked-by (cx-identity)))
+      then
+        (if (and (eq ?m:request UNLOCK) (not ?locked))
+        then
+          (modify ?m (response UNLOCKED))
+        )
+        (if (and (or (eq ?m:request LOCK) (eq ?m:request RENEW-LOCK)) ?locked)
+        then
+          (modify ?m (response ACQUIRED))
+        )
+		  )
+	  )
 	)
 )
 


### PR DESCRIPTION
On lock renewal, the response of the mutex would be changed from
pending to acquired or rejected upon the receival of the mutex-op-feedback
fact. The decision when the next lock renewal have to be started is
based on the lock-time of the mutex. This would have been updated only
if the robmem-trigger of the renewal arrived before the mutex-op-feedback.
If this was not the case, the renewal started again instantly

In order to prohibit this race, we have to adapt the response field
directly when receiving the robmem-trigger, instead of a seperate rule. To make
this consistent with normal locking, this is changed generally for all requests