### PR TITLE
cx: change goal priority type to float

### DIFF
--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -153,7 +153,7 @@
 	; higher number entails higher priority
 	; A goal might be preferred for selection, expansion, or execution depending
 	; on its priority. Some spec chains may support this, others not.
-	(slot priority (type INTEGER) (default 0))
+	(slot priority (type FLOAT) (default 0.0))
 	; Parameters that a goal reasoner or expander might need to evaluate goal.
 	; It is recommended to use a rich descriptive structure similar to wm-fact
 	; keys. Examples:


### PR DESCRIPTION
Changes the type of the goal priority to float. There is no practical reason to enforce priorities to be of type INTEGER. However, with a float typed priority we can use small differences in priorities to determine two, equally typed goals eg by distance they have to travel by adding a value between 0 and 1 to the base priority of the class.