### PR TITLE
Allow configuration of the laser-filter map_filter's pixels

### DIFF
--- a/src/plugins/laser-filter/filter_thread.cpp
+++ b/src/plugins/laser-filter/filter_thread.cpp
@@ -519,7 +519,7 @@ LaserFilterThread::create_filter(std::string                             filter_
 	} else if (filter_type == "map_filter") {
 #ifdef HAVE_TF
 		return new LaserMapFilterDataFilter(
-		  filter_name, in_data_size, inbufs, tf_listener, config, logger);
+		  filter_name, in_data_size, inbufs, tf_listener, config, prefix, logger);
 #else
 		throw Exception("Projection filter unavailable, tf missing");
 #endif

--- a/src/plugins/laser-filter/filters/map_filter.h
+++ b/src/plugins/laser-filter/filters/map_filter.h
@@ -42,6 +42,7 @@ private:
 	map_t *     map_;
 	std::string frame_map_;
 	float       cfg_occupied_thresh_;
+	int         num_pixels_;
 
 public:
 	LaserMapFilterDataFilter(const std::string &                     filter_name,
@@ -49,6 +50,7 @@ public:
 	                         std::vector<LaserDataFilter::Buffer *> &in,
 	                         fawkes::tf::Transformer *               tf_listener,
 	                         fawkes::Configuration *                 config,
+	                         const std::string &                     prefix,
 	                         fawkes::Logger *                        logger);
 
 	virtual void filter();


### PR DESCRIPTION
The number of pixels to be filtered by the map_filter were hard-coded
previously. Now configuration can be used to set the value. A default
value of 2 pixels is used in case the configuration won't set a certain
value.