### PR TITLE
mongodb: bind instance to wildcard IP

### DIFF
--- a/src/plugins/mongodb/mongodb_instance_config.cpp
+++ b/src/plugins/mongodb/mongodb_instance_config.cpp
@@ -101,7 +101,7 @@ MongoDBInstanceConfig::MongoDBInstanceConfig(Configuration *config,
 		}
 	}
 
-	argv_ = {"mongod", "--port", std::to_string(port_), "--dbpath", data_path_};
+	argv_ = {"mongod", "--bind_ip_all", "--port", std::to_string(port_), "--dbpath", data_path_};
 
 	if (!log_path_.empty()) {
 		if (log_append_) {


### PR DESCRIPTION
With mongodb 3.6, the default changed from wildcard bind to localhost.
This commit spawns mongodb with --bind_ip_all, restoring the wildcard
bind.