### PR TITLE
Set change stream wait time to 10ms for MongoDB 4

### DIFF
--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
@@ -856,6 +856,7 @@ ClipsRobotMemoryThread::clips_robotmemory_register_trigger(std::string env_name,
 			                               CLIPS::Value(clips_trigger).as_address());
 			return true;
 		} catch (std::system_error &e) {
+			logger->log_warn(name(), "Error while registering trigger: %s", e.what());
 			MutexLocker clips_lock(envs_[env_name].objmutex_ptr());
 			envs_[env_name]->assert_fact_f("(mutex-trigger-register-feedback FAIL \"%s\")",
 			                               assert_name.c_str());

--- a/src/plugins/robot-memory/event_trigger_manager.cpp
+++ b/src/plugins/robot-memory/event_trigger_manager.cpp
@@ -179,7 +179,7 @@ EventTriggerManager::create_change_stream(mongocxx::collection &coll, bsoncxx::d
 	}
 	mongocxx::options::change_stream opts;
 	opts.full_document("updateLookup");
-	opts.max_await_time(std::chrono::milliseconds(0));
+	opts.max_await_time(std::chrono::milliseconds(10));
 	auto res = coll.watch(opts);
 	// Go to end of change stream to get new updates from then on.
 	auto it = res.begin();

--- a/src/plugins/robot-memory/event_trigger_manager.cpp
+++ b/src/plugins/robot-memory/event_trigger_manager.cpp
@@ -179,7 +179,7 @@ EventTriggerManager::create_change_stream(mongocxx::collection &coll, bsoncxx::d
 	}
 	mongocxx::options::change_stream opts;
 	opts.full_document("updateLookup");
-	opts.max_await_time(std::chrono::milliseconds(10));
+	opts.max_await_time(std::chrono::milliseconds(1));
 	auto res = coll.watch(opts);
 	// Go to end of change stream to get new updates from then on.
 	auto it = res.begin();


### PR DESCRIPTION
MongoDB 4 no longer allows registering a change stream with a `maxAwaitTimeMS` of 0ms. Set it to a very low value of 10ms, such that it almost immediately returns.