### PR TITLE
realsense add delay between pols if error occur

### DIFF
--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -108,6 +108,8 @@ private:
 	int           laser_power_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;
+	fawkes::Time  next_pol_time_;
+	float         cfg_pol_delay_;
 };
 
 #endif


### PR DESCRIPTION
if an error occurs the old realsense is drowned in querry requests. delaying these requests
reduces overhead on the realsense side and hopefully increases stability