### PR TITLE
Escape * to obtain git files

### DIFF
--- a/etc/buildsys/root/check.mk
+++ b/etc/buildsys/root/check.mk
@@ -28,7 +28,7 @@ __buildsys_root_check_mk_ := 1
 
 YAMLLINT ?= 1
 
-GITFILES = git ls-files --full-name *.{h,cpp} | awk "{ print \"$$(git rev-parse --show-toplevel)/\"\$$1 }"
+GITFILES = git ls-files --full-name \*.{h,cpp} | awk "{ print \"$$(git rev-parse --show-toplevel)/\"\$$1 }"
 
 .PHONY: license-check
 license-check:

--- a/etc/buildsys/root/docs.mk
+++ b/etc/buildsys/root/docs.mk
@@ -25,7 +25,7 @@ apidoc: api.doxygen fawkes.luadoc skiller.luadoc
 quickdoc: api-quick.doxygen
 tracdoc: api-trac.doxygen
 
-GIT_FILES = git ls-files --full-name *.{h,cpp} | awk '{ print "'$$(git rev-parse --show-toplevel)'/"$$1 }'
+GIT_FILES = git ls-files --full-name \*.{h,cpp} | awk '{ print "'$$(git rev-parse --show-toplevel)'/"$$1 }'
 
 %.doxygen:
 	$(SILENT) echo -e "[DOC] Building documentation ($(TBOLDGRAY)$@$(TNORMAL)). This may take a while..."


### PR DESCRIPTION
Whenever a `*.cpp` or `*.h` file exists in the git basedir, the license and doxygen check doesn't work as expected, since the bash already expands `*.{cpp,h}`.