### PR TITLE
Register robot-memory triggers asynchronously

### DIFF
--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.h
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.h
@@ -135,6 +135,7 @@ private:
 
 private:
 	std::list<ClipsRmTrigger *>              clips_triggers_;
+	fawkes::Mutex                            clips_triggers_mutex_;
 	std::map<std::string, std::future<bool>> mutex_futures_;
 	std::future<bool>                        mutex_expire_future_;
 };


### PR DESCRIPTION
There is a potential deadlock between the clips environment and robot-memory if we do the trigger registration synchronously (#90).
    
To avoid the deadlock, make the register_trigger function asynchronous: It creates a future that will assert a feedback fact into the clips environment once registering the trigger has succeeded or failed. This is similar to the pattern used for `mutex_try_lock_async`.

This fixes #90.
