### PR TITLE
robot-memory: return true in renew and unlock only if query succeeded

### DIFF
--- a/src/plugins/robot-memory/robot_memory.cpp
+++ b/src/plugins/robot-memory/robot_memory.cpp
@@ -973,7 +973,10 @@ RobotMemory::mutex_unlock(const std::string &name, const std::string &identity)
 		                                   .upsert(true)
 		                                   .return_document(options::return_document::k_after)
 		                                   .write_concern(write_concern));
-		return true;
+		if (!new_doc) {
+			return false;
+		}
+		return new_doc->view()["locked"].get_bool();
 	} catch (operation_exception &e) {
 		return false;
 	}
@@ -1029,7 +1032,7 @@ RobotMemory::mutex_renew_lock(const std::string &name, const std::string &identi
 		                                   .upsert(false)
 		                                   .return_document(options::return_document::k_after)
 		                                   .write_concern(write_concern));
-		return true;
+		return static_cast<bool>(new_doc);
 	} catch (operation_exception &e) {
 		logger_->log_warn(name_, "Renewing lock on mutex %s failed: %s", name.c_str(), e.what());
 		return false;


### PR DESCRIPTION
The find_one_and_update query may fail and return an optional without a
value. Check whether a document returned and also check whether it
contains the expected value.