### PR TITLE
skiller: call states' reset() before clearing vars

### DIFF
--- a/src/lua/fawkes/fsm.lua
+++ b/src/lua/fawkes/fsm.lua
@@ -355,6 +355,10 @@ function FSM:reset()
       self.current:do_exit()
    end
 
+   for n,s in pairs(self.states) do
+      s:reset()
+   end
+
    for k,_ in pairs(self.vars) do
       self.vars[k] = nil
    end
@@ -367,9 +371,6 @@ function FSM:reset()
 	 s:prepare()
       end
       self.prepared = true
-   end
-   for n,s in pairs(self.states) do
-      s:reset()
    end
 
    self.trace         = {}


### PR DESCRIPTION
A state's reset() method is a user-supplied method that is supposed to
perform custom cleanup actions on skill reset (e.g. when skill is
cancelled to execute another one). When implementing this method, a user
expects that the last state of the skill still exists, in particular
that the fsm.vars table hasn't been cleared, yet.