### PR TITLE
Let lock renewal fail if the lock has expired or is owned by another identity

### DIFF
--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -397,6 +397,16 @@
   (modify ?mf (request NONE) (response NONE) (pending-requests ?pending-requests))
 )
 
+(defrule mutex-lock-auto-renew-locked-by-other-entity
+  ?mf <- (mutex (name ?name) (state LOCKED) (request RENEW-LOCK)
+                (pending-requests AUTO-RENEW-PROC $?pending-requests)
+                (locked-by ?lb&:(neq ?lb (cx-identity))))
+  =>
+  (printout error "Received response to renewal request for " ?name
+                  " but lock is locked by " ?lb ". " crlf)
+  (modify ?mf (request NONE) (response NONE) (pending-requests ?pending-requests))
+)
+
 (defrule mutex-lock-auto-renew-failed
 	?mf <- (mutex (name ?name) (state LOCKED)
 								(request RENEW-LOCK) (response REJECTED) (locked-by ?lb)

--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -387,9 +387,9 @@
 	(modify ?mf (request NONE) (response NONE) (pending-requests ?pending-requests))
 )
 
-(defrule mutex-lock-auto-renew-done-but-lock-open
+(defrule mutex-lock-auto-renew-lock-open
 	?mf <- (mutex (name ?name) (state OPEN)
-	              (request RENEW-LOCK) (response ACQUIRED|REJECTED)
+	              (request RENEW-LOCK)
 	              (pending-requests AUTO-RENEW-PROC $?pending-requests))
   =>
   (printout error "Received response to renewal request for " ?name


### PR DESCRIPTION
Abort a pending lock renewal if:
* the lock's state is `OPEN`, disregarding the state of the request
* the lock is owned by another identity