### PR TITLE
buildsys: expand globs in git ls-files with git, not the shell

### DIFF
--- a/etc/buildsys/format.mk
+++ b/etc/buildsys/format.mk
@@ -23,8 +23,8 @@ format-modified-clang:
 	$(SILENT) echo -e "$(INDENT_PRINT)[FMT] Formatting modified files (git)"
 	$(SILENTSYMB)if type -p clang-format >/dev/null; then \
 		pushd $(SRCDIR) >/dev/null; \
-		MODIFIED_FILES=$$(git ls-files -m *.{h,cpp}); \
-		UNTRACKED_FILES=$$(git ls-files --exclude-standard --others *.{h,cpp}); \
+		MODIFIED_FILES=$$(git ls-files -m \*.{h,cpp}); \
+		UNTRACKED_FILES=$$(git ls-files --exclude-standard --others \*.{h,cpp}); \
 		FILES=$$(echo "$$MODIFIED_FILES" "$$UNTRACKED_FILES" | tr ' ' '\n' | sort -u); \
 		if [ -n "$$FILES" ]; then \
 			if type -p parallel >/dev/null; then \
@@ -44,7 +44,7 @@ format-all:
 	$(SILENT) echo -e "$(INDENT_PRINT)[FMT] Formatting all local files (git)"
 	$(SILENTSYMB)if type -p clang-format >/dev/null; then \
 		pushd $(SRCDIR) >/dev/null; \
-		FILES=$$(git ls-files *.{h,cpp}); \
+		FILES=$$(git ls-files \*.{h,cpp}); \
 		if [ -n "$$FILES" ]; then \
 			if type -p parallel >/dev/null; then \
 				parallel -u --will-cite --bar clang-format -i ::: $$FILES; \
@@ -62,7 +62,7 @@ format-all:
 format-diff:
 	$(SILENTSYMB)if type -p clang-format >/dev/null; then \
 		pushd $(SRCDIR) >/dev/null; \
-		FILES=$$(git ls-files *.{h,cpp}); \
+		FILES=$$(git ls-files \*.{h,cpp}); \
 		if [ -n "$$FILES" ]; then \
 			for f in $$FILES; do \
 				DIFF=$$(diff -u $$f <(clang-format $$f)); \

--- a/etc/buildsys/root/check.mk
+++ b/etc/buildsys/root/check.mk
@@ -53,7 +53,7 @@ format-check: check-parallel
 			for f in $$OFFENDING_FILES; do \
 				echo -e "$(INDENT_PRINT)$(TRED)--> $$f is not properly formatted$(TNORMAL)"; \
 			done; \
-			NUM_FILES=$$(git ls-files *.{h,cpp} | wc -l); \
+			NUM_FILES=$$(git ls-files \*.{h,cpp} | wc -l); \
 			BAD_FILES=$$(wc -w <<< "$$OFFENDING_FILES"); \
 			echo -e "$(INDENT_PRINT)$(TRED)--> $$BAD_FILES/$$NUM_FILES have bad formatting.$(TNORMAL)"; \
 			exit 1; \

--- a/etc/buildsys/root/format.mk
+++ b/etc/buildsys/root/format.mk
@@ -24,7 +24,7 @@ __buildsys_root_format_mk_ := 1
 format-clang: check-parallel
 	$(SILENT) echo -e "$(INDENT_PRINT)[FMT] Formatting full tree"
 	$(SILENTSYMB)if type -p clang-format >/dev/null; then \
-		ALL_FILES=$$(git ls-files *.{h,cpp}); \
+		ALL_FILES=$$(git ls-files \*.{h,cpp}); \
 		if type -p parallel >/dev/null; then \
 			parallel -u --will-cite --bar clang-format -i ::: $$ALL_FILES; \
 		else \
@@ -39,7 +39,7 @@ format-clang: check-parallel
 format-modified-clang: check-parallel
 	$(SILENT) echo -e "$(INDENT_PRINT)[FMT] Formatting modified files (git)"
 	$(SILENTSYMB)if type -p clang-format >/dev/null; then \
-		ALL_FILES=$$(git ls-files -m *.{h,cpp}); \
+		ALL_FILES=$$(git ls-files -m \*.{h,cpp}); \
 		if type -p parallel >/dev/null; then \
 			parallel -u --will-cite --bar clang-format -i ::: $$ALL_FILES; \
 		else \
@@ -72,7 +72,7 @@ format-emacs: check-parallel
 	$(SILENT) echo -e "$(INDENT_PRINT)[FMT] Formatting (emacs) where necessary"
 	$(SILENT) echo -e "$(INDENT_PRINT)[FMT] $(TYELLOW)Use 'format' target to use clang-format$(TNORMAL)"
 	$(SILENTSYMB)if type -p emacs >/dev/null; then \
-		ALL_FILES=$$(git ls-files *.{h,cpp}); \
+		ALL_FILES=$$(git ls-files \*.{h,cpp}); \
 		if type -p parallel >/dev/null; then \
 			export FAWKES_BASEDIR=$(abspath $(FAWKES_BASEDIR)); \
 			parallel -u --will-cite --bar --results /tmp/emacs-format -- emacs -q --batch {} -l $(abspath $(FAWKES_BASEDIR))/etc/format-scripts/emacs-format-cpp.el -f format-code ::: $$ALL_FILES; \

--- a/etc/format-scripts/check-all-files.sh
+++ b/etc/format-scripts/check-all-files.sh
@@ -16,7 +16,7 @@
 
 SCRIPT_PATH=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 
-ALL_FILES=$(git ls-files *.{h,cpp})
+ALL_FILES=$(git ls-files \*.{h,cpp})
 if type -p parallel >/dev/null; then
 	OFFENDING_FILES=$(parallel --will-cite --bar $SCRIPT_PATH/check-file.sh ::: $ALL_FILES)
 else

--- a/etc/format-scripts/check-branch-files.sh
+++ b/etc/format-scripts/check-branch-files.sh
@@ -33,7 +33,7 @@ MERGE_BASE=$($DIFF --old-line-format='' --new-line-format='' \
              | head -1)
 
 AFFECTED_FILES=$(git diff --name-only $MERGE_BASE HEAD | grep -E '\.(cpp|h)$' | paste -sd " " -)
-MODIFIED_FILES=$(git ls-files -m *.{h,cpp})
+MODIFIED_FILES=$(git ls-files -m \*.{h,cpp})
 
 # If no (C++) files are affected we are done
 if [ -z "$AFFECTED_FILES" -a -z "$MODIFIED_FILES" ]; then


### PR DESCRIPTION
If we call `git ls-files *.{h,cpp}`, then (depending on the shell), the
expansion of `*` may already be done by the shell instead of git. This
is undesired, as the shell does not list files in sub-directories, in
contrast to git. Thus, to make sure that we list all files, escape the
glob `*` so we always pass it to git. This issue occurs when using zsh,
but probably may also occur with bash, depending on the shell
configuration.

To test:
```
$ cd src/plugins/robot-memory/
$ vim computables/computables_manager.cpp
[ change the formatting ]
$ make format
```

Without this change, the file `computables/computables_manager.cpp` would not be re-formatted (at least when using zsh as shell).