### PR TITLE
Add plugin to simulate skill execution

### DIFF
--- a/src/plugins/refboxcomm/Makefile
+++ b/src/plugins/refboxcomm/Makefile
@@ -22,7 +22,7 @@ LIBS_refboxcomm = fawkescore fawkesutils fawkesaspects fawkesblackboard \
 		  fawkesinterface fawkesnetcomm \
 		  GameStateInterface SwitchInterface
 OBJS_refboxcomm = $(patsubst %.cpp,%.o,$(subst $(SRCDIR)/,,$(wildcard $(SRCDIR)/*.cpp))) \
-                  processor/processor.o processor/state_handler.o processor/remotebb.o
+                  processor/processor.o processor/state_handler.o processor/remotebb.o processor/enums.o
 OBJS_all    = $(OBJS_refboxcomm)
 PLUGINS_all = $(PLUGINDIR)/refboxcomm.so
 PLUGINS_build = $(PLUGINS_all)

--- a/src/plugins/skiller-simulator/Makefile
+++ b/src/plugins/skiller-simulator/Makefile
@@ -1,0 +1,29 @@
+#*****************************************************************************
+#                      Makefile Build System for Fawkes
+#                            -------------------
+#   Created on Mon 06 May 2019 08:54:03 CEST
+#   Copyright (C) 2019 by Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../..
+
+include $(BASEDIR)/etc/buildsys/config.mk
+include $(LIBSRCDIR)/utils/utils.mk
+
+LIBS_skiller_simulator  = fawkescore fawkesutils fawkesaspects \
+                          fawkesblackboard fawkesinterface fawkeslogging \
+                          SkillerInterface
+OBJS_skiller_simulator  = skiller_simulator_plugin.o exec_thread.o
+OBJS_all                = $(OBJS_skiller_simulator)
+PLUGINS_all             = $(PLUGINDIR)/skiller-simulator.so
+PLUGINS_build           = $(PLUGINS_all)
+
+include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -1,0 +1,166 @@
+/***************************************************************************
+ *  exec_thread.cpp - Simulate skill execution
+ *
+ *  Created: Mon 06 May 2019 08:51:53 CEST 08:51
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "exec_thread.h"
+
+using namespace std;
+using namespace fawkes;
+
+/** @class SkillerSimulatorExecutionThread "exec_thread.h"
+ *  Simulated Skill Execution Thread.
+ *  This thread pretends to execute a skill, similar to the real skiller execution thread.
+ *
+ *  @see SkillerExecutionThread
+ *  @author Till Hofmann
+ */
+
+/** Constructor. */
+SkillerSimulatorExecutionThread::SkillerSimulatorExecutionThread()
+: Thread("SkillerSimulatorExecutionThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+{
+}
+
+void
+SkillerSimulatorExecutionThread::init()
+{
+	skiller_if_      = blackboard->open_for_writing<SkillerInterface>("Skiller");
+	skill_runtime_   = config->get_float_or_default("/plugins/skiller-simulation/skill-runtime", 1);
+	skill_starttime_ = Time();
+}
+
+void
+SkillerSimulatorExecutionThread::loop()
+{
+	bool skill_enqueued  = false;
+	bool write_interface = false;
+	while (!skiller_if_->msgq_empty()) {
+		if (skiller_if_->msgq_first_is<SkillerInterface::AcquireControlMessage>()) {
+			SkillerInterface::AcquireControlMessage m =
+			  skiller_if_->msgq_first<SkillerInterface::AcquireControlMessage>();
+			if (skiller_if_->exclusive_controller() == 0) {
+				logger->log_debug(name(),
+				                  "%s is new exclusive controller (ID %u)",
+				                  m.sender_thread_name(),
+				                  m.sender_id());
+				skiller_if_->set_exclusive_controller(m.sender_id());
+				write_interface = true;
+			} else if (m.is_steal_control()) {
+				logger->log_warn(name(), "%s steals exclusive control", m.sender_thread_name());
+				skiller_if_->set_exclusive_controller(m.sender_id());
+				skiller_if_->set_msgid(m.id());
+				write_interface = true;
+			} else {
+				logger->log_warn(
+				  name(),
+				  "%s tried to acquire exclusive control, but another controller exists already",
+				  m.sender_thread_name());
+			}
+		} else if (skiller_if_->msgq_first_is<SkillerInterface::ReleaseControlMessage>()) {
+			SkillerInterface::ReleaseControlMessage m =
+			  skiller_if_->msgq_first<SkillerInterface::ReleaseControlMessage>();
+			if (skiller_if_->exclusive_controller() == m.sender_id()) {
+				logger->log_debug(name(), "%s releases exclusive control", m.sender_thread_name());
+			} else if (skiller_if_->exclusive_controller() != 0) {
+				logger->log_warn(name(),
+				                 "%s tried to release exclusive control, but it's not the controller",
+				                 m.sender_thread_name());
+			}
+		} else if (skiller_if_->msgq_first_is<SkillerInterface::ExecSkillMessage>()) {
+			SkillerInterface::ExecSkillMessage m =
+			  skiller_if_->msgq_first<SkillerInterface::ExecSkillMessage>();
+			if (skiller_if_->exclusive_controller() == 0
+			    || skiller_if_->exclusive_controller() == m.sender_id()) {
+				if (skill_enqueued) {
+					logger->log_warn(name(),
+					                 "More than one skill string enqueued, ignoring previous string (%s).",
+					                 skiller_if_->skill_string());
+				}
+				if (skiller_if_->exclusive_controller() == 0) {
+					std::string sender = m.sender_thread_name();
+					if (sender == "Unknown") {
+						sender = "Remote";
+					}
+					logger->log_info(name(),
+					                 "%s executed '%s' without any exclusive controller",
+					                 sender.c_str(),
+					                 m.skill_string());
+				} else {
+					logger->log_info(name(), "%s executes '%s'", m.sender_thread_name(), m.skill_string());
+				}
+			}
+			if (skiller_if_->status() == SkillerInterface::S_RUNNING) {
+				logger->log_info(name(),
+				                 "Aborting execution of previous skill string '%s' for new goal",
+				                 skiller_if_->skill_string());
+			}
+			skiller_if_->set_skill_string(m.skill_string());
+			skiller_if_->set_msgid(m.id());
+			skiller_if_->set_error("");
+			skiller_if_->set_status(SkillerInterface::S_RUNNING);
+			skill_starttime_ = Time();
+			write_interface  = true;
+			skill_enqueued   = true;
+		} else if (skiller_if_->msgq_first_is<SkillerInterface::StopExecMessage>()) {
+			SkillerInterface::StopExecMessage m =
+			  skiller_if_->msgq_first<SkillerInterface::StopExecMessage>();
+			if (skiller_if_->exclusive_controller() == m.sender_id()) {
+				logger->log_debug(name(),
+				                  "Stopping execution of '%s' on request",
+				                  skiller_if_->skill_string());
+				skiller_if_->set_skill_string("");
+				skiller_if_->set_error("");
+				skiller_if_->set_msgid(m.id());
+				skiller_if_->set_status(SkillerInterface::S_INACTIVE);
+			} else {
+				std::string sender = m.sender_thread_name();
+				if (sender == "Unknown") {
+					sender = "Remote";
+				}
+				logger->log_debug(name(), "%s sent stop without any exclusive controller", sender.c_str());
+			}
+		} else {
+			logger->log_warn(name(), "Unhandled message in skiller interface");
+		}
+		skiller_if_->msgq_pop();
+	}
+
+	if (!skill_enqueued) {
+		if (skiller_if_->status() == SkillerInterface::S_RUNNING) {
+			Time now = Time();
+			if (Time() > skill_starttime_ + skill_runtime_) {
+				logger->log_info(name(), "Skill '%s' is final", skiller_if_->skill_string());
+				skiller_if_->set_skill_string("");
+				skiller_if_->set_status(SkillerInterface::S_FINAL);
+				write_interface = true;
+			}
+		}
+	}
+
+	if (write_interface) {
+		skiller_if_->write();
+	}
+}
+
+void
+SkillerSimulatorExecutionThread::finalize()
+{
+	blackboard->close(skiller_if_);
+}

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -53,57 +53,57 @@ SkillerSimulatorExecutionThread::loop()
 	bool write_interface = false;
 	while (!skiller_if_->msgq_empty()) {
 		if (skiller_if_->msgq_first_is<SkillerInterface::AcquireControlMessage>()) {
-			SkillerInterface::AcquireControlMessage m =
+			SkillerInterface::AcquireControlMessage *m =
 			  skiller_if_->msgq_first<SkillerInterface::AcquireControlMessage>();
 			if (skiller_if_->exclusive_controller() == 0) {
 				logger->log_debug(name(),
 				                  "%s is new exclusive controller (ID %u)",
-				                  m.sender_thread_name(),
-				                  m.sender_id());
-				skiller_if_->set_exclusive_controller(m.sender_id());
+				                  m->sender_thread_name(),
+				                  m->sender_id());
+				skiller_if_->set_exclusive_controller(m->sender_id());
 				write_interface = true;
-			} else if (m.is_steal_control()) {
-				logger->log_warn(name(), "%s steals exclusive control", m.sender_thread_name());
-				skiller_if_->set_exclusive_controller(m.sender_id());
-				skiller_if_->set_msgid(m.id());
+			} else if (m->is_steal_control()) {
+				logger->log_warn(name(), "%s steals exclusive control", m->sender_thread_name());
+				skiller_if_->set_exclusive_controller(m->sender_id());
+				skiller_if_->set_msgid(m->id());
 				write_interface = true;
 			} else {
 				logger->log_warn(
 				  name(),
 				  "%s tried to acquire exclusive control, but another controller exists already",
-				  m.sender_thread_name());
+				  m->sender_thread_name());
 			}
 		} else if (skiller_if_->msgq_first_is<SkillerInterface::ReleaseControlMessage>()) {
-			SkillerInterface::ReleaseControlMessage m =
+			SkillerInterface::ReleaseControlMessage *m =
 			  skiller_if_->msgq_first<SkillerInterface::ReleaseControlMessage>();
-			if (skiller_if_->exclusive_controller() == m.sender_id()) {
-				logger->log_debug(name(), "%s releases exclusive control", m.sender_thread_name());
+			if (skiller_if_->exclusive_controller() == m->sender_id()) {
+				logger->log_debug(name(), "%s releases exclusive control", m->sender_thread_name());
 			} else if (skiller_if_->exclusive_controller() != 0) {
 				logger->log_warn(name(),
 				                 "%s tried to release exclusive control, but it's not the controller",
-				                 m.sender_thread_name());
+				                 m->sender_thread_name());
 			}
 		} else if (skiller_if_->msgq_first_is<SkillerInterface::ExecSkillMessage>()) {
-			SkillerInterface::ExecSkillMessage m =
+			SkillerInterface::ExecSkillMessage *m =
 			  skiller_if_->msgq_first<SkillerInterface::ExecSkillMessage>();
 			if (skiller_if_->exclusive_controller() == 0
-			    || skiller_if_->exclusive_controller() == m.sender_id()) {
+			    || skiller_if_->exclusive_controller() == m->sender_id()) {
 				if (skill_enqueued) {
 					logger->log_warn(name(),
 					                 "More than one skill string enqueued, ignoring previous string (%s).",
 					                 skiller_if_->skill_string());
 				}
 				if (skiller_if_->exclusive_controller() == 0) {
-					std::string sender = m.sender_thread_name();
+					std::string sender = m->sender_thread_name();
 					if (sender == "Unknown") {
 						sender = "Remote";
 					}
 					logger->log_info(name(),
 					                 "%s executed '%s' without any exclusive controller",
 					                 sender.c_str(),
-					                 m.skill_string());
+					                 m->skill_string());
 				} else {
-					logger->log_info(name(), "%s executes '%s'", m.sender_thread_name(), m.skill_string());
+					logger->log_info(name(), "%s executes '%s'", m->sender_thread_name(), m->skill_string());
 				}
 			}
 			if (skiller_if_->status() == SkillerInterface::S_RUNNING) {
@@ -111,26 +111,26 @@ SkillerSimulatorExecutionThread::loop()
 				                 "Aborting execution of previous skill string '%s' for new goal",
 				                 skiller_if_->skill_string());
 			}
-			skiller_if_->set_skill_string(m.skill_string());
-			skiller_if_->set_msgid(m.id());
+			skiller_if_->set_skill_string(m->skill_string());
+			skiller_if_->set_msgid(m->id());
 			skiller_if_->set_error("");
 			skiller_if_->set_status(SkillerInterface::S_RUNNING);
 			skill_starttime_ = Time();
 			write_interface  = true;
 			skill_enqueued   = true;
 		} else if (skiller_if_->msgq_first_is<SkillerInterface::StopExecMessage>()) {
-			SkillerInterface::StopExecMessage m =
+			SkillerInterface::StopExecMessage *m =
 			  skiller_if_->msgq_first<SkillerInterface::StopExecMessage>();
-			if (skiller_if_->exclusive_controller() == m.sender_id()) {
+			if (skiller_if_->exclusive_controller() == m->sender_id()) {
 				logger->log_debug(name(),
 				                  "Stopping execution of '%s' on request",
 				                  skiller_if_->skill_string());
 				skiller_if_->set_skill_string("");
 				skiller_if_->set_error("");
-				skiller_if_->set_msgid(m.id());
+				skiller_if_->set_msgid(m->id());
 				skiller_if_->set_status(SkillerInterface::S_INACTIVE);
 			} else {
-				std::string sender = m.sender_thread_name();
+				std::string sender = m->sender_thread_name();
 				if (sender == "Unknown") {
 					sender = "Remote";
 				}

--- a/src/plugins/skiller-simulator/exec_thread.h
+++ b/src/plugins/skiller-simulator/exec_thread.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+ *  exec_thread.h - Simulate skill execution
+ *
+ *  Created: Mon 06 May 2019 08:53:11 CEST 08:53
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef _PLUGINS_SKILLER_SIMULATOR_EXEC_THREAD_H_
+#	define _PLUGINS_SKILLER_SIMULATOR_EXEC_THREAD_H_
+
+#endif /* !_PLUGINS_SKILLER_SIMULATOR_EXEC_THREAD_H_ */
+
+#include <aspect/blackboard.h>
+#include <aspect/blocked_timing.h>
+#include <aspect/clock.h>
+#include <aspect/configurable.h>
+#include <aspect/logging.h>
+#include <core/threading/thread.h>
+#include <interfaces/SkillerInterface.h>
+#include <plugins/skiller/skiller_feature.h>
+
+class SkillerSimulatorExecutionThread : public fawkes::Thread,
+                                        public fawkes::BlockedTimingAspect,
+                                        public fawkes::LoggingAspect,
+                                        public fawkes::BlackBoardAspect,
+                                        public fawkes::ConfigurableAspect
+{
+public:
+	SkillerSimulatorExecutionThread();
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
+
+protected:
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
+
+private:
+	fawkes::SkillerInterface *skiller_if_;
+	double                    skill_runtime_;
+	fawkes::Time              skill_starttime_;
+};

--- a/src/plugins/skiller-simulator/skiller_simulator_plugin.cpp
+++ b/src/plugins/skiller-simulator/skiller_simulator_plugin.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *  skiller_simulator_plugin.cpp - Simulate the execution of a skill
+ *
+ *  Created: Mon 06 May 2019 09:01:14 CEST 09:01
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "skiller_simulator_plugin.h"
+
+#include "exec_thread.h"
+
+using namespace fawkes;
+
+/** @class SkillerSimulatorPlugin <plugins/skiller-simulator/skiller_simulator_plugin.cpp>
+ *  Skill Simulated Execution Plugin.
+ *  This plugin acts like the skiller plugin but only simulates skill execution.
+ *
+ *  @author Till Hofmann
+ */
+
+/** Constructor.
+ *  @param config Fawkes configuration to read config values from.
+ */
+SkillerSimulatorPlugin::SkillerSimulatorPlugin(Configuration *config) : Plugin(config)
+{
+	thread_list.push_back(new SkillerSimulatorExecutionThread());
+}
+
+PLUGIN_DESCRIPTION("Simulated Skill Execution")
+EXPORT_PLUGIN(SkillerSimulatorPlugin)

--- a/src/plugins/skiller-simulator/skiller_simulator_plugin.h
+++ b/src/plugins/skiller-simulator/skiller_simulator_plugin.h
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *  skiller_plugin.h - Simulate the execution of a skill
+ *
+ *  Created: Mon 06 May 2019 09:01:39 CEST 09:01
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef _PLUGINS_SKILLER_SIMULATOR_EXEC_PLUGIN_H_
+#define _PLUGINS_SKILLER_SIMULATOR_EXEC_PLUGIN_H_
+
+#include <core/plugin.h>
+
+class SkillerSimulatorPlugin : public fawkes::Plugin
+{
+public:
+	explicit SkillerSimulatorPlugin(fawkes::Configuration *config);
+};
+
+#endif /* !_PLUGINS_SKILLER_SIMULATOR_EXEC_PLUGIN_H_ */


### PR DESCRIPTION
This provides a new plugin `skiller-simulator` that provides the same interface as the real skiller but never really executes a skill. Currently, the implementation is rather simple and is more a mockup than a simulation, each skill just takes a fixed amount of time to execute. However, this is already sufficient for many purposes related to agent development.

In the future, this could possibly be extended by having per-skill execution times or even by reading old log files to get a realistic execution time.

This implements #114.