### PR TITLE
clips-executive: retract sync-map if we receive a delete trigger

### DIFF
--- a/src/plugins/clips-executive/clips/wm-robmem-sync.clp
+++ b/src/plugins/clips-executive/clips/wm-robmem-sync.clp
@@ -363,7 +363,7 @@
 		(if (time> ?ts ?sm:update-timestamp)
 		then
 			(printout debug "wm-robmem-sync-delete: removing " ?id crlf)
-			(retract ?wf)
+			(retract ?wf ?sm)
 		else
 			(printout warn "wm-robmem-sync-delete: received delete for " ?id
 								" with older timetamp than our own" crlf)


### PR DESCRIPTION
If we get a trigger for the deletion of a wm-fact, also retract the sync
map entry in addition to the wm-fact. Otherwise, we cannot distinguish
whether we deleted the fact locally or received a delete trigger for the
fact, and therefore trigger another deletion. This may cause issues
especially if the trigger is delayed, because we may delete facts on
other robots that have been created after the original deletion.