### PR TITLE
robot memory: run thread in continuous mode

### DIFF
--- a/src/plugins/robot-memory/Makefile
+++ b/src/plugins/robot-memory/Makefile
@@ -29,6 +29,9 @@ OBJS_robot_memory += $(patsubst %.cpp,%.o,$(patsubst qa/%,,$(subst $(SRCDIR)/,,$
 OBJS_all    = $(OBJS_robot_memory)
 PLUGINS_all = $(PLUGINDIR)/robot-memory.so
 
+# Enable this flag for time tracking
+#CFLAGS += -DUSE_TIMETRACKER
+
 ifeq ($(HAVE_ROBOT_MEMORY)$(HAVE_CPP11),11)
   CFLAGS += $(CFLAGS_ROBOT_MEMORY) $(CFLAGS_CPP11)
   LDFLAGS += $(LDFLAGS_ROBOT_MEMORY)

--- a/src/plugins/robot-memory/computables/computables_manager.cpp
+++ b/src/plugins/robot-memory/computables/computables_manager.cpp
@@ -67,6 +67,19 @@ ComputablesManager::ComputablesManager(fawkes::Configuration *config, RobotMemor
 #endif
 }
 
+/**
+ * Copy-construct a ComputablesManager.
+ * Do *not* copy-construct the computables that are managed by the manager, but
+ * only call the constructor with the other's config and robot memory.
+ * If you want to use a computable with the new manager, you will need to
+ * register it again.
+ * @param other A reference to the other ComputablesManager to copy from.
+ */
+ComputablesManager::ComputablesManager(const ComputablesManager &other)
+: ComputablesManager(other.config_, other.robot_memory_)
+{
+}
+
 ComputablesManager::~ComputablesManager()
 {
 #ifdef USE_TIMETRACKER

--- a/src/plugins/robot-memory/computables/computables_manager.h
+++ b/src/plugins/robot-memory/computables/computables_manager.h
@@ -84,6 +84,9 @@ public:
 	}
 
 private:
+	ComputablesManager(const ComputablesManager &other);
+
+private:
 	std::string            name = "RobotMemory ComputablesManager";
 	fawkes::Configuration *config_;
 	RobotMemory *          robot_memory_;

--- a/src/plugins/robot-memory/computables/computables_manager.h
+++ b/src/plugins/robot-memory/computables/computables_manager.h
@@ -37,6 +37,12 @@
 //forward declaration
 class RobotMemory;
 
+namespace fawkes {
+#ifdef USE_TIMETRACKER
+class TimeTracker;
+#endif
+} // namespace fawkes
+
 class ComputablesManager
 {
 public:
@@ -86,6 +92,13 @@ private:
 	std::string             matching_test_collection_;
 	//cached querries as ((collection, querry), cached_until)
 	std::map<std::tuple<std::string, std::string>, long long> cached_querries_;
+#ifdef USE_TIMETRACKER
+	fawkes::TimeTracker *tt_;
+	unsigned int         tt_loopcount_;
+	unsigned int         ttc_cleanup_;
+	unsigned int         ttc_cleanup_inner_loop_;
+	unsigned int         ttc_cleanup_remove_query_;
+#endif
 };
 
 #endif /* FAWKES_SRC_PLUGINS_ROBOT_MEMORY_COMPUTABLES_COMPUTABLES_MANAGER_H_ */

--- a/src/plugins/robot-memory/event_trigger_manager.h
+++ b/src/plugins/robot-memory/event_trigger_manager.h
@@ -36,6 +36,12 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <list>
 
+namespace fawkes {
+#ifdef USE_TIMETRACKER
+class TimeTracker;
+#endif
+} // namespace fawkes
+
 class EventTriggerManager
 {
 	/// Access for robot memory to use the check_events function in the loop
@@ -114,6 +120,15 @@ private:
 	bool                     cfg_debug_;
 
 	std::list<EventTrigger *> triggers;
+
+#ifdef USE_TIMETRACKER
+	fawkes::TimeTracker *tt_;
+	unsigned int         tt_loopcount_;
+	unsigned int         ttc_trigger_loop_;
+	unsigned int         ttc_callback_loop_;
+	unsigned int         ttc_callback_;
+	unsigned int         ttc_reinit_;
+#endif
 };
 
 #endif //FAWKES_SRC_PLUGINS_ROBOT_MEMORY_EVENT_TRIGGER_MANAGER_H_

--- a/src/plugins/robot-memory/robot_memory.h
+++ b/src/plugins/robot-memory/robot_memory.h
@@ -38,7 +38,10 @@
 
 namespace fawkes {
 class RobotMemoryInterface;
-}
+#ifdef USE_TIMETRACKER
+class TimeTracker;
+#endif
+} // namespace fawkes
 
 class RobotMemory
 {
@@ -206,6 +209,13 @@ private:
 	bool                 is_distributed_database(const std::string &dbcollection);
 	mongocxx::client *   get_mongodb_client(const std::string &collection);
 	mongocxx::collection get_collection(const std::string &dbcollection);
+
+#ifdef USE_TIMETRACKER
+	fawkes::TimeTracker *tt_;
+	unsigned int         tt_loopcount_;
+	unsigned int         ttc_events_;
+	unsigned int         ttc_cleanup_;
+#endif
 };
 
 #endif /* FAWKES_SRC_PLUGINS_ROBOT_MEMORY_ROBOT_MEMORY_H_ */

--- a/src/plugins/robot-memory/robot_memory_thread.h
+++ b/src/plugins/robot-memory/robot_memory_thread.h
@@ -43,6 +43,9 @@
 namespace fawkes {
 class Mutex;
 class RobotMemoryInterface;
+#ifdef USE_TIMETRACKER
+class TimeTracker;
+#endif
 } // namespace fawkes
 
 class RobotMemoryThread : public fawkes::Thread,
@@ -76,6 +79,13 @@ private:
 	fawkes::RobotMemoryIniFin robot_memory_inifin_;
 	BlackboardComputable *    blackboard_computable;
 	TransformComputable *     transform_computable;
+
+#ifdef USE_TIMETRACKER
+	fawkes::TimeTracker *tt_;
+	unsigned int         tt_loopcount_;
+	unsigned int         ttc_msgproc_;
+	unsigned int         ttc_rmloop_;
+#endif
 };
 
 #endif

--- a/src/plugins/robot-memory/robot_memory_thread.h
+++ b/src/plugins/robot-memory/robot_memory_thread.h
@@ -43,6 +43,7 @@
 namespace fawkes {
 class Mutex;
 class RobotMemoryInterface;
+class TimeWait;
 #ifdef USE_TIMETRACKER
 class TimeTracker;
 #endif
@@ -53,7 +54,6 @@ class RobotMemoryThread : public fawkes::Thread,
                           public fawkes::ConfigurableAspect,
                           public fawkes::ClockAspect,
                           public fawkes::MongoDBAspect,
-                          public fawkes::BlockedTimingAspect,
                           public fawkes::BlackBoardAspect,
                           public fawkes::TransformAspect,
                           public fawkes::AspectProviderAspect
@@ -79,6 +79,8 @@ private:
 	fawkes::RobotMemoryIniFin robot_memory_inifin_;
 	BlackboardComputable *    blackboard_computable;
 	TransformComputable *     transform_computable;
+
+	fawkes::TimeWait *timewait_;
 
 #ifdef USE_TIMETRACKER
 	fawkes::TimeTracker *tt_;


### PR DESCRIPTION
Decouple the thread from the main loop and let it run continuously.
Robot memory takes a long time to process trigger events, which blocks
the main loop and results in a lot of loop time warnings.

By default, use the main loop time as desired loop time and wait at the
end of the loop if the loop completed faster than desired. The loop time
can be overwritten in the config.

The disadvantage of running it continuously is that the triggers do not
run in the SENSOR_PROCESS hook anymore but may be triggered at any time.
However, as the thread takes too long and therefore is decoupled from
the main loop anyway, this is already happening now. Thus, this should
do no harm.

Also add some time tracking to robot memory, which can be enabled by setting the respective CFLAG.

Running the thread in continuous mode also speeds up the processing:
With RM running in the hook:
```
TimeTracker stats - class times
==================================================================
Class 'RM Trigger Trigger Loop'
  avg=0.868563 (868.563 ms)
  dev=1.30284 (1302.84 ms)
  res=100 results
Class 'RM Trigger Callback Loop'
  avg=1.29669 (1296.69 ms)
  dev=1.26287 (1262.87 ms)
  res=50 results
Class 'RM Trigger Single Callback'
  avg=0.14003 (140.03 ms)
  dev=0.199821 (199.821 ms)
  res=463 results
Class 'RM Trigger Reinit' has no results.

TimeTracker stats - class times
==================================================================
Class 'RobotMemory Cleanup Function Call'
  avg=1.18e-06 (0.00118 ms)
  dev=4.936e-07 (0.0004936 ms)
  res=100 results
Class 'RobotMemory Cleanup Inner Loop' has no results.
Class 'RobotMemory Cleanup Database Remove Query' has no results.


TimeTracker stats - class times
==================================================================
Class 'RobotMemory Events'
  avg=0.926768 (926.768 ms)
  dev=1.39011 (1390.11 ms)
  res=100 results
Class 'RobotMemory Cleanup'
  avg=3.921e-05 (0.03921 ms)
  dev=1.84866e-05 (0.0184866 ms)
  res=100 results


TimeTracker stats - class times
==================================================================
Class 'Message Processing'
  avg=2.28e-06 (0.00228 ms)
  dev=8.432e-07 (0.0008432 ms)
  res=100 results
Class 'Robot Memory Processing Loop'
  avg=0.926826 (926.826 ms)
  dev=1.39009 (1390.09 ms)
  res=100 results
```

With the thread running continuously:
```
TimeTracker stats - class times
==================================================================
Class 'RM Trigger Trigger Loop'
  avg=0.24906 (249.06 ms)
  dev=0.457098 (457.098 ms)
  res=85 results
Class 'RM Trigger Callback Loop'
  avg=1.16027 (1160.27 ms)
  dev=0.803269 (803.269 ms)
  res=14 results
Class 'RM Trigger Single Callback'
  avg=0.0938942 (93.8942 ms)
  dev=0.155746 (155.746 ms)
  res=173 results
Class 'RM Trigger Reinit' has no results.


TimeTracker stats - class times
==================================================================
Class 'RobotMemory Cleanup Function Call'
  avg=1.88235e-06 (0.00188235 ms)
  dev=1.08789e-06 (0.00108789 ms)
  res=85 results
Class 'RobotMemory Cleanup Inner Loop' has no results.
Class 'RobotMemory Cleanup Database Remove Query' has no results.


TimeTracker stats - class times
==================================================================
Class 'RobotMemory Events'
  avg=0.317522 (317.522 ms)
  dev=0.582702 (582.702 ms)
  res=85 results
Class 'RobotMemory Cleanup'
  avg=2.02235e-05 (0.0202235 ms)
  dev=2.70347e-05 (0.0270347 ms)
  res=85 results


TimeTracker stats - class times
==================================================================
Class 'Message Processing'
  avg=4.29412e-06 (0.00429412 ms)
  dev=1.30934e-06 (0.00130934 ms)
  res=85 results
Class 'Robot Memory Processing Loop'
  avg=0.317566 (317.566 ms)
  dev=0.582706 (582.706 ms)
  res=85 results
```

These numbers should be taken with a grain of salt, but the general tendency is clear enough.