### PR TITLE
Check for collisions in truncated interface message type

### DIFF
--- a/src/libs/interface/message.h
+++ b/src/libs/interface/message.h
@@ -29,7 +29,7 @@
 #include <interface/field_iterator.h>
 #include <interface/types.h>
 
-#define INTERFACE_MESSAGE_TYPE_SIZE_ 32
+#define INTERFACE_MESSAGE_TYPE_SIZE_ 64
 
 namespace fawkes {
 

--- a/src/libs/interfaces/generator/cpp_generator.cpp
+++ b/src/libs/interfaces/generator/cpp_generator.cpp
@@ -456,7 +456,7 @@ CppInterfaceGenerator::write_create_message_method_cpp(FILE *f)
 	bool first = true;
 	for (vector<InterfaceMessage>::iterator i = messages.begin(); i != messages.end(); ++i) {
 		fprintf(f,
-		        "  %sif ( strncmp(\"%s\", type, INTERFACE_MESSAGE_TYPE_SIZE_) == 0 ) {\n"
+		        "  %sif ( strncmp(\"%s\", type, INTERFACE_MESSAGE_TYPE_SIZE_ - 1) == 0 ) {\n"
 		        "    return new %s();\n",
 		        first ? "" : "} else ",
 		        i->getName().c_str(),

--- a/src/libs/interfaces/generator/parser.cpp
+++ b/src/libs/interfaces/generator/parser.cpp
@@ -32,7 +32,7 @@
 #include <iostream>
 #include <vector>
 
-//#define CHECK_MESSAGE_TYPE_SIZE
+#define CHECK_MESSAGE_TYPE_SIZE
 
 using namespace std;
 using namespace xmlpp;

--- a/src/libs/interfaces/generator/parser.cpp
+++ b/src/libs/interfaces/generator/parser.cpp
@@ -589,11 +589,11 @@ InterfaceParser::parse()
 				throw InterfaceGeneratorInvalidContentException("no name for message");
 			}
 			msg_name = attr->get_value();
-			if (msg_name.length() > INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - 7) {
+			if (msg_name.length() + std::string("Message").length() > INTERFACE_MESSAGE_TYPE_SIZE_ - 1) {
 				throw InterfaceGeneratorInvalidContentException(
 				  "Interface message name '%s' too long, max length is %u",
 				  msg_name.c_str(),
-				  INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - 7);
+				  INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - std::string("Message").length());
 			}
 		} else {
 			throw InterfaceGeneratorInvalidContentException("message is not an element");

--- a/src/libs/interfaces/generator/parser.cpp
+++ b/src/libs/interfaces/generator/parser.cpp
@@ -651,6 +651,22 @@ InterfaceParser::parse()
 
 		messages.push_back(msg);
 	}
+	bool duplicateExists = false;
+	for (auto msg1 = messages.begin(); msg1 != messages.end(); ++msg1) {
+		for (auto msg2 = msg1 + 1; msg2 != messages.end(); ++msg2) {
+			if (strncmp(msg1->getName().c_str(),
+			            msg2->getName().c_str(),
+			            INTERFACE_MESSAGE_TYPE_SIZE_ - 1)
+			    == 0) {
+				cout << "Possible duplicate at message network syncing detected:" << endl;
+				cout << msg1->getName() << " and " << msg2->getName() << endl << endl;
+				duplicateExists = true;
+			}
+		}
+	}
+	if (duplicateExists)
+		throw InterfaceGeneratorInvalidContentException(
+		  "Duplicates after serializing by BB network handler exist!");
 }
 
 /** Get interface name.

--- a/src/libs/interfaces/generator/parser.cpp
+++ b/src/libs/interfaces/generator/parser.cpp
@@ -32,8 +32,6 @@
 #include <iostream>
 #include <vector>
 
-#define CHECK_MESSAGE_TYPE_SIZE
-
 using namespace std;
 using namespace xmlpp;
 
@@ -591,14 +589,12 @@ InterfaceParser::parse()
 				throw InterfaceGeneratorInvalidContentException("no name for message");
 			}
 			msg_name = attr->get_value();
-#ifdef CHECK_MESSAGE_TYPE_SIZE
 			if (msg_name.length() > INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - 7) {
 				throw InterfaceGeneratorInvalidContentException(
 				  "Interface message name '%s' too long, max length is %u",
 				  msg_name.c_str(),
 				  INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - 7);
 			}
-#endif
 		} else {
 			throw InterfaceGeneratorInvalidContentException("message is not an element");
 		}

--- a/src/libs/interfaces/generator/parser.cpp
+++ b/src/libs/interfaces/generator/parser.cpp
@@ -25,6 +25,7 @@
 #include "exceptions.h"
 
 #include <interface/interface.h>
+#include <interface/message.h>
 #include <libxml++/libxml++.h>
 #include <utils/misc/string_conversions.h>
 
@@ -588,6 +589,12 @@ InterfaceParser::parse()
 				throw InterfaceGeneratorInvalidContentException("no name for message");
 			}
 			msg_name = attr->get_value();
+			if (msg_name.length() > INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - 7) {
+				throw InterfaceGeneratorInvalidContentException(
+				  "Interface message name '%s' too long, max length is %u",
+				  msg_name.c_str(),
+				  INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - 7);
+			}
 		} else {
 			throw InterfaceGeneratorInvalidContentException("message is not an element");
 		}

--- a/src/libs/interfaces/generator/parser.cpp
+++ b/src/libs/interfaces/generator/parser.cpp
@@ -32,6 +32,8 @@
 #include <iostream>
 #include <vector>
 
+//#define CHECK_MESSAGE_TYPE_SIZE
+
 using namespace std;
 using namespace xmlpp;
 
@@ -589,12 +591,14 @@ InterfaceParser::parse()
 				throw InterfaceGeneratorInvalidContentException("no name for message");
 			}
 			msg_name = attr->get_value();
+#ifdef CHECK_MESSAGE_TYPE_SIZE
 			if (msg_name.length() > INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - 7) {
 				throw InterfaceGeneratorInvalidContentException(
 				  "Interface message name '%s' too long, max length is %u",
 				  msg_name.c_str(),
 				  INTERFACE_MESSAGE_TYPE_SIZE_ - 1 - 7);
 			}
+#endif
 		} else {
 			throw InterfaceGeneratorInvalidContentException("message is not an element");
 		}


### PR DESCRIPTION
During syncing of fawkes interface messages from different fawkes instances via the BlackboardNetHandler the message type is truncated to `INTERFACE_MESSAGE_TYPE - 1` characters. However, when the serialized message arrives at the other fawkes node, a new blackboard interface message is generated. To trigger the creation of the correct message type, the truncated message type is compared with possible message types of the specific interface. This comparison is done over `INTERFACE_MESSAGE_TYPE` characters and thus include a null terminator, leading to a not recognized message type, whenever the original interface message type includes more than `INTERFACE_MESSAGE_TYPE - 1` characters. This PR corrects the number of characters which are compared to `INTERFACE_MESSAGE_TYPE - 1` characters.

Truncating the message type can also lead to possible collisions of different message types. A real strict policy would limit the maximum number of characters in a message type to `INTERFACE_MESSAGE_TYPE - 1`. This policy can be activated (introduced by this PR) by defining `CHECK_MESSAGE_TYPE_SIZE` during compilation. It is not defined by default.
Right now, 6 

A less strict policy checks for collisions during truncation and throws an appropriate Exception to interrupt the generation of the translated interface. It further outputs all collisions to make debugging as easy as possible.