### PR TITLE
clips executive: keep sync map entry on delete

### DIFF
--- a/src/plugins/clips-executive/clips/wm-robmem-sync.clp
+++ b/src/plugins/clips-executive/clips/wm-robmem-sync.clp
@@ -250,11 +250,12 @@
 (defrule wm-robmem-sync-fact-removed
 	(wm-fact (key cx identity) (value ?identity))
 	(wm-robmem-sync-conf (wm-fact-key-prefix $?key-prefix) (enabled TRUE))
-	?sm <- (wm-robmem-sync-map-entry (wm-fact-id ?id) (wm-fact-key $?key-prefix $?rest))
+	?sm <- (wm-robmem-sync-map-entry (wm-fact-id ?id) (wm-fact-idx ?idx&~0) (wm-fact-key $?key-prefix $?rest))
 	(not (wm-fact (id ?id)))
 	=>
 	;(printout error "Remove " ?id " from robot memory" crlf)
-	(retract ?sm)
+	(bind ?now (time-trunc-ms (now-systime)))
+	(modify ?sm (wm-fact-idx 0) (update-timestamp ?now))
 	; We do not know when exactly the wm-fact was retracted, use the current time instead
 	(bind ?now (time-trunc-ms (now-systime)))
 	(bind ?query (wm-robmem-sync-create-query ?id ?now))
@@ -363,7 +364,8 @@
 		(if (time> ?ts ?sm:update-timestamp)
 		then
 			(printout debug "wm-robmem-sync-delete: removing " ?id crlf)
-			(retract ?wf ?sm)
+			(retract ?wf)
+			(modify ?sm (wm-fact-idx 0) (update-timestamp ?ts))
 		else
 			(printout warn "wm-robmem-sync-delete: received delete for " ?id
 								" with older timetamp than our own" crlf)


### PR DESCRIPTION
If we delete a fact, we should not also delete the sync map entry, because then we lose the information when the fact was deleted. This becomes important if we later get an update trigger, as we need to know if the update was before or after the deletion.

For the same reason, also create a new sync map entry if we get a delete trigger but we have never seen the fact before.