### PR TITLE
Make log verbosity tunable for each goal

### DIFF
--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -289,7 +289,7 @@
 	?mf <- (mutex (name ?name) (request RENEW-LOCK) (response NONE)
 								(state LOCKED) (locked-by ?lb&:(eq ?lb (cx-identity))))
 	=>
-	(printout t "Renewing lock " ?name crlf)
+	(printout debug "Renewing lock " ?name crlf)
 	(robmem-mutex-renew-lock-async (str-cat ?name) (cx-identity))
 	(modify ?mf (response PENDING))
 )
@@ -370,7 +370,7 @@
 								(locked-by ?lb&:(eq ?lb (cx-identity)))
 								(lock-time $?lt&:(timeout (time-trunc-ms (now-systime)) ?lt ?renew-interval)))
 	=>
-	(printout t "Automatic renewal of lock for mutex " ?name crlf)
+	(printout debug "Automatic renewal of lock for mutex " ?name crlf)
 	(modify ?mf (request RENEW-LOCK) (response NONE) (pending-requests AUTO-RENEW-PROC))
 )
 
@@ -379,7 +379,7 @@
 								(request RENEW-LOCK) (response ACQUIRED)
 								(pending-requests AUTO-RENEW-PROC $?pending-requests))
 	=>
-	(printout t "Automatic renewal of lock for mutex " ?name " completed" crlf)
+	(printout debug "Automatic renewal of lock for mutex " ?name " completed" crlf)
 	(modify ?mf (request NONE) (response NONE) (pending-requests ?pending-requests))
 )
 

--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -342,7 +342,7 @@
 (defrule mutex-expire-locks-start
 	?mf <- (mutex-expire-task (task ?task) (state NONE) (max-age-sec ?max-age-sec))
 	=>
-	(printout t ?task " locks " crlf)
+	(printout debug ?task " locks " crlf)
 	(robmem-mutex-expire-locks-async ?max-age-sec)
 	(modify ?mf (state PENDING))
 )

--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -188,6 +188,10 @@
 	; which we have committed, in particular if there are multiple
 	; possible sub-goals or associated plans.
 	(slot committed-to (type SYMBOL))
+
+	; Amount of information to print. If set to quiet, regular events such as a
+	; committed or dispatched goal will only be logged to the debug log.
+	(slot verbosity (type SYMBOL) (allowed-values QUIET DEFAULT) (default DEFAULT))
 )
 
 (deffunction goal-retract-goal-tree (?id)


### PR DESCRIPTION
Add a slot `verbosity` with the allowed values `DEFAULT` and `QUIET` to the goal template and remove log messages for those goals for any typical behavior.

Also redirect log messages about lock renewal to the debug output.