### PR TITLE
Allow pushable host specific config files.

### DIFF
--- a/src/libs/config/yaml.cpp
+++ b/src/libs/config/yaml.cpp
@@ -43,6 +43,7 @@
 #include <fstream>
 #include <queue>
 #include <regex>
+#include <unistd.h>
 
 namespace fawkes {
 
@@ -611,7 +612,7 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 	try {
 		const YAML::Node &includes = doc["include"];
 		for (YAML::const_iterator it = includes.begin(); it != includes.end(); ++it) {
-			std::string include        = it->as<std::string>();
+			std::string include        = insert_hostname(it->as<std::string>());
 			bool        ignore_missing = false;
 			if (it->Tag() == "tag:fawkesrobotics.org,cfg/ignore-missing") {
 				ignore_missing = true;
@@ -621,7 +622,8 @@ YamlConfiguration::read_meta_doc(YAML::Node &                doc,
 				if (host_file != "") {
 					throw Exception("YamlConfig: Only one host-specific file can be specified");
 				}
-				host_file = abs_cfg_path(it->Scalar());
+
+				host_file = abs_cfg_path(insert_hostname(it->Scalar()));
 				continue;
 			}
 

--- a/src/libs/config/yaml.cpp
+++ b/src/libs/config/yaml.cpp
@@ -584,23 +584,24 @@ abs_cfg_path(const std::string &path)
 	}
 }
 
-/** Replace <> in string with hostname
- * @param prelim preliminary filename (potentially with <>)
- * @return filename with <> replaced with hostname
+/** Replace $host in string with hostname
+ * @param prelim preliminary filename (potentially with $host)
+ * @return filename with $host replaced with hostname
  */
 static std::string
 insert_hostname(std::string prelim)
 {
-	static char *hostname = NULL;
+	const std::string to_replace = "$host";
+	static char *     hostname   = NULL;
 	if (hostname == NULL) {
 		hostname = new char[256];
 		gethostname(hostname, 256);
 	}
-	size_t repl_position = prelim.find("<>");
+	size_t repl_position = prelim.find(to_replace);
 	if (repl_position == std::string::npos) {
 		return prelim;
 	} else {
-		return prelim.replace(repl_position, 2, std::string(hostname));
+		return prelim.replace(repl_position, to_replace.length(), std::string(hostname));
 	}
 }
 

--- a/src/libs/config/yaml.cpp
+++ b/src/libs/config/yaml.cpp
@@ -583,6 +583,26 @@ abs_cfg_path(const std::string &path)
 	}
 }
 
+/** Replace <> in string with hostname
+ * @param prelim preliminary filename (potentially with <>)
+ * @return filename with <> replaced with hostname
+ */
+static std::string
+insert_hostname(std::string prelim)
+{
+	static char *hostname = NULL;
+	if (hostname == NULL) {
+		hostname = new char[256];
+		gethostname(hostname, 256);
+	}
+	size_t repl_position = prelim.find("<>");
+	if (repl_position == std::string::npos) {
+		return prelim;
+	} else {
+		return prelim.replace(repl_position, 2, std::string(hostname));
+	}
+}
+
 void
 YamlConfiguration::read_meta_doc(YAML::Node &                doc,
                                  std::queue<LoadQueueEntry> &load_queue,


### PR DESCRIPTION
In several occasions it would be useful to push host specific host.yaml files.
Until now, this was not possible as the host specific config file was named equally for all hosts.


This PR introduces changes to load config styles named `*<>*.yaml`, where `<>` is replaced by the hostname. See also PR [#164](https://github.com/carologistics/fawkes-robotino/pull/164) of the fawkes-robotino repo.