### PR TITLE
Cx restore prefixes: Fix query creation and execution

### DIFF
--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
@@ -637,6 +637,7 @@ ClipsRobotMemoryThread::clips_robotmemory_cursor_next(void *cursor)
 		} else {
 			auto b = new bsoncxx::builder::basic::document();
 			b->append(bsoncxx::builder::concatenate(*it));
+			it++;
 			return CLIPS::Value(b);
 		}
 	} catch (mongocxx::query_exception &e) {

--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
@@ -87,6 +87,9 @@ ClipsRobotMemoryThread::clips_context_init(const std::string &          env_name
 	clips->add_function("bson-append",
 	                    sigc::slot<void, void *, std::string, CLIPS::Value>(
 	                      sigc::mem_fun(*this, &ClipsRobotMemoryThread::clips_bson_append)));
+	clips->add_function("bson-append-regex",
+	                    sigc::slot<void, void *, std::string, CLIPS::Value>(
+	                      sigc::mem_fun(*this, &ClipsRobotMemoryThread::clips_bson_append_regex)));
 	clips->add_function("bson-append-array",
 	                    sigc::slot<void, void *, std::string, CLIPS::Values>(
 	                      sigc::mem_fun(*this, &ClipsRobotMemoryThread::clips_bson_append_array)));
@@ -305,6 +308,27 @@ ClipsRobotMemoryThread::clips_bson_append(void *bson, std::string field_name, CL
 	} catch (bsoncxx::exception &e) {
 		logger->log_error("MongoDB",
 		                  "Failed to append array value to field %s: %s",
+		                  field_name.c_str(),
+		                  e.what());
+	}
+}
+
+void
+ClipsRobotMemoryThread::clips_bson_append_regex(void *       bson,
+                                                std::string  field_name,
+                                                CLIPS::Value regex_string)
+{
+	using namespace bsoncxx::builder;
+	if (regex_string.type() != CLIPS::TYPE_STRING) {
+		logger->log_error("MongoDB", "Regex string has to be of type string");
+		return;
+	}
+	try {
+		auto b = static_cast<basic::document *>(bson);
+		b->append(basic::kvp(field_name, bsoncxx::types::b_regex{regex_string.as_string()}));
+	} catch (bsoncxx::exception &e) {
+		logger->log_error("MongoDB",
+		                  "Failed to append regex to field %s: %s",
 		                  field_name.c_str(),
 		                  e.what());
 	}

--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.h
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.h
@@ -71,12 +71,13 @@ protected:
 private:
 	std::map<std::string, fawkes::LockPtr<CLIPS::Environment>> envs_;
 
-	CLIPS::Value  clips_bson_create();
-	CLIPS::Value  clips_bson_parse(std::string document);
-	void          clips_bson_destroy(void *bson);
-	void          clips_bson_append(void *bson, std::string field_name, CLIPS::Value value);
-	void          clips_bson_append_array(void *bson, std::string field_name, CLIPS::Values values);
-	void          clips_bson_append_time(void *bson, std::string field_name, CLIPS::Values time);
+	CLIPS::Value clips_bson_create();
+	CLIPS::Value clips_bson_parse(std::string document);
+	void         clips_bson_destroy(void *bson);
+	void         clips_bson_append(void *bson, std::string field_name, CLIPS::Value value);
+	void clips_bson_append_regex(void *bson, std::string field_name, CLIPS::Value regex_string);
+	void clips_bson_append_array(void *bson, std::string field_name, CLIPS::Values values);
+	void clips_bson_append_time(void *bson, std::string field_name, CLIPS::Values time);
 	CLIPS::Value  clips_bson_array_start(void *bson, std::string field_name);
 	void          clips_bson_array_finish(void *barr);
 	void          clips_bson_array_append(void *barr, CLIPS::Value value);

--- a/src/plugins/robot-memory/robot_memory.h
+++ b/src/plugins/robot-memory/robot_memory.h
@@ -55,7 +55,7 @@ public:
 
 	//robot memory functions
 	mongocxx::cursor         query(bsoncxx::document::view query,
-	                               const std::string &     collection    = "",
+	                               const std::string &     collection_name = "",
 	                               mongocxx::options::find query_options = mongocxx::options::find());
 	bsoncxx::document::value aggregate(const std::vector<bsoncxx::document::view> &pipeline,
 	                                   const std::string &                         collection = "");


### PR DESCRIPTION
Sometimes we want to check a robot-memory collection and assert all worldmodel-facts that are currently missing. This is done by creating a regex query for all wm-fact keys that are configured to be synced. This PR fixes the regex query creation and adapts the query execution to the changes of the new mongocxx-driver.