### PR TITLE
Do not pack interface structs

### DIFF
--- a/src/libs/interfaces/generator/cpp_generator.cpp
+++ b/src/libs/interfaces/generator/cpp_generator.cpp
@@ -132,7 +132,7 @@ CppInterfaceGenerator::write_struct(FILE *                         f,
 
 	fprintf(f,
 	        "%s/** Internal data storage, do NOT modify! */\n"
-	        "%stypedef struct __attribute__((packed)) {\n"
+	        "%stypedef struct {\n"
 	        "%s  int64_t timestamp_sec;  /**< Interface Unix timestamp, seconds */\n"
 	        "%s  int64_t timestamp_usec; /**< Interface Unix timestamp, micro-seconds */\n",
 	        is.c_str(),


### PR DESCRIPTION
Packing interface structs is a bad idea if we access the pointer of a
member of that struct, as the pointer may now be unaligned. We have
never observed memory issues with blackboard interfaces, so packing
seems to be unnecessary anyway.

This effectively reverts 46f1e250c8f6b5938a05a1ad4a347f13285519cb,
except that it removes every packing.

This fixes an address-of-packed member warning that has been added in
GCC9.