### PR TITLE
Fix make target 'install'

### DIFF
--- a/etc/buildsys/btypes/rules_sysinstall.mk
+++ b/etc/buildsys/btypes/rules_sysinstall.mk
@@ -200,13 +200,16 @@ $(DESTDIR)$(EXEC_LIBDIR)/%.so: $(LIBDIR)/%.so
 	ln -sf "$(notdir $(subst $(LIBDIR),$(abspath $(DESTDIR)$(EXEC_LIBDIR)/$(INST_LIB_SUBDIR_$(call nametr,$*))),$<).$(SOVER_$(call nametr,$*)))" "$(subst $(LIBDIR),$(abspath $(DESTDIR)$(EXEC_LIBDIR)/$(INST_LIB_SUBDIR_$(call nametr,$*))),$<)" || exit $$?; \
 	)
 	$(SILENT) $(if $(HDRS_$(call nametr,$*)),$(foreach h,$(HDRS_$(call nametr,$*)), \
-	if [ -f "$(SRCDIR)/$h" ]; then \
-		echo -e "$(INDENT_PRINT)--- Copying header $h to $(DESTDIR)$(EXEC_INCDIR)/$(INST_HDRS_SUBDIR_$(call nametr,$*))/$(if $(HDR_RENAME_$h),$(HDR_RENAME_$h),$h)"; \
-		install -D -m 644 "$(SRCDIR)/$h" "$(DESTDIR)$(EXEC_INCDIR)/$(INST_HDRS_SUBDIR_$(call nametr,$*))/$(if $(HDR_RENAME_$h),$(HDR_RENAME_$h),$h)" || exit $$?; \
+	if [ -f "$(SRCDIR)/$h" ] ; then \
+		hpath=$(SRCDIR)/$h; \
+	elif [ -f "$(IFACESRCDIR)/$h" ]; then \
+		hpath=$(IFACESRCDIR)/$h; \
 	else \
 		echo -e "$(INDENT_PRINT)--- $(TRED)Header $h does not exist.$(TNORMAL)"; \
 		exit 1; \
 	fi; \
+	echo -e "$(INDENT_PRINT)--- Copying header $h to $(DESTDIR)$(EXEC_INCDIR)/$(INST_HDRS_SUBDIR_$(call nametr,$*))/$(if $(HDR_RENAME_$h),$(HDR_RENAME_$h),$h)"; \
+	install -D -m 644 "$$hpath" "$(DESTDIR)$(EXEC_INCDIR)/$(INST_HDRS_SUBDIR_$(call nametr,$*))/$(if $(HDR_RENAME_$h),$(HDR_RENAME_$h),$h)" || exit $$?; \
 	))
 
 #	$(SILENTSYMB) for h in $(HDRS_$(call nametr,$*)); do \

--- a/etc/buildsys/btypes/rules_sysinstall.mk
+++ b/etc/buildsys/btypes/rules_sysinstall.mk
@@ -74,7 +74,7 @@ $(INST_RESDIRS):
 	$(SILENTSYMB) if [ -d "$(RESDIR)/$@" ]; then	\
 		echo -e "$(INDENT_PRINT)[DIR] $(DESTDIR)$(TBOLDGRAY)$(RESDIR)/$@$(TNORMAL)"; \
 		mkdir -p $(DESTDIR)$(EXEC_RESDIR)/$@ || exit $?; \
-		echo -e "$(INDENT_PRINT)[CPY] $(PARENTDIR)$(TBOLDGRAY)$@(TNORMAL) -> $(DESTDIR)$(EXEC_RESDIR)/$@"; \
+		echo -e "$(INDENT_PRINT)[CPY] $(PARENTDIR)$(TBOLDGRAY)$@$(TNORMAL) -> $(DESTDIR)$(EXEC_RESDIR)/$@"; \
 		cp -af $(RESDIR)/$@/* $(DESTDIR)$(EXEC_RESDIR)/$@ || exit $$?; \
 	fi
 endif

--- a/etc/buildsys/btypes/rules_sysinstall.mk
+++ b/etc/buildsys/btypes/rules_sysinstall.mk
@@ -17,15 +17,15 @@ include $(BUILDSYSDIR)/btypes/rules_fawkes.mk
 include $(BUILDSYSDIR)/ext/gmsl
 
 # Plugins are installed to special directory
-$(foreach P,$(PLUGINS_all:$(PLUGINDIR)/%.so=%),$(eval INST_LIB_SUBDIR_$(call nametr,$P) = $(FFLIBSUBDIR)/plugins))
+$(foreach P,$(PLUGINS_build:$(PLUGINDIR)/%.so=%),$(eval INST_LIB_SUBDIR_$(call nametr,$P) = $(FFLIBSUBDIR)/plugins))
 
 # Library headers get subdir matching name if not set
-$(foreach P,$(LIBS_all:$(LIBDIR)/libfawkes%.so=%) $(LIBS_gui:$(LIBDIR)/libfawkes%.so=%),$(if $(and $(call not,$(INST_HDRS_SUBDIR_libfawkes$P)),$P),$(eval INST_HDRS_SUBDIR_libfawkes$P = $(P:_%=%))))
-$(foreach P,$(LIBS_all:$(LIBDIR)/libfv%.so=%) $(LIBS_gui:$(LIBDIR)/libfv%.so=%),$(if $(and $(call not,$(INST_HDRS_SUBDIR_libfv$P)),$P),$(eval INST_HDRS_SUBDIR_libfv$P = fv$P)))
+$(foreach P,$(LIBS_build:$(LIBDIR)/libfawkes%.so=%) $(LIBS_gui:$(LIBDIR)/libfawkes%.so=%),$(if $(and $(call not,$(INST_HDRS_SUBDIR_libfawkes$P)),$P),$(eval INST_HDRS_SUBDIR_libfawkes$P = $(P:_%=%))))
+$(foreach P,$(LIBS_build:$(LIBDIR)/libfv%.so=%) $(LIBS_gui:$(LIBDIR)/libfv%.so=%),$(if $(and $(call not,$(INST_HDRS_SUBDIR_libfv$P)),$P),$(eval INST_HDRS_SUBDIR_libfv$P = fv$P)))
 
 ifdef __buildsys_lua_mk_
 # Lua libraries are "inferred" and automatically installed to proper directory
-$(foreach L,$(LIBS_all:$(LIBDIR)/lua/%.so=%),$(if $L,$(eval INST_LIB_SUBDIR_lua_$(call nametr,$L) = $(FFLIBSUBDIR))))
+$(foreach L,$(LIBS_build:$(LIBDIR)/lua/%.so=%),$(if $L,$(eval INST_LIB_SUBDIR_lua_$(call nametr,$L) = $(FFLIBSUBDIR))))
 endif
 
 # Prefix man pages with proper path
@@ -49,7 +49,7 @@ endif
 endif
 
 .PHONY: install_targets
-install_targets: $(subst $(LIBDIR),$(DESTDIR)$(EXEC_LIBDIR),$(LIBS_all) $(LIBS_gui)) $(subst $(PLUGINDIR),$(DESTDIR)$(EXEC_PLUGINDIR),$(PLUGINS_all)) $(subst $(BINDIR),$(DESTDIR)$(EXEC_BINDIR),$(BINS_all) $(BINS_gui)) $(MANPAGES_install)
+install_targets: $(subst $(LIBDIR),$(DESTDIR)$(EXEC_LIBDIR),$(LIBS_build) $(LIBS_gui)) $(subst $(PLUGINDIR),$(DESTDIR)$(EXEC_PLUGINDIR),$(PLUGINS_build)) $(subst $(BINDIR),$(DESTDIR)$(EXEC_BINDIR),$(BINS_build) $(BINS_gui)) $(MANPAGES_install)
 
 .PHONY: install_resdirs $(INST_RESDIRS)
 install_resdirs: $(INST_RESDIRS)
@@ -146,22 +146,22 @@ endif
 # uninstall target to remove files from system
 .PHONY: uninstall
 uninstall: presubdirs subdirs
-ifneq ($(BINS_all)$(BINS_gui),)
-	$(SILENTSYMB)echo -e "$(INDENT_PRINT)--- Uninstalling binaries: $(subst $(BINDIR)/,,$(BINS_all) $(BINS_gui))"
-	$(SILENT)rm -f $(subst $(BINDIR),$(DESTDIR)$(EXEC_BINDIR),$(BINS_all) $(BINS_gui))
-	$(SILENT)$(foreach B,$(subst $(BINDIR)/,,$(BINS_all) $(BINS_gui)),$(if $(wildcard $(DESTDIR)$(EXEC_DFILEDIR)/$B.desktop),rm -f $(DESTDIR)$(EXEC_DFILEDIR)/$B.desktop;))
+ifneq ($(BINS_build)$(BINS_gui),)
+	$(SILENTSYMB)echo -e "$(INDENT_PRINT)--- Uninstalling binaries: $(subst $(BINDIR)/,,$(BINS_build) $(BINS_gui))"
+	$(SILENT)rm -f $(subst $(BINDIR),$(DESTDIR)$(EXEC_BINDIR),$(BINS_build) $(BINS_gui))
+	$(SILENT)$(foreach B,$(subst $(BINDIR)/,,$(BINS_build) $(BINS_gui)),$(if $(wildcard $(DESTDIR)$(EXEC_DFILEDIR)/$B.desktop),rm -f $(DESTDIR)$(EXEC_DFILEDIR)/$B.desktop;))
 endif
-ifneq ($(LIBS_all)$(LIBS_gui),)
-	$(SILENTSYMB)echo -e "$(INDENT_PRINT)--- Uninstalling libraries: $(subst $(LIBDIR)/,,$(LIBS_all) $(LIBS_gui))"
-	$(SILENT)$(foreach L,$(subst $(LIBDIR)/,,$(LIBS_all) $(LIBS_gui)), \
+ifneq ($(LIBS_build)$(LIBS_gui),)
+	$(SILENTSYMB)echo -e "$(INDENT_PRINT)--- Uninstalling libraries: $(subst $(LIBDIR)/,,$(LIBS_build) $(LIBS_gui))"
+	$(SILENT)$(foreach L,$(subst $(LIBDIR)/,,$(LIBS_build) $(LIBS_gui)), \
 	rm -f $(abspath $(DESTDIR)$(EXEC_LIBDIR)/$(INST_LIB_SUBDIR_$(call nametr,$(L:%.so=%))))/$L*; \
 	$(if $(HDRS_$(call nametr,$(L:%.so=%))), \
 	rm -f $(foreach h,$(HDRS_$(call nametr,$(L:%.so=%))),"$(DESTDIR)$(EXEC_INCDIR)/$(INST_HDRS_SUBDIR_$(call nametr,$(L:%.so=%)))/$(if $(HDR_RENAME_$h),$(HDR_RENAME_$h),$h)" ); \
 	))
 endif
-ifneq ($(PLUGINS_all)$(PLUGINS_gui),)
-	$(SILENTSYMB)echo -e "$(INDENT_PRINT)--- Uninstalling plugins: $(subst $(PLUGINDIR)/,,$(PLUGINS_all) $(PLUGINS_gui))"
-	$(SILENT)rm -f $(subst $(PLUGINDIR),$(DESTDIR)$(EXEC_PLUGINDIR),$(PLUGINS_all) $(PLUGINS_gui))
+ifneq ($(PLUGINS_build)$(PLUGINS_gui),)
+	$(SILENTSYMB)echo -e "$(INDENT_PRINT)--- Uninstalling plugins: $(subst $(PLUGINDIR)/,,$(PLUGINS_build) $(PLUGINS_gui))"
+	$(SILENT)rm -f $(subst $(PLUGINDIR),$(DESTDIR)$(EXEC_PLUGINDIR),$(PLUGINS_build) $(PLUGINS_gui))
 endif
 ifneq ($(INST_RESDIRS),)
 	$(SILENTSYMB)echo -e "$(INDENT_PRINT)--- Removing resource direcotries: $(INST_RESDIRS)"

--- a/src/plugins/flite/Makefile
+++ b/src/plugins/flite/Makefile
@@ -28,6 +28,8 @@ OBJS_all    = $(OBJS_flite)
 PLUGINS_all = $(PLUGINDIR)/flite.so
 
 ifeq ($(HAVE_FLITE)$(HAVE_ALSA),11)
+  CFLAGS += $(CFLAGS_ALSA)
+  LDFLAGS += $(LDFLAGS_ALSA)
   PLUGINS_build = $(PLUGINS_all)
 else
   ifneq ($(HAVE_FLITE),1)

--- a/src/plugins/flite/synth_thread.cpp
+++ b/src/plugins/flite/synth_thread.cpp
@@ -22,10 +22,10 @@
 
 #include "synth_thread.h"
 
+#include <alsa/asoundlib.h>
 #include <interfaces/SpeechSynthInterface.h>
 #include <utils/time/wait.h>
 
-#include <asoundlib.h>
 #include <cmath>
 
 using namespace fawkes;

--- a/src/plugins/mongodb/Makefile
+++ b/src/plugins/mongodb/Makefile
@@ -19,8 +19,6 @@ include $(BASEDIR)/etc/buildsys/config.mk
 include $(LIBSRCDIR)/utils/utils.mk
 include $(BUILDSYSDIR)/boost.mk
 
-PRESUBDIRS = aspect interfaces
-
 INCDIRS += $(INCDIRS_MONGODB)
 
 MONGODB_REQ_BOOST_LIBS = system filesystem
@@ -51,6 +49,7 @@ ifeq ($(HAVE_MONGODB_REQ_BOOST_LIBS),1)
 endif
 
 ifeq ($(HAVE_MONGODB)$(HAVE_CPP14)$(HAVE_MONGODB_REQ_BOOST_LIBS),111)
+  PRESUBDIRS = aspect interfaces
   PLUGINS_build = $(PLUGINS_all)
 else
   ifneq ($(HAVE_MONGODB),1)

--- a/src/plugins/pddl-planner/Makefile
+++ b/src/plugins/pddl-planner/Makefile
@@ -18,8 +18,6 @@ BASEDIR = ../../..
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/src/plugins/mongodb/mongodb.mk
 
-PRESUBDIRS = interfaces
-
 LIBS_pddl_planner = m fawkescore fawkesutils fawkesaspects fawkesbaseapp \
                       fawkesblackboard fawkesinterface fawkesrobotmemory \
                       PddlPlannerInterface
@@ -30,6 +28,8 @@ OBJS_all    = $(OBJS_pddl_planner)
 PLUGINS_all = $(PLUGINDIR)/pddl-planner.$(SOEXT)
 
 ifeq ($(HAVE_CPP11)$(HAVE_MONGODB),11)
+  PRESUBDIRS = interfaces
+
   CFLAGS  += $(CFLAGS_CPP11) $(CFLAGS_MONGODB)
   LDFLAGS += $(LDFLAGS_CTEMPLATE) $(LDFLAGS_MONGODB)
 

--- a/src/plugins/pddl-robot-memory/Makefile
+++ b/src/plugins/pddl-robot-memory/Makefile
@@ -19,8 +19,6 @@ include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/src/plugins/robot-memory/robot_memory.mk
 include $(BASEDIR)/src/plugins/pddl-robot-memory/ctemplate.mk
 
-PRESUBDIRS = interfaces
-
 LIBS_pddl_robot_memory = m fawkescore fawkesutils fawkesaspects fawkesbaseapp \
                          fawkesblackboard fawkesinterface fawkesrobotmemory \
                          PddlGenInterface
@@ -31,6 +29,8 @@ OBJS_all   = $(OBJS_pddl_robot_memory)
 PLUGINS_all = $(PLUGINDIR)/pddl-robot-memory.$(SOEXT)	  
 
 ifeq ($(HAVE_CPP11)$(HAVE_ROBOT_MEMORY)$(HAVE_CTEMPLATE),111)
+  PRESUBDIRS = interfaces
+
   CFLAGS  += $(CFLAGS_CPP11) $(CFLAGS_ROBOT_MEMORY)
   LDFLAGS += $(LDFLAGS_CTEMPLATE) $(LDFLAGS_ROBOT_MEMORY)
 

--- a/src/plugins/perception/pcl-db/Makefile
+++ b/src/plugins/perception/pcl-db/Makefile
@@ -23,8 +23,6 @@ include $(BASEDIR)/src/plugins/mongodb/mongodb.mk
 # Add -DUSE_TIMETRACKER to enable time tracking
 CFLAGS += -DUSE_TIMETRACKER
 
-PRESUBDIRS = interfaces
-
 ifeq ($(PCL_USES_OPENMP),1)
   ifneq ($(USE_OPENMP),1)
     CFLAGS  += $(CFLAGS_OPENMP)
@@ -57,6 +55,8 @@ PLUGINS_all = $(PLUGINDIR)/pcl-db-store.so \
               $(PLUGINDIR)/pcl-db-merge.so
 
 ifeq ($(HAVE_MONGODB)$(HAVE_PCL)$(HAVE_TF)$(HAVE_CPP11),1111)
+  PRESUBDIRS = interfaces
+
   CFLAGS += $(CFLAGS_PCL) $(CFLAGS_TF) $(CFLAGS_MONGODB) $(CFLAGS_CPP11)
   LDFLAGS += $(LDFLAGS_PCL) $(LDFLAGS_TF) $(LDFLAGS_MONGODB)
 

--- a/src/plugins/webview/Makefile
+++ b/src/plugins/webview/Makefile
@@ -45,7 +45,6 @@ PLUGINS_all = $(PLUGINDIR)/webview.so
 
 ifeq ($(HAVE_BOOST_LIBS)$(HAVE_LIBMICROHTTPD),11)
   PLUGINS_build = $(PLUGINS_all)
-  INST_RESDIRS = webview
 
   CFLAGS  += $(call boost-libs-cflags,$(REQ_BOOST_LIBS))
   LDFLAGS += $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))

--- a/src/plugins/webview/frontend/Makefile
+++ b/src/plugins/webview/frontend/Makefile
@@ -21,6 +21,7 @@ NPM = $(shell type -p npm)
 
 ifneq ($(NPM),)
   TARGETS_all += dist/index.html
+  INST_RESDIRS = webview
 
   SRCS_FRONTEND = $(shell find $(SRCDIR)/src/ -regex '.*\.\(html\|ts\|json\|js\|scss\)')
 else


### PR DESCRIPTION
Adapt the sysinstall target to recent changes in the build system.

This is a step towards fixing the FTBFS status in Fedora.