### PR TITLE
clips-executive: update timestamp when updating known fact

### DIFF
--- a/src/plugins/clips-executive/clips/wm-robmem-sync.clp
+++ b/src/plugins/clips-executive/clips/wm-robmem-sync.clp
@@ -308,7 +308,7 @@
 				then
 					(printout debug "wm-robmem-sync-update: updating (known fact) " ?id crlf)
 					(bind ?new-wf (modify ?wf (type ?type) (is-list ?is-list) (value ?value) (values ?values)))
-					(modify ?sm (wm-fact-idx (fact-index ?new-wf)))
+					(modify ?sm (wm-fact-idx (fact-index ?new-wf)) (update-timestamp ?update-timestamp))
 				else
 					(printout warn "wm-robmem-sync-update: received update for " ?id " with older data than our own" crlf)
 				)


### PR DESCRIPTION
If we receive an update for a known fact with a newer timestamp than our
own, also update the local timestamp. This ensures that we keep the fact
if another agent deleted and re-adds the fact, even if the triggers for
those events reach us in the wrong order.