### PR TITLE
realsense: fix typo in delay config value name

### DIFF
--- a/cfg/conf.d/realsense.yaml
+++ b/cfg/conf.d/realsense.yaml
@@ -14,8 +14,10 @@ realsense:
   # messages. If false, switch messages will be ignored.
   # use_switch: true
 
-  # Number of retries after unsuccessful polling before restarting the camera
-  # restart_after_num_errors: 50
+  # restart device after num retries
+  restart_after_num_errors: 20
+  # wait time before polling new images
+  delay_between_poll_errors: 0.5
 
   # Section to set the Realsense device options
   device_options:

--- a/src/plugins/realsense/realsense_thread.cpp
+++ b/src/plugins/realsense/realsense_thread.cpp
@@ -51,8 +51,9 @@ RealsenseThread::init()
 	laser_power_                 = config->get_int(cfg_prefix + "device_options/laser_power");
 	restart_after_num_errors_ =
 	  config->get_uint_or_default(std::string(cfg_prefix + "restart_after_num_errors").c_str(), 50);
-	cfg_pol_delay_ =
-	  config->get_float_or_default(std::string(cfg_prefix + "delay_between_pol_errors").c_str(), 1.0);
+	cfg_poll_delay_ =
+	  config->get_float_or_default(std::string(cfg_prefix + "delay_between_poll_errors").c_str(),
+	                               1.0);
 	cfg_use_switch_ = config->get_bool_or_default((cfg_prefix + "use_switch").c_str(), true);
 
 	if (cfg_use_switch_) {
@@ -77,7 +78,7 @@ RealsenseThread::init()
 
 	rs_stream_type_ = RS_STREAM_DEPTH;
 	connect_and_start_camera();
-	next_pol_time_ = fawkes::Time(clock);
+	next_poll_time_ = fawkes::Time(clock);
 }
 
 void
@@ -97,7 +98,7 @@ RealsenseThread::loop()
 		return;
 	}
 
-	if (error_counter_ > 0 && next_pol_time_ > fawkes::Time(clock)) {
+	if (error_counter_ > 0 && next_poll_time_ > fawkes::Time(clock)) {
 		return;
 	}
 
@@ -123,7 +124,7 @@ RealsenseThread::loop()
 		pcl_utils::set_time(realsense_depth_refptr_, fawkes::Time(clock));
 	} else {
 		error_counter_++;
-		next_pol_time_ = fawkes::Time(clock) + cfg_pol_delay_;
+		next_poll_time_ = fawkes::Time(clock) + cfg_poll_delay_;
 		logger->log_warn(name(),
 		                 "Poll for frames not successful (%s)",
 		                 rs_get_error_message(rs_error_));

--- a/src/plugins/realsense/realsense_thread.h
+++ b/src/plugins/realsense/realsense_thread.h
@@ -108,8 +108,8 @@ private:
 	int           laser_power_;
 	uint          restart_after_num_errors_;
 	uint          error_counter_ = 0;
-	fawkes::Time  next_pol_time_;
-	float         cfg_pol_delay_;
+	fawkes::Time  next_poll_time_;
+	float         cfg_poll_delay_;
 };
 
 #endif


### PR DESCRIPTION
config param and variable "delay_between_poll_errors" had a typo.