### PR TITLE
correctly disable realsense on SwitchMessage

### DIFF
--- a/cfg/conf.d/realsense.yaml
+++ b/cfg/conf.d/realsense.yaml
@@ -20,5 +20,4 @@ realsense:
   # Section to set the Realsense device options
   device_options:
     # Laser power from 0 - 15 as integer
-    laser_power_high: 15
-    laser_power_low: 0
+    laser_power: 15

--- a/cfg/conf.d/realsense.yaml
+++ b/cfg/conf.d/realsense.yaml
@@ -20,4 +20,5 @@ realsense:
   # Section to set the Realsense device options
   device_options:
     # Laser power from 0 - 15 as integer
-    laser_power: 15
+    laser_power_high: 15
+    laser_power_low: 0

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -238,13 +238,14 @@ RealsenseThread::set_laser_power(int laser_power){
         rs_device_ = get_camera();
     }
 
-    double dev_laser_power = rs_get_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, &rs_error_);
-    if ( dev_laser_power != laser_power){
+    //double dev_laser_power = rs_get_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, &rs_error_);
+    if ( current_laser_power_ != laser_power){
+        current_laser_power_ = laser_power;
+        logger->log_info(name(),
+                         "set laser power to %i was %i",
+                         laser_power, current_laser_power_);
         rs_set_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, laser_power_high_, &rs_error_);
         log_error();
-        logger->log_info(name(),
-                         "set laser power to %i ",
-                         laser_power);
     }
 
 }

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -240,10 +240,10 @@ RealsenseThread::set_laser_power(int laser_power){
 
     //double dev_laser_power = rs_get_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, &rs_error_);
     if ( current_laser_power_ != laser_power){
-        current_laser_power_ = laser_power;
         logger->log_info(name(),
                          "set laser power to %i was %i",
                          laser_power, current_laser_power_);
+        current_laser_power_ = laser_power;
         rs_set_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, laser_power_high_, &rs_error_);
         log_error();
     }

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -49,7 +49,7 @@ RealsenseThread::init()
 	const std::string cfg_prefix = "/realsense/";
 	frame_id_                    = config->get_string(cfg_prefix + "frame_id");
 	pcl_id_                      = config->get_string(cfg_prefix + "pcl_id");
-    laser_power_                 = config->get_int(cfg_prefix + "device_options/laser_power");
+	laser_power_                 = config->get_int(cfg_prefix + "device_options/laser_power");
 	restart_after_num_errors_ =
 	  config->get_uint_or_default(std::string(cfg_prefix + "restart_after_num_errors").c_str(), 50);
 
@@ -85,20 +85,20 @@ RealsenseThread::loop()
 	if (cfg_use_switch_) {
 		read_switch();
 	}
-    if (enable_camera_ && !last_enable_camera_){
-        if (!camera_running_){
-            connect_and_start_camera();
-            // Start reading in the next loop
-        }
-        last_enable_camera_ = true;
+	if (enable_camera_ && !last_enable_camera_) {
+		if (!camera_running_) {
+			connect_and_start_camera();
+			// Start reading in the next loop
+		}
+		last_enable_camera_ = true;
 
-    } else if (!enable_camera_ && last_enable_camera_) {
-        if (camera_running_ ) {
-            // decrease laser power
-            stop_camera();
-        }
+	} else if (!enable_camera_ && last_enable_camera_) {
+		if (camera_running_) {
+			// decrease laser power
+			stop_camera();
+		}
 
-        last_enable_camera_ = false;
+		last_enable_camera_ = false;
 	}
 
 	if (rs_poll_for_frames(rs_device_, &rs_error_) == 1) {
@@ -122,17 +122,18 @@ RealsenseThread::loop()
 		}
 		pcl_utils::set_time(realsense_depth_refptr_, fawkes::Time(clock));
 	} else {
-		error_counter_++;
-		logger->log_warn(name(),
-		                 "Poll for frames not successful (%s)",
-		                 rs_get_error_message(rs_error_));
-		if (error_counter_ >= restart_after_num_errors_) {
-			error_counter_ = 0;
-			stop_camera();
-            if (enable_camera_){
-                logger->log_warn(name(), "Polling failed, restarting device");
-                connect_and_start_camera();
-            }
+		if (!enable_camera_) {
+			error_counter_++;
+			logger->log_warn(name(),
+			                 "Poll for frames not successful (%s)",
+			                 rs_get_error_message(rs_error_));
+			if (error_counter_ >= restart_after_num_errors_) {
+				error_counter_ = 0;
+				stop_camera();
+			} else {
+				logger->log_warn(name(), "Polling failed, restarting device");
+				connect_and_start_camera();
+			}
 		}
 	}
 }
@@ -143,7 +144,7 @@ RealsenseThread::finalize()
 	realsense_depth_refptr_.reset();
 	pcl_manager->remove_pointcloud(pcl_id_.c_str());
 	stop_camera();
-    rs_delete_context(rs_context_, &rs_error_);
+	rs_delete_context(rs_context_, &rs_error_);
 	blackboard->close(switch_if_);
 	//TODO Documentation with librealsense
 }
@@ -166,7 +167,7 @@ RealsenseThread::connect_and_start_camera()
 	}
 
 	rs_device_ = get_camera();
-    rs_set_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, laser_power_, &rs_error_);
+	rs_set_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, laser_power_, &rs_error_);
 	log_error();
 	enable_depth_stream();
 

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -127,10 +127,12 @@ RealsenseThread::loop()
 		                 "Poll for frames not successful (%s)",
 		                 rs_get_error_message(rs_error_));
 		if (error_counter_ >= restart_after_num_errors_) {
-			logger->log_warn(name(), "Polling failed, restarting device");
 			error_counter_ = 0;
 			stop_camera();
-			connect_and_start_camera();
+            if (enable_camera_){
+                logger->log_warn(name(), "Polling failed, restarting device");
+                connect_and_start_camera();
+            }
 		}
 	}
 }
@@ -141,6 +143,7 @@ RealsenseThread::finalize()
 	realsense_depth_refptr_.reset();
 	pcl_manager->remove_pointcloud(pcl_id_.c_str());
 	stop_camera();
+    rs_delete_context(rs_context_, &rs_error_);
 	blackboard->close(switch_if_);
 	//TODO Documentation with librealsense
 }
@@ -267,7 +270,6 @@ RealsenseThread::stop_camera()
 	if (camera_running_) {
 		logger->log_info(name(), "Stopping realsense camera ...");
 		rs_stop_device(rs_device_, &rs_error_);
-		rs_delete_context(rs_context_, &rs_error_);
 		log_error();
 		logger->log_info(name(), "Realsense camera stopped!");
 		camera_running_ = false;

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -95,9 +95,9 @@ RealsenseThread::loop()
         }
 		return;
 	} else if (!enable_camera_) {
-		if (camera_running_) {
+        if (camera_running_ ) {
             // decrease laser power
-            set_laser_power(laser_power_high_);
+            set_laser_power(laser_power_low_);
 		}
 		return;
 	}
@@ -234,12 +234,19 @@ RealsenseThread::enable_depth_stream()
 
 void
 RealsenseThread::set_laser_power(int laser_power){
-    rs_device_ = get_camera();
-    rs_set_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, laser_power_high_, &rs_error_);
-    log_error();
-    logger->log_info(name(),
-                     "set laser power to %i ",
-                     laser_power);
+    if(!rs_device_){
+        rs_device_ = get_camera();
+    }
+
+    double dev_laser_power = rs_get_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, &rs_error_);
+    if ( dev_laser_power != laser_power){
+        rs_set_device_option(rs_device_, RS_OPTION_F200_LASER_POWER, laser_power_high_, &rs_error_);
+        log_error();
+        logger->log_info(name(),
+                         "set laser power to %i ",
+                         laser_power);
+    }
+
 }
 
 /*

--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -84,7 +84,7 @@ protected:
 private:
 	fawkes::SwitchInterface *switch_if_;
 	bool                     cfg_use_switch_;
-    bool                     last_enable_camera_;
+	bool                     last_enable_camera_;
 
 	typedef pcl::PointXYZ              PointType;
 	typedef pcl::PointCloud<PointType> Cloud;
@@ -106,7 +106,7 @@ private:
 	std::string   pcl_id_;
 	bool          enable_camera_  = true;
 	bool          camera_running_ = false;
-    int           laser_power_;
+	int           laser_power_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;
 };

--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -110,6 +110,7 @@ private:
     int           laser_power_low_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;
+    int           current_laser_power_;
 };
 
 #endif

--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -65,6 +65,7 @@ private:
 	bool       connect_and_start_camera();
 	rs_device *get_camera();
 	void       enable_depth_stream();
+    void       set_laser_power(int laser_power);
 	void       log_error();
 	void       log_depths(const uint16_t *image);
 	void       fill_pointcloud();
@@ -105,7 +106,8 @@ private:
 	std::string   pcl_id_;
 	bool          enable_camera_  = true;
 	bool          camera_running_ = false;
-	int           laser_power_;
+    int           laser_power_high_;
+    int           laser_power_low_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;
 };

--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -85,6 +85,7 @@ protected:
 private:
 	fawkes::SwitchInterface *switch_if_;
 	bool                     cfg_use_switch_;
+    bool                     last_enable_camera_;
 
 	typedef pcl::PointXYZ              PointType;
 	typedef pcl::PointCloud<PointType> Cloud;

--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -65,7 +65,6 @@ private:
 	bool       connect_and_start_camera();
 	rs_device *get_camera();
 	void       enable_depth_stream();
-    void       set_laser_power(int laser_power);
 	void       log_error();
 	void       log_depths(const uint16_t *image);
 	void       fill_pointcloud();
@@ -107,11 +106,9 @@ private:
 	std::string   pcl_id_;
 	bool          enable_camera_  = true;
 	bool          camera_running_ = false;
-    int           laser_power_high_;
-    int           laser_power_low_;
+    int           laser_power_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;
-    int           current_laser_power_;
 };
 
 #endif


### PR DESCRIPTION
Realsense stopped device and cleared the device context. This could lead to reinitializing USB handshakes. Using the Switch Interface sometimes broke the camera connection. Reusing the existing context after enabling Switch interface, should increases stability.