### PR TITLE
robot-memory: renew_lock should only return true on success

### DIFF
--- a/src/plugins/robot-memory/robot_memory.cpp
+++ b/src/plugins/robot-memory/robot_memory.cpp
@@ -1052,7 +1052,7 @@ RobotMemory::mutex_renew_lock(const std::string &name, const std::string &identi
 		                                   .upsert(false)
 		                                   .return_document(options::return_document::k_after)
 		                                   .write_concern(write_concern));
-		return true;
+		return static_cast<bool>(new_doc);
 	} catch (operation_exception &e) {
 		logger_->log_warn(name_, "Renewing lock on mutex %s failed: %s", name.c_str(), e.what());
 		return false;


### PR DESCRIPTION
If we did not update any document (and find_one_and_update returned an
optional that does not contain a value), then we failed to renew the
lock. Thus, we should return true if and only if a document was
returned.

The rest of the code is already prepared to process the return value, this is the missing bit to handle renewal failures correctly.