### PR TITLE
clips-executive: ignore response when unlocking a mutex

### DIFF
--- a/src/plugins/clips-executive/clips/lock-actions.clp
+++ b/src/plugins/clips-executive/clips/lock-actions.clp
@@ -103,7 +103,7 @@
 	                    (action-name unlock) (state RUNNING)
 	                    (param-names $?param-names) (param-values $?param-values))
 	?mf <- (mutex (name ?name&:(eq ?name (plan-action-arg name ?param-names ?param-values)))
-	              (request UNLOCK) (response UNLOCKED))
+	              (state OPEN) (request UNLOCK))
 	=>
 	(modify ?pa (state EXECUTION-SUCCEEDED))
 	(modify ?mf (request NONE) (response NONE))

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -142,7 +142,7 @@
 )
 
 (defrule resource-locks-unlock-done
-  ?m <- (mutex (name ?res) (request UNLOCK) (response UNLOCKED))
+  ?m <- (mutex (name ?res) (state OPEN) (request UNLOCK))
   ?g <- (goal (acquired-resources $?acq
                 &:(member$ (mutex-to-resource ?res) ?acq)))
   =>


### PR DESCRIPTION
This PR fixes issues when unlocking an already open lock.  There will not be an unlock response,
because no unlock took place. Currently this causes behaviour such as goals getting stuck on freeing resource locks, if a lock was somehow lost. To recover from failures like this, we can simply ignore the response while unlocking,if the lock is open.