### PR TITLE
delay next poll if error while polling for realsense data occurs

### DIFF
--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -108,6 +108,8 @@ private:
 	int           laser_power_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;
+	fawkes::Time  next_pol_time_;
+	float         cfg_pol_delay_;
 };
 
 #endif


### PR DESCRIPTION
The Realsense gets drowned by pol querries. Delaying the pol after an error occurs, increases chance to regain controll of the device

