### PR TITLE
Adapt pcl_utils to ROS melodic with updated PCL

### DIFF
--- a/src/libs/pcl_utils/utils.h
+++ b/src/libs/pcl_utils/utils.h
@@ -78,12 +78,12 @@ template <typename PointT>
 inline void
 set_time(pcl::PointCloud<PointT> &cloud, const fawkes::Time &time)
 {
-#if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
+#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
+	cloud.header.stamp = time.in_usec();
+#else
+#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
 	cloud.header.stamp.sec  = time.get_sec();
 	cloud.header.stamp.nsec = time.get_usec() * 1000;
-#else
-#	if PCL_VERSION_COMPARE(>=, 1, 7, 0)
-	cloud.header.stamp = time.in_usec();
 #	else
 	PointCloudTimestamp pclts;
 	pclts.time.sec     = time.get_sec();
@@ -129,11 +129,11 @@ template <typename PointT>
 inline void
 get_time(const fawkes::RefPtr<const pcl::PointCloud<PointT>> &cloud, fawkes::Time &time)
 {
-#if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
-	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
-#else
-#	if PCL_VERSION_COMPARE(>=, 1, 7, 0)
+#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
 	time.set_time(cloud->header.stamp / 1000000U, cloud->header.stamp % 1000000);
+#else
+#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
+	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
 #	else
 	PointCloudTimestamp pclts;
 	pclts.timestamp = cloud->header.stamp;
@@ -152,11 +152,11 @@ template <typename PointT>
 inline void
 get_time(const fawkes::RefPtr<pcl::PointCloud<PointT>> &cloud, fawkes::Time &time)
 {
-#if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
-	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
-#else
-#	if PCL_VERSION_COMPARE(>=, 1, 7, 0)
+#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
 	time.set_time(cloud->header.stamp / 1000000U, cloud->header.stamp % 1000000);
+#else
+#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
+	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
 #	else
 	PointCloudTimestamp pclts;
 	pclts.timestamp = cloud->header.stamp;
@@ -175,11 +175,11 @@ template <typename PointT>
 inline void
 get_time(const pcl::PointCloud<PointT> &cloud, fawkes::Time &time)
 {
-#if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
-	time.set_time(cloud.header.stamp.sec, cloud.header.stamp.nsec / 1000);
-#else
-#	if PCL_VERSION_COMPARE(>=, 1, 7, 0)
+#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
 	time.set_time(cloud.header.stamp / 1000000U, cloud.header.stamp % 1000000);
+#else
+#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
+	time.set_time(cloud.header.stamp.sec, cloud.header.stamp.nsec / 1000);
 #	else
 	PointCloudTimestamp pclts;
 	pclts.timestamp = cloud.header.stamp;
@@ -198,11 +198,11 @@ template <typename PointT>
 inline void
 get_time(const boost::shared_ptr<pcl::PointCloud<PointT>> &cloud, fawkes::Time &time)
 {
-#if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
-	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
-#else
-#	if PCL_VERSION_COMPARE(>=, 1, 7, 0)
+#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
 	time.set_time(cloud->header.stamp / 1000000U, cloud->header.stamp % 1000000);
+#else
+#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
+	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
 #	else
 	PointCloudTimestamp pclts;
 	pclts.timestamp = cloud->header.stamp;
@@ -221,11 +221,11 @@ template <typename PointT>
 inline void
 get_time(const boost::shared_ptr<const pcl::PointCloud<PointT>> &cloud, fawkes::Time &time)
 {
-#if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
-	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
-#else
-#	if PCL_VERSION_COMPARE(>=, 1, 7, 0)
+#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
 	time.set_time(cloud->header.stamp / 1000000U, cloud->header.stamp % 1000000);
+#else
+#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
+	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
 #	else
 	PointCloudTimestamp pclts;
 	pclts.timestamp = cloud->header.stamp;


### PR DESCRIPTION
ROS melodic also ships with an updated PCL. Change the order of the
version checks so we first check the PCL version, and only then check if
we have an old PCL with ROS.