### PR TITLE
clips-executive: fix member check for pending requests

### DIFF
--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -125,7 +125,7 @@
 			(modify ?m (request UNLOCK) (response ERROR)
 			           (error-msg (str-cat "Lock held by " ?m:locked-by ". Cannot release foreign lock.")))
 			else
-				(if (and (eq ?m:request RENEW-LOCK) (not (member$ AUTO-RENEW-PROC ?m:pending-requests)))
+				(if (and (eq ?m:request RENEW-LOCK) (member$ AUTO-RENEW-PROC ?m:pending-requests))
 				then ; auto-renew is running, wait for this to finish and then unlock
 					(modify ?m (pending-requests ?m:pending-requests UNLOCK))
 				else

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -133,7 +133,7 @@
     (if (not (any-factp ((?m mutex))
                         (and (eq ?m:name (resource-to-mutex ?res))
                              (or (eq ?m:request UNLOCK)
-                                 (not (member$ UNLOCK ?m:pending-requests))))))
+                                 (member$ UNLOCK ?m:pending-requests)))))
      then
       (printout warn "Unlocking resource " ?res crlf)
       (mutex-unlock-async (resource-to-mutex ?res))


### PR DESCRIPTION
We wanted to check if UNLOCK is in the pending requests field. The logic was inverted in the last Pull Request, leading to resource locks never actually be requested to unlock.