### PR TITLE
Fix underscores in compiler macros

### DIFF
--- a/src/libs/core/utils/lock_hashmap.h
+++ b/src/libs/core/utils/lock_hashmap.h
@@ -31,7 +31,7 @@
 #if __cplusplus >= 201103L || defined(_LIBCPP_VERSION)
 #	include <functional>
 #	include <unordered_map>
-#elif GLIBCXX___ > 20080305
+#elif __GLIBCXX__ > 20080305
 #	include <tr1/unordered_map>
 #else
 #	include <ext/hash_map>
@@ -45,7 +45,7 @@ template <class KeyType,
           class HashFunction = std::hash<KeyType>,
           class EqualKey     = std::equal_to<KeyType>>
 class LockHashMap : public std::unordered_map<KeyType, ValueType, HashFunction, EqualKey>
-#elif GLIBCXX___ > 20080305
+#elif __GLIBCXX__ > 20080305
           class HashFunction = std::tr1::hash<KeyType>,
           class EqualKey     = std::equal_to<KeyType>>
 class LockHashMap : public std::tr1::unordered_map<KeyType, ValueType, HashFunction, EqualKey>
@@ -96,7 +96,7 @@ LockHashMap<KeyType, ValueType, HashFunction, EqualKey>::LockHashMap(
   const LockHashMap<KeyType, ValueType, HashFunction, EqualKey> &lh)
 #if __cplusplus >= 201103L || defined(_LIBCPP_VERSION)
 : std::unordered_map<KeyType, ValueType, HashFunction, EqualKey>::unordered_map(lh)
-#elif GLIBCXX___ > 20080305
+#elif __GLIBCXX__ > 20080305
 : std::tr1::unordered_map<KeyType, ValueType, HashFunction, EqualKey>::unordered_map(lh)
 #else
 : gnu_cxx_::hash_map<KeyType, ValueType, HashFunction, EqualKey>::hash_map(lh)

--- a/src/libs/core/utils/lock_hashset.h
+++ b/src/libs/core/utils/lock_hashset.h
@@ -31,7 +31,7 @@
 #if __cplusplus >= 201103L || defined(_LIBCPP_VERSION)
 #	include <functional>
 #	include <unordered_set>
-#elif GLIBCXX___ > 20080305
+#elif __GLIBCXX__ > 20080305
 #	include <tr1/unordered_set>
 #else
 #	include <ext/hash_set>
@@ -44,7 +44,7 @@ template <class KeyType,
           class HashFunction = std::hash<KeyType>,
           class EqualKey     = std::equal_to<KeyType>>
 class LockHashSet : public std::unordered_set<KeyType, HashFunction, EqualKey>
-#elif GLIBCXX___ > 20080305
+#elif __GLIBCXX__ > 20080305
           class HashFunction = std::tr1::hash<KeyType>,
           class EqualKey     = std::equal_to<KeyType>>
 class LockHashSet : public std::tr1::unordered_set<KeyType, HashFunction, EqualKey>
@@ -97,7 +97,7 @@ LockHashSet<KeyType, HashFunction, EqualKey>::LockHashSet(
   const LockHashSet<KeyType, HashFunction, EqualKey> &lh)
 #if __cplusplus >= 201103L || defined(_LIBCPP_VERSION)
 : std::unordered_set<KeyType, HashFunction, EqualKey>::unordered_set(lh),
-#elif GLIBCXX___ > 20080305
+#elif __GLIBCXX__ > 20080305
 : std::tr1::unordered_set<KeyType, HashFunction, EqualKey>::unordered_set(lh),
 #else
 : gnu_cxx_::hash_set<KeyType, HashFunction, EqualKey>::hash_set(lh),

--- a/src/libs/fvutils/color/yuv.cpp
+++ b/src/libs/fvutils/color/yuv.cpp
@@ -411,7 +411,7 @@ yuv444packed_to_yuv422planar(const unsigned char *yuv444,
 	u                = yuv422 + wh;
 	v                = u + wh2;
 
-#ifdef ___OPENMP
+#ifdef _OPENMP
 #	pragma omp parallel for firstprivate(wh2) private(i, iy, iiy) shared(y, u, v, yuv444) \
 	  schedule(static)
 #endif
@@ -436,7 +436,7 @@ yuv444packed_to_yuv422packed(const unsigned char *yvu444,
 	unsigned int wh  = (width * height);
 	int          wh2 = wh >> 1;
 
-#ifdef ___OPENMP
+#ifdef _OPENMP
 #	pragma omp parallel for firstprivate(wh2) private(i, iiy) shared(yuv422, yvu444) schedule(static)
 #endif
 	for (i = 0; i < wh2; i += 4) {
@@ -463,7 +463,7 @@ yvu444packed_to_yuv422planar(const unsigned char *yvu444,
 	u                = yuv422 + wh;
 	v                = u + wh2;
 
-#ifdef ___OPENMP
+#ifdef _OPENMP
 #	pragma omp parallel for firstprivate(wh2) private(i, iy, iiy) shared(y, u, v, yvu444) \
 	  schedule(static)
 #endif
@@ -488,7 +488,7 @@ yvu444packed_to_yuv422packed(const unsigned char *yvu444,
 	unsigned int wh  = (width * height);
 	int          wh2 = wh >> 1;
 
-#ifdef ___OPENMP
+#ifdef _OPENMP
 #	pragma omp parallel for firstprivate(wh2) private(i, iiy) shared(yuv422, yvu444) schedule(static)
 #endif
 	for (i = 0; i < wh2; i += 4) {

--- a/src/libs/netcomm/utils/ntoh64.h
+++ b/src/libs/netcomm/utils/ntoh64.h
@@ -34,7 +34,7 @@
 
 #define hton64_(x) ntohll(x)
 
-#ifdef OPTIMIZE___
+#ifdef __OPTIMIZE__
 #	define ntoh64(x) ntoh64_(x)
 #	define hton64(x) ntoh64_(x)
 #else
@@ -51,6 +51,6 @@ hton64(uint64_t x)
 	return ntoh64_(x);
 }
 
-#endif // OPTIMIZE___
+#endif // __OPTIMIZE__
 
 #endif // NETCOMM_UTILS_NTOH64__

--- a/src/plugins/clips/feature_blackboard.cpp
+++ b/src/plugins/clips/feature_blackboard.cpp
@@ -311,7 +311,7 @@ BlackboardCLIPSFeature::clips_blackboard_preload(const std::string &env_name,
 		// no interface of this type registered yet, add deftemplate for it
 		Interface *iface = NULL;
 		try {
-			iface = blackboard_->open_for_reading(type.c_str(), "clips_blackboard_preload___");
+			iface = blackboard_->open_for_reading(type.c_str(), "__clips_blackboard_preload__");
 			clips_assert_interface_type(env_name, name, iface, type);
 			blackboard_->close(iface);
 			interfaces_[env_name].reading.insert(std::make_pair(type, std::list<fawkes::Interface *>()));

--- a/src/plugins/openrave/environment.cpp
+++ b/src/plugins/openrave/environment.cpp
@@ -498,9 +498,9 @@ OpenRaveEnvironment::run_graspplanning(const std::string &target_name,
 	// Now we can safely run our python code
 
 	// using python C API
-	PyObject *py_main = PyImport_AddModule("main___"); // borrowed reference
+	PyObject *py_main = PyImport_AddModule("__main__"); // borrowed reference
 	if (!py_main) {
-		// main___ should always exist
+		// __main__ should always exist
 		fclose(py_file);
 		Py_EndInterpreter(int_state);
 		PyThreadState_Swap(cur_state);
@@ -511,7 +511,7 @@ OpenRaveEnvironment::run_graspplanning(const std::string &target_name,
 	}
 	PyObject *py_dict = PyModule_GetDict(py_main); // borrowed reference
 	if (!py_dict) {
-		// main___ should have a dictionary
+		// __main__ should have a dictionary
 		fclose(py_file);
 		Py_Finalize();
 		throw fawkes::Exception(


### PR DESCRIPTION
Some compiler macros (and other variables and names) were changed erroneously when adapting the underscores in private member variable names. Change them back to the correct names.

Candidates for renaming were found with `git grep '___'`.

This fixes #93.