### PR TITLE
CX: resource locking with multiple goals

### DIFF
--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -60,7 +60,7 @@
               (required-resources $?req))
   (mutex (name ?n&:(member$ (mutex-to-resource ?n) ?req))
          (state LOCKED) (locked-by ?locker&~?identity))
-  (not (mutex (name ?n&:(member$ (mutex-to-resource ?n) ?req))
+  (not (mutex (name ?n1&:(member$ (mutex-to-resource ?n1) ?req))
               (request ~NONE)))
   =>
   (printout warn "Rejecting goal " ?goal-id ", " (mutex-to-resource ?n)

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -34,17 +34,17 @@
 )
 
 (defrule resource-locks-request-lock
+  "Request a mutex for each required resource if none of the respective mutexes
+   is already locked or has a pending request."
   (goal (mode COMMITTED)
-        (acquired-resources $?acq)
-        (required-resources $?req))
-  ; We may have multiple goals requiring the same resource. If that's the case,
-  ; wait until the other goal releases the resources.
+        (acquired-resources)
+        (required-resources $?req&:(> (length$ ?req) 0)))
   (not (mutex (name ?n&:(member$ (mutex-to-resource ?n) ?req))
               (request ~NONE)))
   (not (mutex (name ?n&:(member$ (mutex-to-resource ?n) ?req))
               (state LOCKED)))
   =>
-  (foreach ?res (set-diff ?req ?acq)
+  (foreach ?res ?req
     (printout warn "Locking resource " ?res crlf)
     (mutex-try-lock-async (resource-to-mutex ?res))
   )

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -44,6 +44,7 @@
               (request ~NONE)))
   (not (mutex (name ?n&:(member$ (mutex-to-resource ?n) ?req))
               (state LOCKED)))
+	(not (resource-locks-resource-requested-for ?res&:(member$ ?res ?req) ?))
   =>
   (foreach ?res ?req
     (printout warn "Locking resource " ?res crlf)

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -70,9 +70,15 @@
     (printout warn "Rejecting goal " ?goal-id ", " (mutex-to-resource ?n)
                    " is already locked by " ?locker crlf)
   else
-    (do-for-fact ((?og goal)) (member$ (mutex-to-resource ?n) ?og:acquired-resources)
-      (printout warn "Rejecting goal " ?goal-id ", " (mutex-to-resource ?n)
-                     " is already locked for " ?og:id crlf)
+    (if (not (do-for-fact ((?og goal))
+               (member$ (mutex-to-resource ?n) ?og:acquired-resources)
+               (printout warn "Rejecting goal " ?goal-id ", "
+                              (mutex-to-resource ?n)
+                              " is already locked for " ?og:id crlf)))
+     then
+      (printout error "Rejecting goal " ?goal-id ", resource "
+                      (mutex-to-resource ?n)
+                      " is already locked, but could not determine why!" crlf)
     )
   )
   (modify ?g (mode FINISHED) (outcome REJECTED))


### PR DESCRIPTION
Adapt the resource locking so it properly works even if multiple (local) goals require the same resources.

With this PR, we now immediately reject a goal if we have already acquired a required resource for another goal. Previously, we would wait until the other goal is finished and then try continue acquiring the resource.

We now explicitly track for which goal we requested a resource with the `resource-locks-resource-requested-for` fact.