### PR TITLE
Clips-Executive lock fixes

### DIFF
--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -454,7 +454,8 @@
 
 (defrule mutex-trigger-event
 	(wm-fact (key cx identity) (value ?identity))
-	?rt <- (robmem-trigger (name "mutex-trigger") (ptr ?obj))
+	?rt <- (robmem-trigger (name "mutex-trigger") (ptr ?obj) (rcvd-at $?recv-time))
+	(not (robmem-trigger (name "mutex-trigger") (rcvd-at $?comp-time&:(time> ?recv-time ?comp-time))))
 	=>
 	(bind ?op (sym-cat (bson-get ?obj "operationType")))
 

--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -125,7 +125,7 @@
 			(modify ?m (request UNLOCK) (response ERROR)
 			           (error-msg (str-cat "Lock held by " ?m:locked-by ". Cannot release foreign lock.")))
 			else
-				(if (and (eq ?m:request RENEW-LOCK) (eq ?m:pending-requests (create$ AUTO-RENEW-PROC)))
+				(if (and (eq ?m:request RENEW-LOCK) (not (member$ AUTO-RENEW-PROC ?m:pending-requests)))
 				then ; auto-renew is running, wait for this to finish and then unlock
 					(modify ?m (pending-requests ?m:pending-requests UNLOCK))
 				else

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -132,7 +132,8 @@
   (foreach ?res ?acq
     (if (not (any-factp ((?m mutex))
                         (and (eq ?m:name (resource-to-mutex ?res))
-                             (eq ?m:request UNLOCK))))
+                             (or (eq ?m:request UNLOCK)
+                                 (not (member$ UNLOCK ?m:pending-requests))))))
      then
       (printout warn "Unlocking resource " ?res crlf)
       (mutex-unlock-async (resource-to-mutex ?res))


### PR DESCRIPTION
This PR fixes 3 minor issues in locking and lock expiring:

- Due to the introduction of lock expiring, a mutex can have multiple requests pending. At some places, a mutex was checked if an unlock is pending, without taking this into account. 
- Occasionally it can happen, that multiple robmem-trigger of the same mutex gets asserted. Clips used to deal with them, starting with the newest. If the trigger indicates an unlock, followed by a lock, clips would have applied them the wrong way around, resulting in a wrongfully unlocked mutex. This is fixed by enforcing clips to handle the oldest robmem-trigger first
- The update document in the expire locks function was created wrongly. 