### PR TITLE
Add (RGB/BGR)_Float as colorspaces

### DIFF
--- a/src/libs/fvutils/color/colorspaces.cpp
+++ b/src/libs/fvutils/color/colorspaces.cpp
@@ -80,6 +80,10 @@ colorspace_by_name(const char *mode)
 		return CARTESIAN_3D_DOUBLE;
 	} else if (strcmp(mode, "CARTESIAN_3D_FLOAT_RGB") == 0) {
 		return CARTESIAN_3D_FLOAT_RGB;
+	} else if (strcmp(mode, "RGB_FLOAT") == 0) {
+		return RGB_FLOAT;
+	} else if (strcmp(mode, "BGR_FLOAT") == 0) {
+		return BGR_FLOAT;
 	} else {
 		return CS_UNKNOWN;
 	}
@@ -114,6 +118,8 @@ colorspace_to_string(colorspace_t colorspace)
 	case CARTESIAN_3D_DOUBLE: return "CARTESIAN_3D_DOUBLE";
 	case CARTESIAN_3D_FLOAT_RGB: return "CARTESIAN_3D_FLOAT_RGB";
 	case RGB_PLANAR: return "RGB_PLANAR";
+	case RGB_FLOAT: return "RGB_FLOAT";
+	case BGR_FLOAT: return "BGR_FLOAT";
 	default: return "CS_UNKNOWN";
 	}
 }
@@ -164,6 +170,9 @@ colorspace_buffer_size(colorspace_t cspace, unsigned int width, unsigned int hei
 	case CARTESIAN_3D_DOUBLE: return (3 * (size_t)width * height * sizeof(double));
 
 	case CARTESIAN_3D_FLOAT_RGB: return (4 * (size_t)width * height * sizeof(float));
+
+	case RGB_FLOAT:
+	case BGR_FLOAT: return (3 * (size_t)width * height * sizeof(float));
 
 	case CS_UNKNOWN:
 	case COLORSPACE_N: return 0;

--- a/src/libs/fvutils/color/colorspaces.h
+++ b/src/libs/fvutils/color/colorspaces.h
@@ -72,7 +72,9 @@ typedef enum {
 
 	RGB_PLANAR    = 26, /**< RGB with three successive planes of R, G, and B each */
 	YUV420_PLANAR = 27, /**< YUV 4:2:0 in planar format */
-	COLORSPACE_N  = 28  /**< number of colorspaces */
+	RGB_FLOAT     = 28, /**< RGB, 12 bytes per pixel, 4 byte per color, ordered, line by line */
+	BGR_FLOAT     = 29, /**< BGR, 12 bytes per pixel, 4 byte per color, ordered, line by line */
+	COLORSPACE_N  = 30  /**< number of colorspaces */
 } colorspace_t;
 
 size_t         colorspace_buffer_size(colorspace_t cspace, unsigned int width, unsigned int height);

--- a/src/libs/fvutils/color/conversions.cpp
+++ b/src/libs/fvutils/color/conversions.cpp
@@ -134,6 +134,17 @@ convert(colorspace_t         from,
 		yvu444packed_to_yuv422planar(src, dst, width, height);
 	} else if ((from == YVU444_PACKED) && (to == YUV422_PACKED)) {
 		yvu444packed_to_yuv422packed(src, dst, width, height);
+	} else if ((from == RGB) && (to == RGB_FLOAT)) {
+		rgb_to_rgbfloat(src, dst, width, height);
+	} else if ((from == RGB_FLOAT) && (to == RGB)) {
+		rgbfloat_to_rgb(src, dst, width, height);
+	} else if ((from == BGR) && (to == BGR_FLOAT)) {
+		rgb_to_rgbfloat(src, dst, width, height); // does the job, see below
+	} else if ((from == BGR_FLOAT) && (to == BGR)) {
+		rgbfloat_to_rgb(src,
+		                dst,
+		                width,
+		                height); // does the job, bc byte order does not play a role for conversion
 	} else {
 		throw fawkes::Exception("Cannot convert image data from %s to %s",
 		                        colorspace_to_string(from),

--- a/src/libs/fvutils/color/rgb.cpp
+++ b/src/libs/fvutils/color/rgb.cpp
@@ -200,4 +200,40 @@ gray8_to_rgb_plainc(const unsigned char *mono8,
 	}
 }
 
+/** Convert RGB to RGB_FLOAT
+ * @param rgb RGB source buffer
+ * @param rgb_float RGB_FLOAT destination buffer
+ * @param width width in pixels
+ * @param height height in pixels
+ */
+void
+rgb_to_rgbfloat(const unsigned char *rgb,
+                unsigned char *      rgb_float,
+                unsigned int         width,
+                unsigned int         height)
+{
+	float *float_rgb = reinterpret_cast<float *>(rgb_float);
+	for (unsigned int i = 0; i < 3 * width * height; ++i) {
+		*float_rgb++ = static_cast<float>(*rgb++);
+	}
+}
+
+/** Convert RGB_FLOAT to RGB
+ * @param rgb_float RGB_FLOAT source buffer
+ * @param rgb RGB destination buffer
+ * @param width width in pixels
+ * @param height height in pixels
+ */
+void
+rgbfloat_to_rgb(const unsigned char *rgb_float,
+                unsigned char *      rgb,
+                unsigned int         width,
+                unsigned int         height)
+{
+	const float *float_rgb = reinterpret_cast<const float *>(rgb_float);
+	for (unsigned int i = 0; i < 3 * width * height; ++i) {
+		*rgb++ = static_cast<unsigned char>(*float_rgb++);
+	}
+}
+
 } // end namespace firevision

--- a/src/libs/fvutils/color/rgb.h
+++ b/src/libs/fvutils/color/rgb.h
@@ -98,6 +98,16 @@ void gray8_to_rgb_plainc(const unsigned char *mono8,
                          unsigned int         width,
                          unsigned int         height);
 
+void rgb_to_rgbfloat(const unsigned char *rgb,
+                     unsigned char *      rgb_float,
+                     unsigned int         width,
+                     unsigned int         height);
+
+void rgbfloat_to_rgb(const unsigned char *rgb_float,
+                     unsigned char *      rgb,
+                     unsigned int         width,
+                     unsigned int         height);
+
 void bgr_to_rgb_plainc(const unsigned char *BGR,
                        unsigned char *      RGB,
                        unsigned int         width,


### PR DESCRIPTION
This colorspace is useful, as it is widely used as input data format for tensorflow graphs.

By introducing the conversion methods directly into the firevision library, the use of specialized conversion methods in each plugin itself is reduced, leading to more flexible code.