### PR TITLE
Keep sender info when copying an interface message

### DIFF
--- a/src/libs/interface/message.cpp
+++ b/src/libs/interface/message.cpp
@@ -90,16 +90,17 @@ Message::Message(const char *type)
  */
 Message::Message(const Message &mesg)
 {
-	message_id_    = 0;
-	hops_          = mesg.hops_;
-	enqueued_      = false;
-	num_fields_    = mesg.num_fields_;
-	data_size      = mesg.data_size;
-	data_ptr       = malloc(data_size);
-	data_ts        = (message_data_ts_t *)data_ptr;
-	_sender_id     = 0;
-	_type          = strdup(mesg._type);
-	time_enqueued_ = new Time(mesg.time_enqueued_);
+	message_id_         = 0;
+	hops_               = mesg.hops_;
+	enqueued_           = false;
+	num_fields_         = mesg.num_fields_;
+	data_size           = mesg.data_size;
+	data_ptr            = malloc(data_size);
+	data_ts             = (message_data_ts_t *)data_ptr;
+	_sender_id          = mesg.sender_id();
+	_sender_thread_name = strdup(mesg.sender_thread_name());
+	_type               = strdup(mesg._type);
+	time_enqueued_      = new Time(mesg.time_enqueued_);
 
 	_transmit_via_iface              = NULL;
 	sender_interface_instance_serial = 0;
@@ -118,13 +119,6 @@ Message::Message(const Message &mesg)
 		info_dest = &((*info_dest)->next);
 		info_src  = info_src->next;
 	}
-
-	Thread *t = Thread::current_thread_noexc();
-	if (t) {
-		_sender_thread_name = strdup(t->name());
-	} else {
-		_sender_thread_name = strdup("Unknown");
-	}
 }
 
 /** Copy constructor.
@@ -139,7 +133,8 @@ Message::Message(const Message *mesg)
 	data_size                        = mesg->data_size;
 	data_ptr                         = malloc(data_size);
 	data_ts                          = (message_data_ts_t *)data_ptr;
-	_sender_id                       = 0;
+	_sender_id                       = mesg->sender_id();
+	_sender_thread_name              = strdup(mesg->sender_thread_name());
 	_type                            = strdup(mesg->_type);
 	_transmit_via_iface              = NULL;
 	sender_interface_instance_serial = 0;
@@ -158,13 +153,6 @@ Message::Message(const Message *mesg)
 
 		info_dest = &((*info_dest)->next);
 		info_src  = info_src->next;
-	}
-
-	Thread *t = Thread::current_thread_noexc();
-	if (t) {
-		_sender_thread_name = strdup(t->name());
-	} else {
-		_sender_thread_name = strdup("Unknown");
 	}
 }
 

--- a/src/libs/interfaces/generator/cpp_generator.cpp
+++ b/src/libs/interfaces/generator/cpp_generator.cpp
@@ -891,14 +891,13 @@ CppInterfaceGenerator::write_message_ctor_dtor_cpp(FILE *                      f
 	        "/** Copy constructor.\n"
 	        " * @param m message to copy from\n"
 	        " */\n"
-	        "%s%s::%s(const %s *m) : %s(\"%s\")\n"
+	        "%s%s::%s(const %s *m) : %s(m)\n"
 	        "{\n",
 	        inclusion_prefix.c_str(),
 	        classname.c_str(),
 	        classname.c_str(),
 	        classname.c_str(),
-	        super_class.c_str(),
-	        classname.c_str());
+	        super_class.c_str());
 
 	fprintf(f,
 	        "  data_size = m->data_size;\n"

--- a/src/libs/interfaces/generator/cpp_generator.cpp
+++ b/src/libs/interfaces/generator/cpp_generator.cpp
@@ -592,7 +592,7 @@ CppInterfaceGenerator::write_message_ctor_dtor_h(FILE *                         
 	}
 
 	write_ctor_dtor_h(f, is, classname);
-	fprintf(f, "%s%s(const %s *m);\n", is.c_str(), classname.c_str(), classname.c_str());
+	fprintf(f, "%sexplicit %s(const %s *m);\n", is.c_str(), classname.c_str(), classname.c_str());
 }
 
 /** Write message clone method header.


### PR DESCRIPTION
When copy-constructing an interface message, copy the sender id and the thread name from the copied message instead of reinitializing them with 0 and the current thread's name respectively.

Also adapt the interface generator to actually use the copy constructor of `Message` when copy-constructing a message of a particular interface.

I encountered this bug while working on a skiller simulator, which would provide the same interface as the Skiller but without actually executing any skills. There, the skillgui would not get exclusive control because the message is copied and the copied message wouldn't contain the correct sender ID. This does not occur with the real skiller, because there, the message processing happens in lua and therefore, the message is never copied.