### PR TITLE
clips-executive: add function wm-robmem-flush

### DIFF
--- a/src/plugins/clips-executive/clips/wm-robmem-sync.clp
+++ b/src/plugins/clips-executive/clips/wm-robmem-sync.clp
@@ -185,6 +185,12 @@
 	(retract ?wi)
 )
 
+(deffunction wm-robmem-flush ()
+	(bind ?query (bson-create))
+	(robmem-remove ?*WM-ROBMEM-SYNC-COLLECTION* ?query)
+	(bson-destroy ?query)
+)
+
 
 (deffunction wm-robmem-sync-create-fact-doc (?wf ?identity ?update-timestamp)
 	(bind ?doc (bson-create))


### PR DESCRIPTION
The function simply removes all documents from the synced robot memory
collection.