### PR TITLE
add new realsense2 plugin 

### DIFF
--- a/cfg/conf.d/realsense2.yaml
+++ b/cfg/conf.d/realsense2.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+---
+doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/realsense2
+---
+realsense2:
+  # Frame ID of the PointCloud
+  frame_id: "cam_conveyor"
+
+  # ID of the PointCloud
+  pcl_id: "/camera/depth/points"
+
+  # If true, the camera will be enabled/disabled on incoming Enable/Disable
+  # messages. If false, switch messages will be ignored.
+  # use_switch: true
+
+  # Number of retries after unsuccessful polling before restarting the camera
+  # restart_after_num_errors: 50
+
+  # Section to set the Realsense device options
+  device_options:
+    # Laser power from 0 - 15 as integer
+    laser_power: 15

--- a/cfg/conf.d/realsense2.yaml
+++ b/cfg/conf.d/realsense2.yaml
@@ -12,10 +12,14 @@ realsense2:
 
   # If true, the camera will be enabled/disabled on incoming Enable/Disable
   # messages. If false, switch messages will be ignored.
-  # use_switch: true
+  use_switch: true
+
+  # Desired Frame rate. Device will try deliver new frames in time.
+  # 0 for don't care
+  frame_rate: 30
 
   # Number of retries after unsuccessful polling before restarting the camera
-  # restart_after_num_errors: 50
+  restart_after_num_errors: 50
 
   # Section to set the Realsense device options
   device_options:

--- a/src/plugins/Makefile
+++ b/src/plugins/Makefile
@@ -20,7 +20,7 @@ include $(BASEDIR)/etc/buildsys/config.mk
 SUBDIRS	= bbsync bblogger webview ttmainloop rrd \
 	  laser imu flite festival joystick openrave \
 	  katana jaco pantilt roomba nao robotino \
-	  bumblebee2 realsense perception amcl \
+	  bumblebee2 realsense realsense2 perception amcl \
 	  skiller luaagent \
 	  laser-filter laser-lines laser-cluster laser-pointclouds \
 	  static_transforms navgraph navgraph-clusters navgraph-generator colli \

--- a/src/plugins/realsense2/Makefile
+++ b/src/plugins/realsense2/Makefile
@@ -37,7 +37,6 @@ REALSENSE_MIN_VERSION = 2.16.0
 
 ifeq ($(shell $(PKGCONFIG) --exists realsense2; echo $$?),0)
     ifeq ($(shell $(PKGCONFIG) --atleast-version $(REALSENSE_MIN_VERSION) realsense2; echo $$?),0)
-        CFLAGS  += -DHAVE_REALSENSE2
 	CFLAGS  += $(shell $(PKGCONFIG) --cflags realsense2)
 	LDFLAGS += $(shell $(PKGCONFIG) --libs realsense2)
         LIBS_realsense2 += realsense2

--- a/src/plugins/realsense2/Makefile
+++ b/src/plugins/realsense2/Makefile
@@ -20,9 +20,11 @@ include $(BASEDIR)/etc/buildsys/config.mk
 include $(BUILDSYSDIR)/pcl.mk
 include $(BUILDCONFDIR)/tf/tf.mk
 
-CFLAGS += $(CFLAGS_CPP11)
-CFLAGS  += $(CFLAGS_TF) $(CFLAGS_PCL) $(CFFLAGS_conveyor_pose)
-LDFLAGS += $(LDFLAGS_TF) $(LDFLAGS_PCL)
+CFLAGS  +=  $(CFLAGS_CPP11)
+CFLAGS  +=  $(CFLAGS_TF) $(CFLAGS_PCL) $(CFFLAGS_conveyor_pose)
+CFLAGS  += `$(PKGCONFIG) --cflags realsense2`
+LDFLAGS +=  $(LDFLAGS_TF) $(LDFLAGS_PCL)
+LDFLAGS += `$(PKGCONFIG) --libs realsense2`
 
 LIBS_realsense2 = m fawkescore fawkesutils fawkesaspects fawkesbaseapp \
                       fawkesblackboard fawkesinterface \
@@ -33,29 +35,19 @@ OBJS_realsense2 = realsense2_plugin.o realsense2_thread.o
 OBJS_all    = $(OBJS_realsense2)
 PLUGINS_all = $(PLUGINDIR)/realsense2.$(SOEXT)
 
-REALSENSE2_INCLUDE_PATHS_ = /usr/include/librealsense2 /usr/local/include/librealsense2
-REALSENSE_INCLUDE_PATHS_ = /usr/include/librealsense /usr/local/include/librealsense
+REALSENSE_MIN_VERSION = 2.16.0
 
-ifneq ($(wildcard $(addsuffix /rs.h,$(REALSENSE2_INCLUDE_PATHS_))),)
-  # The old librealsense has been moved to librealsense1, librealsense is now
-  # librealsense2.
-  CFLAGS += -DHAVE_REALSENSE2
-  LIBS_realsense2 += realsense2
-  PLUGINS_build = $(PLUGINS_all)
-else ifneq ($(wildcard $(addsuffix /rs.h,$(REALSENSE_INCLUDE_PATHS_))),)
-  # No librealsense2 but there is a librealsense.
-  # Check its version by checking for RS_API_MAJOR_VERSION in the header.
-  REALSENSE_VERSION=$(shell awk \
-    '/^\#define\s+RS2_API_MAJOR_VERSION\s+\S+/{ print $$3; }' \
-    $(firstword $(wildcard $(addsuffix /rs.h,$(REALSENSE_INCLUDE_PATHS_)))))
-  ifeq ($(REALSENSE_VERSION),2)
-    LIBS_realsense2 += realsense2
-    PLUGINS_build = $(PLUGINS_all)
-  else
-    WARN_TARGETS += warning_librealsense_version
-  endif
+ifeq ($(shell $(PKGCONFIG) --exists realsense2; echo $$?),0)
+    ifeq ($(shell $(PKGCONFIG) --atleast-version $(REALSENSE_MIN_VERSION) realsense2; echo $$?),0)
+        CFLAGS += -DHAVE_REALSENSE2
+        LIBS_realsense2 += realsense2
+        PLUGINS_build = $(PLUGINS_all)
+    else
+        WARN_TARGETS += warning_librealsense_version
+	REALSENSE_VERSION = $(shell $(PKGCONFIG) --modversion realsense2)
+    endif
 else
-  WARN_TARGETS += warning_librealsense
+    WARN_TARGETS += warning_librealsense
 endif
 
 ifeq ($(OBJSSUBMAKE),1)
@@ -63,9 +55,9 @@ all: $(WARN_TARGETS)
 
 .PHONY: warning_librealsense warning_librealsense_version
 warning_librealsense:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense Plugin$(TNORMAL) (librealsense2 not found)"
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense2 Plugin$(TNORMAL) (librealsense2 not found)"
 warning_librealsense_version:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense Plugin$(TNORMAL) (incompatible librealsense version $(REALSENSE_VERSION))"
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense2 Plugin$(TNORMAL) (incompatible librealsense version $(REALSENSE_VERSION); required >= $(REALSENSE_MIN_VERSION))"
 endif
 
 include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/realsense2/Makefile
+++ b/src/plugins/realsense2/Makefile
@@ -4,6 +4,7 @@
 #   Created on Mon Jun 13 17:09:44 2016
 #   Copyright (C) 2016 by Johannes Rothe
 #                 2018 by Till Hofmann
+#                 2019 by Christoph Gollok
 #
 #*****************************************************************************
 #

--- a/src/plugins/realsense2/Makefile
+++ b/src/plugins/realsense2/Makefile
@@ -1,0 +1,70 @@
+#*****************************************************************************
+#         Makefile Build System for Fawkes: realsense Plugin
+#                            -------------------
+#   Created on Mon Jun 13 17:09:44 2016
+#   Copyright (C) 2016 by Johannes Rothe
+#                 2018 by Till Hofmann
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../..
+include $(BASEDIR)/etc/buildsys/config.mk
+include $(BUILDSYSDIR)/pcl.mk
+include $(BUILDCONFDIR)/tf/tf.mk
+
+CFLAGS += $(CFLAGS_CPP11)
+CFLAGS  += $(CFLAGS_TF) $(CFLAGS_PCL) $(CFFLAGS_conveyor_pose)
+LDFLAGS += $(LDFLAGS_TF) $(LDFLAGS_PCL)
+
+LIBS_realsense2 = m fawkescore fawkesutils fawkesaspects fawkesbaseapp \
+                      fawkesblackboard fawkesinterface \
+                      fawkespcl_utils SwitchInterface
+
+OBJS_realsense2 = realsense2_plugin.o realsense2_thread.o 
+
+OBJS_all    = $(OBJS_realsense2)
+PLUGINS_all = $(PLUGINDIR)/realsense2.$(SOEXT)
+
+REALSENSE2_INCLUDE_PATHS_ = /usr/include/librealsense2 /usr/local/include/librealsense2
+REALSENSE_INCLUDE_PATHS_ = /usr/include/librealsense /usr/local/include/librealsense
+
+ifneq ($(wildcard $(addsuffix /rs.h,$(REALSENSE2_INCLUDE_PATHS_))),)
+  # The old librealsense has been moved to librealsense1, librealsense is now
+  # librealsense2.
+  CFLAGS += -DHAVE_REALSENSE2
+  LIBS_realsense2 += realsense2
+  PLUGINS_build = $(PLUGINS_all)
+else ifneq ($(wildcard $(addsuffix /rs.h,$(REALSENSE_INCLUDE_PATHS_))),)
+  # No librealsense2 but there is a librealsense.
+  # Check its version by checking for RS_API_MAJOR_VERSION in the header.
+  REALSENSE_VERSION=$(shell awk \
+    '/^\#define\s+RS2_API_MAJOR_VERSION\s+\S+/{ print $$3; }' \
+    $(firstword $(wildcard $(addsuffix /rs.h,$(REALSENSE_INCLUDE_PATHS_)))))
+  ifeq ($(REALSENSE_VERSION),2)
+    LIBS_realsense2 += realsense2
+    PLUGINS_build = $(PLUGINS_all)
+  else
+    WARN_TARGETS += warning_librealsense_version
+  endif
+else
+  WARN_TARGETS += warning_librealsense
+endif
+
+ifeq ($(OBJSSUBMAKE),1)
+all: $(WARN_TARGETS)
+
+.PHONY: warning_librealsense warning_librealsense_version
+warning_librealsense:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense Plugin$(TNORMAL) (librealsense2 not found)"
+warning_librealsense_version:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense Plugin$(TNORMAL) (incompatible librealsense version $(REALSENSE_VERSION))"
+endif
+
+include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/realsense2/Makefile
+++ b/src/plugins/realsense2/Makefile
@@ -22,9 +22,7 @@ include $(BUILDCONFDIR)/tf/tf.mk
 
 CFLAGS  +=  $(CFLAGS_CPP11)
 CFLAGS  +=  $(CFLAGS_TF) $(CFLAGS_PCL) $(CFFLAGS_conveyor_pose)
-CFLAGS  += `$(PKGCONFIG) --cflags realsense2`
 LDFLAGS +=  $(LDFLAGS_TF) $(LDFLAGS_PCL)
-LDFLAGS += `$(PKGCONFIG) --libs realsense2`
 
 LIBS_realsense2 = m fawkescore fawkesutils fawkesaspects fawkesbaseapp \
                       fawkesblackboard fawkesinterface \
@@ -39,7 +37,9 @@ REALSENSE_MIN_VERSION = 2.16.0
 
 ifeq ($(shell $(PKGCONFIG) --exists realsense2; echo $$?),0)
     ifeq ($(shell $(PKGCONFIG) --atleast-version $(REALSENSE_MIN_VERSION) realsense2; echo $$?),0)
-        CFLAGS += -DHAVE_REALSENSE2
+        CFLAGS  += -DHAVE_REALSENSE2
+	CFLAGS  += $(shell $(PKGCONFIG) --cflags realsense2)
+	LDFLAGS += $(shell $(PKGCONFIG) --libs realsense2)
         LIBS_realsense2 += realsense2
         PLUGINS_build = $(PLUGINS_all)
     else

--- a/src/plugins/realsense2/realsense2_plugin.cpp
+++ b/src/plugins/realsense2/realsense2_plugin.cpp
@@ -1,0 +1,46 @@
+
+/***************************************************************************
+ *  realsense2_plugin.cpp - realsense2
+ *
+ *  Plugin created: Wed May 22 10:09:22 2018
+
+ *  Copyright  2019 Christoph Gollok
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "realsense2_thread.h"
+
+#include <core/plugin.h>
+
+using namespace fawkes;
+
+/** Driver for the Intel RealSense2 cameras.
+ * @author Christoph Gollok
+ */
+class Realsense2Plugin : public fawkes::Plugin
+{
+public:
+	/** Constructor
+   * @param config Fakwes configuration
+   */
+	explicit Realsense2Plugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new Realsense2Thread());
+	}
+};
+
+PLUGIN_DESCRIPTION("Driver for Intel RealSense2 camera")
+EXPORT_PLUGIN(Realsense2Plugin)

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -99,10 +99,9 @@ Realsense2Thread::loop()
 	}
 	if (rs_pipe_->poll_for_frames(&rs_data_)) {
 		rs2::frame depth_frame = rs_data_.first(RS2_STREAM_DEPTH);
-		logger->log_info(name(), "GOT RS2 DEPTH FRAME");
-		error_counter_        = 0;
-		const uint16_t *image = reinterpret_cast<const uint16_t *>(depth_frame.get_data());
-		Cloud::iterator it    = realsense_depth_->begin();
+		error_counter_         = 0;
+		const uint16_t *image  = reinterpret_cast<const uint16_t *>(depth_frame.get_data());
+		Cloud::iterator it     = realsense_depth_->begin();
 		for (int y = 0; y < intrinsics_.height; y++) {
 			for (int x = 0; x < intrinsics_.width; x++) {
 				float scaled_depth = camera_scale_ * (static_cast<float>(*image));
@@ -201,10 +200,12 @@ Realsense2Thread::get_camera(rs2::device &dev)
 			return false;
 		} else {
 			logger->log_info(name(), "found devices: %d", devlist.size());
-			if (devlist.front().is<rs400::advanced_mode>())
+			if (devlist.front().is<rs400::advanced_mode>()) {
 				dev = devlist.front().as<rs400::advanced_mode>();
-			else
-				dev = dev = devlist.front();
+			} else {
+				dev = devlist.front();
+			}
+
 			std::string dev_name = "Unknown Device";
 			if (dev.supports(RS2_CAMERA_INFO_NAME)) {
 				dev_name = dev.get_info(RS2_CAMERA_INFO_NAME);

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -244,7 +244,64 @@ void
 Realsense2Thread::enable_depth_stream()
 {
 
+    std::cout << "ENABLE DEPTH_STREAM:" << std::endl;
+    try {
+        rs2::depth_sensor depth_sensor = rs_device_.first<rs2::depth_sensor>();
+        if (depth_sensor.supports(RS2_OPTION_EMITTER_ENABLED)){
+            depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 1.f); // Enable emitter
+            depth_enabled_ = true;
+        }
+        if (depth_sensor.supports(RS2_OPTION_LASER_POWER)){
+            rs2::option_range range = depth_sensor.get_option_range(RS2_OPTION_LASER_POWER);
+            depth_sensor.set_option(RS2_OPTION_LASER_POWER, range.max); // Set max power
+            depth_enabled_ = true;
+        }
+
+    }
+    catch (const rs2::error & e)
+    {
+        std::cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << std::endl;
+        return;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        return;
+    }
 }
+
+/*
+ * Disable the depth stream from rs_device
+ */
+void
+Realsense2Thread::disable_depth_stream()
+{
+
+    std::cout << "DISABLE DEPTH_STREAM:" << std::endl;
+    try {
+        rs2::depth_sensor depth_sensor = rs_device_.first<rs2::depth_sensor>();
+            if (depth_sensor.supports(RS2_OPTION_EMITTER_ENABLED)){
+                depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 0.f); // Disable emitter
+                depth_enabled_ = false;
+            }
+            if (depth_sensor.supports(RS2_OPTION_LASER_POWER)){
+                depth_sensor.set_option(RS2_OPTION_LASER_POWER, 0.f); // Disable laser
+                depth_enabled_ = false;
+            }
+
+    }
+    catch (const rs2::error & e)
+    {
+        std::cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << std::endl;
+        return;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        return;
+    }
+}
+
 
 /*
  * printout and free the rs_error if available

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -72,9 +72,8 @@ Realsense2Thread::init()
 	realsense_depth_->resize(0);
 	pcl_manager->add_pointcloud(pcl_id_.c_str(), realsense_depth_refptr_);
 
-	rs_pipe_ = new rs2::pipeline();
-
-	camera_running_ = start_camera();
+	rs_pipe_    = new rs2::pipeline();
+	rs_context_ = new rs2::context();
 }
 
 void
@@ -192,7 +191,6 @@ void
 Realsense2Thread::get_camera(rs2::device &dev)
 {
 	try {
-		rs_context_              = new rs2::context();
 		rs2::device_list devlist = rs_context_->query_devices();
 		if (devlist.size() == 0) {
 			std::cerr << "No device connected, please connect a RealSense device" << std::endl;

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -45,10 +45,12 @@ Realsense2Thread::init()
 {
 	// set config values
 	const std::string cfg_prefix = "/realsense2/";
-	frame_id_                    = config->get_string(cfg_prefix + "frame_id");
-	pcl_id_                      = config->get_string(cfg_prefix + "pcl_id");
+	frame_id_ = config->get_string_or_default((cfg_prefix + "frame_id").c_str(), "cam_conveyor");
+	pcl_id_ = config->get_string_or_default((cfg_prefix + "pcl_id").c_str(), "/camera/depth/points");
+	switch_if_name_ =
+	  config->get_string_or_default((cfg_prefix + "switch_if_name").c_str(), "realsense2");
 	restart_after_num_errors_ =
-	  config->get_uint_or_default(std::string(cfg_prefix + "restart_after_num_errors").c_str(), 50);
+	  config->get_uint_or_default((cfg_prefix + "restart_after_num_errors").c_str(), 50);
 
 	cfg_use_switch_ = config->get_bool_or_default((cfg_prefix + "use_switch").c_str(), true);
 
@@ -58,7 +60,7 @@ Realsense2Thread::init()
 		logger->log_info(name(), "Switch will be ignored");
 	}
 
-	switch_if_ = blackboard->open_for_writing<SwitchInterface>("realsense2");
+	switch_if_ = blackboard->open_for_writing<SwitchInterface>(switch_if_name_.c_str());
 	switch_if_->set_enabled(true);
 	switch_if_->write();
 

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -245,12 +245,6 @@ Realsense2Thread::enable_depth_stream()
             depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 1.f); // Enable emitter
             depth_enabled_ = true;
         }
-        if (depth_sensor.supports(RS2_OPTION_LASER_POWER)){
-            rs2::option_range range = depth_sensor.get_option_range(RS2_OPTION_LASER_POWER);
-            depth_sensor.set_option(RS2_OPTION_LASER_POWER, range.max); // Set max power
-            depth_enabled_ = true;
-        }
-
     }
     catch (const rs2::error & e)
     {
@@ -278,11 +272,6 @@ Realsense2Thread::disable_depth_stream()
                 depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 0.f); // Disable emitter
                 depth_enabled_ = false;
             }
-            if (depth_sensor.supports(RS2_OPTION_LASER_POWER)){
-                depth_sensor.set_option(RS2_OPTION_LASER_POWER, 0.f); // Disable laser
-                depth_enabled_ = false;
-            }
-
     }
     catch (const rs2::error & e)
     {

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -132,11 +132,11 @@ Realsense2Thread::loop()
 void
 Realsense2Thread::finalize()
 {
+	stop_camera();
 	delete rs_pipe_;
 	delete rs_context_;
 	realsense_depth_refptr_.reset();
 	pcl_manager->remove_pointcloud(pcl_id_.c_str());
-	stop_camera();
 	blackboard->close(switch_if_);
 }
 
@@ -292,6 +292,12 @@ Realsense2Thread::disable_depth_stream()
 void
 Realsense2Thread::stop_camera()
 {
+	camera_running_ = false;
+	depth_enabled_  = false;
+	try {
+		rs_pipe_->stop();
+	} catch (const std::exception &e) {
+	}
 }
 
 /**

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -1,11 +1,10 @@
 
 /***************************************************************************
- *  realsense_thread.cpp - realsense
+ *  realsense2_plugin.cpp - realsense2
  *
- *  Plugin created: Mon Jun 13 17:09:44 2016
-
- *  Copyright  2016  Johannes Rothe
- *             2017  Till Hofmann
+ *  Plugin created: Wed May 22 10:09:22 2019
+ *
+ *  Copyright  2019 Christoph Gollok
  *
  ****************************************************************************/
 
@@ -28,10 +27,10 @@
 
 using namespace fawkes;
 
-/** @class RealsenseThread 'realsense_thread.h'
+/** @class Realsense2Thread 'realsense2_thread.h'
  * Driver for the Intel RealSense Camera providing Depth Data as Pointcloud
- * Inspired by Intel® RealSense™ Camera - F200 ROS Nodelet
- * @author Johannes Rothe
+ * Inspired by realsense fawkes plugin
+ * @author Christoph Gollok
  */
 
 Realsense2Thread::Realsense2Thread()
@@ -104,8 +103,7 @@ Realsense2Thread::loop()
 		logger->log_info(name(), "GOT RS2 DEPTH FRAME");
 		error_counter_        = 0;
 		const uint16_t *image = reinterpret_cast<const uint16_t *>(depth_frame.get_data());
-		log_error();
-		Cloud::iterator it = realsense_depth_->begin();
+		Cloud::iterator it    = realsense_depth_->begin();
 		for (int y = 0; y < intrinsics_.height; y++) {
 			for (int x = 0; x < intrinsics_.width; x++) {
 				float scaled_depth = camera_scale_ * (static_cast<float>(*image));
@@ -184,8 +182,8 @@ Realsense2Thread::start_camera()
 	return true;
 }
 
-/* Get the rs_device pointer and printout camera details
- * @return rs_device
+/*
+ * Get the rs_device pointer and printout camera details
  */
 void
 Realsense2Thread::get_camera(rs2::device &dev)
@@ -269,22 +267,6 @@ Realsense2Thread::disable_depth_stream()
 		std::cerr << e.what() << std::endl;
 		return;
 	}
-}
-
-/*
- * printout and free the rs_error if available
- */
-void
-Realsense2Thread::log_error()
-{
-}
-
-/*
- * Testing function to log the depth pixel distancens
- */
-void
-Realsense2Thread::log_depths(const uint16_t *image)
-{
 }
 
 /*

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -1,0 +1,170 @@
+
+/***************************************************************************
+ *  realsense_thread.cpp - realsense
+ *
+ *  Plugin created: Mon Jun 13 17:09:44 2016
+
+ *  Copyright  2016  Johannes Rothe
+ *             2017  Till Hofmann
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "realsense2_thread.h"
+
+#include <interfaces/SwitchInterface.h>
+
+using namespace fawkes;
+
+/** @class RealsenseThread 'realsense_thread.h' 
+ * Driver for the Intel RealSense Camera providing Depth Data as Pointcloud
+ * Inspired by Intel® RealSense™ Camera - F200 ROS Nodelet
+ * @author Johannes Rothe
+ */
+
+Realsense2Thread::Realsense2Thread()
+: Thread("Realsense2Thread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_ACQUIRE),
+  switch_if_(NULL)
+{
+}
+
+void
+Realsense2Thread::init()
+{
+	//set config values
+	const std::string cfg_prefix = "/realsense/";
+	frame_id_                    = config->get_string(cfg_prefix + "frame_id");
+	pcl_id_                      = config->get_string(cfg_prefix + "pcl_id");
+	laser_power_                 = config->get_int(cfg_prefix + "device_options/laser_power");
+	restart_after_num_errors_ =
+	  config->get_uint_or_default(std::string(cfg_prefix + "restart_after_num_errors").c_str(), 50);
+
+	cfg_use_switch_ = config->get_bool_or_default((cfg_prefix + "use_switch").c_str(), true);
+
+	if (cfg_use_switch_) {
+		logger->log_info(name(), "Switch enabled");
+	} else {
+		logger->log_info(name(), "Switch will be ignored");
+	}
+
+    switch_if_ = blackboard->open_for_writing<SwitchInterface>("realsense2");
+	switch_if_->set_enabled(true);
+	switch_if_->write();
+
+	camera_scale_ = 1;
+	//initalize pointcloud
+	realsense_depth_refptr_           = new Cloud();
+	realsense_depth_                  = pcl_utils::cloudptr_from_refptr(realsense_depth_refptr_);
+	realsense_depth_->header.frame_id = frame_id_;
+	realsense_depth_->width           = 0;
+	realsense_depth_->height          = 0;
+	realsense_depth_->resize(0);
+	pcl_manager->add_pointcloud(pcl_id_.c_str(), realsense_depth_refptr_);
+
+	connect_and_start_camera();
+
+
+}
+
+void
+Realsense2Thread::loop()
+{
+
+}
+
+void
+Realsense2Thread::finalize()
+{
+
+}
+
+/* Create RS context and start the depth stream
+ * @return true when succesfull
+ */
+bool
+Realsense2Thread::connect_and_start_camera()
+{
+
+    return true;
+}
+
+/* Get the rs_device pointer and printout camera details
+ * @return rs_device
+ */
+//rs2::device *
+//Realsense2Thread::get_camera()
+//{
+
+
+//    return rs2::device();
+//}
+
+/*
+ * Enable the depth stream from rs_device
+ */
+void
+Realsense2Thread::enable_depth_stream()
+{
+
+}
+
+/*
+ * printout and free the rs_error if available
+ */
+void
+Realsense2Thread::log_error()
+{
+
+}
+
+/*
+ * Testing function to log the depth pixel distancens
+ */
+void
+Realsense2Thread::log_depths(const uint16_t *image)
+{
+
+}
+
+/*
+ * Stop the device and delete the context properly
+ */
+void
+Realsense2Thread::stop_camera()
+{
+
+}
+
+/**
+ * Read the switch interface and start/stop the camera if necessary.
+ * @return true iff the interface is currently enabled.
+ */
+bool
+Realsense2Thread::read_switch()
+{
+	while (!switch_if_->msgq_empty()) {
+		Message *msg = switch_if_->msgq_first();
+		if (dynamic_cast<SwitchInterface::EnableSwitchMessage *>(msg)) {
+			enable_camera_ = true;
+		} else if (dynamic_cast<SwitchInterface::DisableSwitchMessage *>(msg)) {
+			enable_camera_ = false;
+		}
+		switch_if_->msgq_pop();
+	}
+	switch_if_->set_enabled(enable_camera_);
+	switch_if_->write();
+	return switch_if_->is_enabled();
+}

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -94,8 +94,10 @@ Realsense2Thread::loop()
     if (enable_camera_ && !depth_enabled_) {
         enable_depth_stream();
         return;
-    } else if (!enable_camera_){
+    } else if (!enable_camera_ && depth_enabled_){
         disable_depth_stream();
+        return;
+    } else if (!depth_enabled_){
         return;
     }
 

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -172,11 +172,14 @@ Realsense2Thread::start_camera()
 		                 camera_scale_);
 
 	} catch (const rs2::error &e) {
-		std::cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args()
-		          << "):\n    " << e.what() << std::endl;
+		logger->log_error(name(),
+		                  "RealSense error calling %s ( %s ):\n    %s",
+		                  e.get_failed_function().c_str(),
+		                  e.get_failed_args().c_str(),
+		                  e.what());
 		return false;
 	} catch (const std::exception &e) {
-		std::cerr << e.what() << std::endl;
+		logger->log_error(name(), "%s", e.what());
 		return false;
 	}
 	return true;
@@ -199,24 +202,28 @@ Realsense2Thread::get_camera(rs2::device &dev)
 			dev              = devlist.front();
 			std::string name = "Unknown Device";
 			if (dev.supports(RS2_CAMERA_INFO_NAME)) {
-				name = dev.get_info(RS2_CAMERA_INFO_NAME);
-			} else
-				std::cout << "name not supported" << std::endl;
+				dev_name = dev.get_info(RS2_CAMERA_INFO_NAME);
+			} else {
+				logger->log_info(name(), "RS2Option RS2_CAMERA_INFO_NAME not supported %d", 1);
+			}
 
-			std::string sn = "########";
+			std::string dev_sn = "########";
 			if (dev.supports(RS2_CAMERA_INFO_SERIAL_NUMBER)) {
-				sn = std::string("#") + rs_device_.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
-			} else
-				std::cout << "serial not supported" << std::endl;
-
-			std::cout << "name: " << name << " SN: " << sn << std::endl;
+				dev_sn = std::string("#") + rs_device_.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+			} else {
+				logger->log_info(name(), "RS2Option RS2_CAMERA_INFO_SERIAL_NUMBER not supported");
+			}
+			logger->log_info(name(), "Camera Name: %s, SN: %s", dev_name.c_str(), dev_sn.c_str());
 		}
 	} catch (const rs2::error &e) {
-		std::cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args()
-		          << "):\n    " << e.what() << std::endl;
+		logger->log_error(name(),
+		                  "RealSense error calling %s ( %s ):\n    %s",
+		                  e.get_failed_function().c_str(),
+		                  e.get_failed_args().c_str(),
+		                  e.what());
 		return;
 	} catch (const std::exception &e) {
-		std::cerr << e.what() << std::endl;
+		logger->log_error(name(), "%s", e.what());
 		return;
 	}
 }
@@ -227,7 +234,6 @@ Realsense2Thread::get_camera(rs2::device &dev)
 void
 Realsense2Thread::enable_depth_stream()
 {
-	std::cout << "ENABLE DEPTH_STREAM:" << std::endl;
 	try {
 		rs2::depth_sensor depth_sensor = rs_device_.first<rs2::depth_sensor>();
 		if (depth_sensor.supports(RS2_OPTION_EMITTER_ENABLED)) {
@@ -236,11 +242,14 @@ Realsense2Thread::enable_depth_stream()
 			depth_enabled_ = true;
 		}
 	} catch (const rs2::error &e) {
-		std::cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args()
-		          << "):\n    " << e.what() << std::endl;
+		logger->log_error(name(),
+		                  "RealSense error calling %s ( %s ):\n    %s",
+		                  e.get_failed_function().c_str(),
+		                  e.get_failed_args().c_str(),
+		                  e.what());
 		return;
 	} catch (const std::exception &e) {
-		std::cerr << e.what() << std::endl;
+		logger->log_error(name(), "%s", e.what());
 		return;
 	}
 }
@@ -251,7 +260,6 @@ Realsense2Thread::enable_depth_stream()
 void
 Realsense2Thread::disable_depth_stream()
 {
-	std::cout << "DISABLE DEPTH_STREAM:" << std::endl;
 	try {
 		rs2::depth_sensor depth_sensor = rs_device_.first<rs2::depth_sensor>();
 		if (depth_sensor.supports(RS2_OPTION_EMITTER_ENABLED)) {
@@ -260,11 +268,14 @@ Realsense2Thread::disable_depth_stream()
 			depth_enabled_ = false;
 		}
 	} catch (const rs2::error &e) {
-		std::cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args()
-		          << "):\n    " << e.what() << std::endl;
+		logger->log_error(name(),
+		                  "RealSense error calling %s ( %s ):\n    %s",
+		                  e.get_failed_function().c_str(),
+		                  e.get_failed_args().c_str(),
+		                  e.what());
 		return;
 	} catch (const std::exception &e) {
-		std::cerr << e.what() << std::endl;
+		logger->log_error(name(), "%s", e.what());
 		return;
 	}
 }

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -198,9 +198,12 @@ Realsense2Thread::get_camera(rs2::device &dev)
 			std::cerr << "No device connected, please connect a RealSense device" << std::endl;
 			return;
 		} else {
-			std::cout << "found devices: " << devlist.size() << std::endl;
-			dev              = devlist.front();
-			std::string name = "Unknown Device";
+			logger->log_info(name(), "found devices: %d", devlist.size());
+			if (devlist.front().is<rs400::advanced_mode>())
+				dev = devlist.front().as<rs400::advanced_mode>();
+			else
+				dev = dev = devlist.front();
+			std::string dev_name = "Unknown Device";
 			if (dev.supports(RS2_CAMERA_INFO_NAME)) {
 				dev_name = dev.get_info(RS2_CAMERA_INFO_NAME);
 			} else {

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -247,7 +247,14 @@ Realsense2Thread::enable_depth_stream()
 			depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED,
 			                        1.f); // Enable emitter
 			depth_enabled_ = true;
+		} else if (depth_sensor.supports(RS2_OPTION_LASER_POWER)) {
+			rs2::option_range range = depth_sensor.get_option_range(RS2_OPTION_LASER_POWER);
+			depth_sensor.set_option(RS2_OPTION_LASER_POWER, range.max); // Set max power
+			depth_enabled_ = true;
+		} else {
+			logger->log_warn(name(), "Enable depth stream not supported on device");
 		}
+
 	} catch (const rs2::error &e) {
 		logger->log_error(name(),
 		                  "RealSense error calling %s ( %s ):\n    %s",
@@ -273,6 +280,12 @@ Realsense2Thread::disable_depth_stream()
 			depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED,
 			                        0.f); // Disable emitter
 			depth_enabled_ = false;
+		} else if (depth_sensor.supports(RS2_OPTION_LASER_POWER)) {
+			rs2::option_range range = depth_sensor.get_option_range(RS2_OPTION_LASER_POWER);
+			depth_sensor.set_option(RS2_OPTION_LASER_POWER, range.min); // Set max power
+			depth_enabled_ = false;
+		} else {
+			logger->log_warn(name(), "Disable depth stream not supported on device");
 		}
 	} catch (const rs2::error &e) {
 		logger->log_error(name(),

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -1,0 +1,110 @@
+
+/***************************************************************************
+ *  realsense_thread.h - realsense
+ *
+ *  Plugin created: Mon Jun 13 17:09:44 2016
+
+ *  Copyright  2016  Johannes Rothe
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef _PLUGINS_REALSENSETHREAD_H_
+#define _PLUGINS_REALSENSETHREAD_H_
+
+#include <aspect/blackboard.h>
+#include <aspect/blocked_timing.h>
+#include <aspect/clock.h>
+#include <aspect/configurable.h>
+#include <aspect/logging.h>
+#include <aspect/pointcloud.h>
+#include <core/threading/thread.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#ifdef HAVE_REALSENSE2
+#	include <librealsense2/rs.hpp>
+#else
+#	include <librealsense2/rs.hpp>
+#endif
+
+#include <string>
+
+namespace fawkes {
+class SwitchInterface;
+}
+
+class Realsense2Thread : public fawkes::Thread,
+                        public fawkes::BlockedTimingAspect,
+                        public fawkes::LoggingAspect,
+                        public fawkes::ConfigurableAspect,
+                        public fawkes::BlackBoardAspect,
+                        public fawkes::PointCloudAspect,
+                        public fawkes::ClockAspect
+{
+public:
+    Realsense2Thread();
+
+	virtual void init();
+	virtual void finalize();
+	virtual void loop();
+
+private:
+	bool       connect_and_start_camera();
+    rs2::device *get_camera();
+	void       enable_depth_stream();
+	void       log_error();
+	void       log_depths(const uint16_t *image);
+	void       fill_pointcloud();
+	void       stop_camera();
+
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+protected:
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
+
+protected:
+	bool read_switch();
+
+private:
+	fawkes::SwitchInterface *switch_if_;
+	bool                     cfg_use_switch_;
+
+	typedef pcl::PointXYZ              PointType;
+	typedef pcl::PointCloud<PointType> Cloud;
+
+	typedef Cloud::Ptr      CloudPtr;
+	typedef Cloud::ConstPtr CloudConstPtr;
+
+	fawkes::RefPtr<Cloud> realsense_depth_refptr_;
+	CloudPtr              realsense_depth_;
+
+    rs2::pipeline * rs_pipe_;
+    rs2::stream_profile stream_profile_;
+	int           num_of_cameras_;
+	float         camera_scale_;
+	std::string   frame_id_;
+	std::string   pcl_id_;
+	bool          enable_camera_  = true;
+	bool          camera_running_ = false;
+	int           laser_power_;
+	uint          restart_after_num_errors_;
+	uint          error_counter_ = 0;
+};
+
+#endif

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -110,6 +110,8 @@ private:
 	std::string frame_id_;
 	std::string pcl_id_;
 	std::string switch_if_name_;
+	uint        frame_rate_;
+	float       laser_power_;
 	bool        camera_running_ = false;
 	bool        enable_camera_  = true;
 	bool        depth_enabled_  = false;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -42,10 +42,10 @@
 #	include <librealsense2/rs.hpp>
 #	include <librealsense2/rs_advanced_mode.hpp>
 #else
-#	include <librealsense2/rsutil.h>
+#	include <librealsense/rsutil.h>
 
-#	include <librealsense2/rs.hpp>
-#	include <librealsense2/rs_advanced_mode.hpp>
+#	include <librealsense/rs.hpp>
+#	include <librealsense/rs_advanced_mode.hpp>
 #endif
 
 #include <string>

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -71,7 +71,7 @@ public:
 
 private:
 	bool start_camera();
-	void get_camera(rs2::device &dev);
+	bool get_camera(rs2::device &dev);
 	void enable_depth_stream();
 	void disable_depth_stream();
 	void stop_camera();
@@ -100,15 +100,11 @@ private:
 	fawkes::RefPtr<Cloud> realsense_depth_refptr_;
 	CloudPtr              realsense_depth_;
 
-	rs2::pipeline *       rs_pipe_;
-	rs2::pipeline_profile rs_pipeline_profile_;
-	rs2::context *        rs_context_;
-	rs2::config           rs_config_;
-	rs2::error *          rs_error_;
-	rs2::device           rs_device_;
-	rs2::stream_profile   stream_profile_;
-	rs2::frameset         rs_data_;
-	rs2_intrinsics        intrinsics_;
+	rs2::pipeline *rs_pipe_;
+	rs2::context * rs_context_;
+	rs2::device    rs_device_;
+	rs2::frameset  rs_data_;
+	rs2_intrinsics intrinsics_;
 
 	float       camera_scale_;
 	std::string frame_id_;
@@ -116,7 +112,6 @@ private:
 	bool        camera_running_ = false;
 	bool        enable_camera_  = true;
 	bool        depth_enabled_  = false;
-	int         laser_power_;
 	uint        restart_after_num_errors_;
 	uint        error_counter_ = 0;
 };

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -37,8 +37,10 @@
 
 #ifdef HAVE_REALSENSE2
 #	include <librealsense2/rs.hpp>
+#   include <librealsense2/rsutil.h>
 #else
-#	include <librealsense2/rs.hpp>
+#   include <librealsense2/rs.hpp>
+#   include <librealsense2/rsutil.h>
 #endif
 
 #include <string>
@@ -96,10 +98,14 @@ private:
 	CloudPtr              realsense_depth_;
 
     rs2::pipeline * rs_pipe_;
-    rs2::config  rs_config;
-    rs2::error * rs_error;
+    rs2::pipeline_profile rs_pipeline_profile_;
+    rs2::context * rs_context_;
+    rs2::config  rs_config_;
+    rs2::error * rs_error_;
+    rs2::device  rs_device_;
     rs2::stream_profile stream_profile_;
     rs2::frameset rs_data_;
+    rs2_intrinsics intrinsics_;
 
 	int           num_of_cameras_;
 	float         camera_scale_;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -31,24 +31,14 @@
 #include <aspect/logging.h>
 #include <aspect/pointcloud.h>
 #include <core/threading/thread.h>
+#include <librealsense2/rsutil.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
-#include <thread>
-
-#ifdef HAVE_REALSENSE2
-#	include <librealsense2/rsutil.h>
-
-#	include <librealsense2/rs.hpp>
-#	include <librealsense2/rs_advanced_mode.hpp>
-#else
-#	include <librealsense/rsutil.h>
-
-#	include <librealsense/rs.hpp>
-#	include <librealsense/rs_advanced_mode.hpp>
-#endif
-
+#include <librealsense2/rs.hpp>
+#include <librealsense2/rs_advanced_mode.hpp>
 #include <string>
+#include <thread>
 
 namespace fawkes {
 class SwitchInterface;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -1,10 +1,10 @@
 
 /***************************************************************************
- *  realsense_thread.h - realsense
+ *  realsense2_thread.h - realsense2
  *
- *  Plugin created: Mon Jun 13 17:09:44 2016
+ *  Plugin created: Wed May 22 10:09:22 2019
 
- *  Copyright  2016  Johannes Rothe
+ *  Copyright  2019 Christoph Gollok
  *
  ****************************************************************************/
 
@@ -72,9 +72,6 @@ private:
 	void get_camera(rs2::device &dev);
 	void enable_depth_stream();
 	void disable_depth_stream();
-	void log_error();
-	void log_depths(const uint16_t *image);
-	void fill_pointcloud();
 	void stop_camera();
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -21,8 +21,8 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#ifndef _PLUGINS_REALSENSETHREAD_H_
-#define _PLUGINS_REALSENSETHREAD_H_
+#ifndef _PLUGINS_REALSENSE2THREAD_H_
+#define _PLUGINS_REALSENSE2THREAD_H_
 
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
@@ -33,14 +33,17 @@
 #include <core/threading/thread.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+
 #include <thread>
 
 #ifdef HAVE_REALSENSE2
+#	include <librealsense2/rsutil.h>
+
 #	include <librealsense2/rs.hpp>
-#   include <librealsense2/rsutil.h>
 #else
-#   include <librealsense2/rs.hpp>
-#   include <librealsense2/rsutil.h>
+#	include <librealsense2/rsutil.h>
+
+#	include <librealsense2/rs.hpp>
 #endif
 
 #include <string>
@@ -50,29 +53,29 @@ class SwitchInterface;
 }
 
 class Realsense2Thread : public fawkes::Thread,
-                        public fawkes::BlockedTimingAspect,
-                        public fawkes::LoggingAspect,
-                        public fawkes::ConfigurableAspect,
-                        public fawkes::BlackBoardAspect,
-                        public fawkes::PointCloudAspect,
-                        public fawkes::ClockAspect
+                         public fawkes::BlockedTimingAspect,
+                         public fawkes::LoggingAspect,
+                         public fawkes::ConfigurableAspect,
+                         public fawkes::BlackBoardAspect,
+                         public fawkes::PointCloudAspect,
+                         public fawkes::ClockAspect
 {
 public:
-    Realsense2Thread();
+	Realsense2Thread();
 
 	virtual void init();
 	virtual void finalize();
 	virtual void loop();
 
 private:
-    bool       start_camera();
-    void       get_camera(rs2::device &dev);
-    void       enable_depth_stream();
-    void       disable_depth_stream();
-	void       log_error();
-	void       log_depths(const uint16_t *image);
-	void       fill_pointcloud();
-	void       stop_camera();
+	bool start_camera();
+	void get_camera(rs2::device &dev);
+	void enable_depth_stream();
+	void disable_depth_stream();
+	void log_error();
+	void log_depths(const uint16_t *image);
+	void fill_pointcloud();
+	void stop_camera();
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
@@ -98,25 +101,25 @@ private:
 	fawkes::RefPtr<Cloud> realsense_depth_refptr_;
 	CloudPtr              realsense_depth_;
 
-    rs2::pipeline * rs_pipe_;
-    rs2::pipeline_profile rs_pipeline_profile_;
-    rs2::context * rs_context_;
-    rs2::config  rs_config_;
-    rs2::error * rs_error_;
-    rs2::device  rs_device_;
-    rs2::stream_profile stream_profile_;
-    rs2::frameset rs_data_;
-    rs2_intrinsics intrinsics_;
+	rs2::pipeline *       rs_pipe_;
+	rs2::pipeline_profile rs_pipeline_profile_;
+	rs2::context *        rs_context_;
+	rs2::config           rs_config_;
+	rs2::error *          rs_error_;
+	rs2::device           rs_device_;
+	rs2::stream_profile   stream_profile_;
+	rs2::frameset         rs_data_;
+	rs2_intrinsics        intrinsics_;
 
-	float         camera_scale_;
-	std::string   frame_id_;
-	std::string   pcl_id_;
-    bool          camera_running_ = false;
-    bool          enable_camera_  = true;
-    bool          depth_enabled_  = false;
-	int           laser_power_;
-	uint          restart_after_num_errors_;
-	uint          error_counter_ = 0;
+	float       camera_scale_;
+	std::string frame_id_;
+	std::string pcl_id_;
+	bool        camera_running_ = false;
+	bool        enable_camera_  = true;
+	bool        depth_enabled_  = false;
+	int         laser_power_;
+	uint        restart_after_num_errors_;
+	uint        error_counter_ = 0;
 };
 
 #endif

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -65,9 +65,10 @@ public:
 	virtual void loop();
 
 private:
-	bool       connect_and_start_camera();
-    rs2::device *get_camera();
-	void       enable_depth_stream();
+    bool       start_camera();
+    void       get_camera(rs2::device &dev);
+    void       enable_depth_stream();
+    void       disable_depth_stream();
 	void       log_error();
 	void       log_depths(const uint16_t *image);
 	void       fill_pointcloud();
@@ -107,13 +108,12 @@ private:
     rs2::frameset rs_data_;
     rs2_intrinsics intrinsics_;
 
-	int           num_of_cameras_;
 	float         camera_scale_;
 	std::string   frame_id_;
 	std::string   pcl_id_;
-	bool          enable_camera_  = true;
-	bool          camera_running_ = false;
-    bool          frames_avalialble_ = false;
+    bool          camera_running_ = false;
+    bool          enable_camera_  = true;
+    bool          depth_enabled_  = false;
 	int           laser_power_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -40,10 +40,12 @@
 #	include <librealsense2/rsutil.h>
 
 #	include <librealsense2/rs.hpp>
+#	include <librealsense2/rs_advanced_mode.hpp>
 #else
 #	include <librealsense2/rsutil.h>
 
 #	include <librealsense2/rs.hpp>
+#	include <librealsense2/rs_advanced_mode.hpp>
 #endif
 
 #include <string>

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -33,6 +33,7 @@
 #include <core/threading/thread.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <thread>
 
 #ifdef HAVE_REALSENSE2
 #	include <librealsense2/rs.hpp>
@@ -95,13 +96,18 @@ private:
 	CloudPtr              realsense_depth_;
 
     rs2::pipeline * rs_pipe_;
+    rs2::config  rs_config;
+    rs2::error * rs_error;
     rs2::stream_profile stream_profile_;
+    rs2::frameset rs_data_;
+
 	int           num_of_cameras_;
 	float         camera_scale_;
 	std::string   frame_id_;
 	std::string   pcl_id_;
 	bool          enable_camera_  = true;
 	bool          camera_running_ = false;
+    bool          frames_avalialble_ = false;
 	int           laser_power_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -109,6 +109,7 @@ private:
 	float       camera_scale_;
 	std::string frame_id_;
 	std::string pcl_id_;
+	std::string switch_if_name_;
 	bool        camera_running_ = false;
 	bool        enable_camera_  = true;
 	bool        depth_enabled_  = false;


### PR DESCRIPTION
Adds Plugin for the librealsese2 compatible Depth Cameras
See -> #110
Requires at least librealsense2  version 2.16 if used  on kernel >= 4.16 to be build

use this to install compatible version. 
dnf --enablerepo=updates-testing-modular module install librealsense/dev