### PR TITLE
Set error code in NavigatorInterface from ros_navigator if move_base is unavailable

### DIFF
--- a/src/plugins/ros/navigator_thread.cpp
+++ b/src/plugins/ros/navigator_thread.cpp
@@ -227,6 +227,8 @@ RosNavigatorThread::loop()
 			logger->log_warn(name(),
 			                 "Command received while ROS ActionClient "
 			                 "not reachable, ignoring");
+			nav_if_->set_error_code(NavigatorInterface::ERROR_PATH_GEN_FAIL);
+			nav_if_->write();
 			nav_if_->msgq_flush();
 		}
 


### PR DESCRIPTION
In case the move_base ROS node is not running notify by setting a proper
error code on the interface.