### PR TITLE
cx: add required resources to plan-action

### DIFF
--- a/src/plugins/clips-executive/clips/plan.clp
+++ b/src/plugins/clips-executive/clips/plan.clp
@@ -23,6 +23,7 @@
 	(slot action-name (type SYMBOL))
 	(multislot param-names)
 	(multislot param-values)
+	(multislot required-resources)
 	(slot duration (type FLOAT))
 	(slot dispatch-time (type FLOAT) (default -1.0))
 	(slot state (type SYMBOL)


### PR DESCRIPTION
Since resources that are needed by a goal are depending on what actions are performed on what resources, it makes sense to be able to connect resources to plan-actions. If a goal is expanded, we then can determine all resources that are needed by the plan-actions of the plan, and lock these. Thus, we dont have to make assumptions about the actual plan of a goal when we formulate it.
Additionally, as soon as all plan-actions that needed a resource lock are final, we can release the resource earlier than the goal is finished.