### PR TITLE
clips-robot-memory: catch bsoncxx::exceptions

### DIFF
--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
@@ -577,7 +577,7 @@ ClipsRobotMemoryThread::clips_robotmemory_query_sort(std::string collection,
 		return CLIPS::Value(new std::unique_ptr<mongocxx::cursor>(
 		                      new mongocxx::cursor(std::move(cursor))),
 		                    CLIPS::TYPE_EXTERNAL_ADDRESS);
-	} catch (mongocxx::exception &e) {
+	} catch (std::system_error &e) {
 		logger->log_warn("MongoDB", "Query failed: %s", e.what());
 		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
 	}
@@ -589,7 +589,7 @@ ClipsRobotMemoryThread::clips_robotmemory_remove(std::string collection, void *b
 	auto b = static_cast<bsoncxx::builder::basic::document *>(bson);
 	try {
 		robot_memory->remove(b->view(), collection);
-	} catch (mongocxx::exception &e) {
+	} catch (std::system_error &e) {
 		logger->log_warn("MongoDB", "Remove failed: %s", e.what());
 	}
 }
@@ -639,7 +639,7 @@ ClipsRobotMemoryThread::clips_robotmemory_cursor_next(void *cursor)
 			it++;
 			return CLIPS::Value(b);
 		}
-	} catch (mongocxx::exception &e) {
+	} catch (std::system_error &e) {
 		logger->log_error("MongoDB", "mongodb-cursor-next: got invalid query: %s", e.what());
 		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
 	}
@@ -700,7 +700,7 @@ ClipsRobotMemoryThread::clips_bson_get(void *bson, std::string field_name)
 
 		default: return CLIPS::Value("INVALID_VALUE_TYPE", CLIPS::TYPE_SYMBOL);
 		}
-	} catch (mongocxx::exception &e) {
+	} catch (std::system_error &e) {
 		logger->log_warn(name(),
 		                 "mongodb-bson-get: failed to get '%s': %s",
 		                 field_name.c_str(),
@@ -777,7 +777,7 @@ ClipsRobotMemoryThread::clips_bson_get_array(void *bson, std::string field_name)
 			}
 		}
 		return rv;
-	} catch (mongocxx::exception &e) {
+	} catch (bsoncxx::exception &e) {
 		logger->log_warn(name(),
 		                 "mongodb-bson-get: failed to get '%s': %s",
 		                 field_name.c_str(),
@@ -822,7 +822,7 @@ ClipsRobotMemoryThread::clips_bson_get_time(void *bson, std::string field_name)
 		rv[0] = CLIPS::Value((long long int)(ts / 1000));
 		rv[1] = CLIPS::Value((ts - (rv[0].as_integer() * 1000)) * 1000);
 		return rv;
-	} catch (mongocxx::exception &e) {
+	} catch (bsoncxx::exception &e) {
 		rv.resize(2, CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL));
 		return rv;
 	}
@@ -855,7 +855,7 @@ ClipsRobotMemoryThread::clips_robotmemory_register_trigger(std::string env_name,
 			                               assert_name.c_str(),
 			                               CLIPS::Value(clips_trigger).as_address());
 			return true;
-		} catch (mongocxx::exception &e) {
+		} catch (std::system_error &e) {
 			MutexLocker clips_lock(envs_[env_name].objmutex_ptr());
 			envs_[env_name]->assert_fact_f("(mutex-trigger-register-feedback FAIL \"%s\")",
 			                               assert_name.c_str());


### PR DESCRIPTION
A bsoncxx:exception is no sub-type of mongocxx::exception, thus we need
to catch it separately. If both exceptions are possible, catch a
std::system_error, which is a super-type of both.