### PR TITLE
Consider all bytes during escape

### DIFF
--- a/src/plugins/robotino/direct_com_message.cpp
+++ b/src/plugins/robotino/direct_com_message.cpp
@@ -758,7 +758,7 @@ void
 DirectRobotinoComMessage::escape()
 {
 	unsigned short to_escape = 0;
-	for (int i = 1; i < payload_size_ + 4; ++i) {
+	for (unsigned int i = 1; i < payload_size_ + MSG_METADATA_SIZE; ++i) {
 		if (data_[i] == MSG_HEAD || data_[i] == MSG_DATA_ESCAPE) {
 			++to_escape;
 		}
@@ -772,7 +772,7 @@ DirectRobotinoComMessage::escape()
 		escaped_data_[0] = MSG_HEAD;
 		unsigned char *p = escaped_data_;
 		*p++             = MSG_HEAD;
-		for (unsigned int i = 1; i < payload_size_ + (MSG_METADATA_SIZE - 1); ++i) {
+		for (unsigned int i = 1; i < payload_size_ + MSG_METADATA_SIZE; ++i) {
 			if (data_[i] == MSG_HEAD || data_[i] == MSG_DATA_ESCAPE) {
 				*p++ = MSG_DATA_ESCAPE;
 				*p++ = data_[i] ^ MSG_DATA_MANGLE;


### PR DESCRIPTION
This PR fixes a bug in the direction communication with the robotino firmware.

The bug appeared **only** if the message sent to the robotino firmware needed to be escaped. In this case, however, the robotino firmware consequently ignored the incoming message.

This bug was definitely the reason for issue #129 and could be also reason for other sporadic events, in which the robotino did not want to start driving.

A more specific explanation of the issue is given in #129.

This fixes #129.