### PR TITLE
lgtm: install libpcl-dev directly

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,9 +1,10 @@
 extraction:
   cpp:
+    prepare:
+      packages:
+      - libpcl-dev
     index:
       build_command:
-      # trigger install of non-whitelisted libpcl-dev
-      - cat /usr/include/pcl-1.8/pcl/pcl_config.h > /dev/null
       - make -j2 uncolored-all
 
 queries:


### PR DESCRIPTION
This package previously had to be installed through a strange hack, but  that hasn't been necessary in a long time. The hack will stop working when the LGTM build environment is upgraded to Ubuntu 19.10.

I've tested that this works on https://lgtm.com/logs/ad4d8523ce6b13ee95871eeb36feb3364f2139f4/lang:cpp