### PR TITLE
protoboard: Template-based, typesafe conversion between ProtoBuf and the blackboard

### DIFF
--- a/src/libs/Makefile
+++ b/src/libs/Makefile
@@ -21,7 +21,7 @@ SUBDIRS = core utils interface netcomm blackboard interfaces config logging tf \
 	  plugin lua aspect network_logger webview gui_utils baseapp navgraph \
 	  fvutils fvcams fvmodels fvfilters fvclassifiers fvstereo fvwidgets \
 	  kdl_parser protobuf_comm protobuf_clips pcl_utils pddl_parser syncpoint \
-	  googletest
+	  googletest protoboard
 
 ifeq ($(HAVE_SIFT),1)
   SUBDIRS += extlib/sift
@@ -70,6 +70,7 @@ pcl_utils: core tf
 kdl_parser: core
 pddl_parser: core
 syncpoint: core googletest logging utils
+protoboard: core aspect blackboard interface protobuf_comm interfaces
 
 include $(BUILDSYSDIR)/rules.mk
 include $(LIBSRCDIR)/extlibs.mk

--- a/src/libs/interfaces/ProtobufPeerInterface.xml
+++ b/src/libs/interfaces/ProtobufPeerInterface.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE interface SYSTEM "interface.dtd">
+<interface name="ProtobufPeerInterface" author="Victor Mataré" year="2017">
+  <data>
+    <comment>Current peers maintained by the protoboard plugin</comment>
+    <field type="int64" name="peers" length="16">Currently active peers</field>
+  </data>
+  <message name="CreatePeer">
+    <comment>Create a peer without encryption</comment>
+    <field type="string" name="address" length="255">IP address or host name</field>
+    <field type="int32" name="port">Port to send to/receive on</field>
+  </message>
+  <message name="CreatePeerLocal">
+    <comment>Create a local peer without encryption (mainly for simulation)</comment>
+    <field type="string" name="address" length="255">IP address or host name</field>
+    <field type="int32" name="send_to_port">Port to send to</field>
+    <field type="int32" name="recv_on_port">Port to receive on</field>
+  </message>
+  <message name="CreatePeerCrypto">
+    <comment>Create a peer with encryption</comment>
+    <field type="string" name="address" length="255">IP address or host name</field>
+    <field type="int32" name="port">Port to send to/receive on</field>
+    <field type="string" name="crypto_key" length="1024">Crypto key</field>
+    <field type="string" name="cipher" length="255">Cipher name</field>
+  </message>
+  <message name="CreatePeerLocalCrypto">
+    <comment>Create a local peer with encryption</comment>
+    <field type="string" name="address" length="255">IP address or host name</field>
+    <field type="int32" name="send_to_port">Port to send to</field>
+    <field type="int32" name="recv_on_port">Port to receive on</field>
+    <field type="string" name="crypto_key" length="1024">Crypto key</field>
+    <field type="string" name="cipher" length="255">Cipher name</field>
+  </message>
+</interface>
+

--- a/src/libs/protoboard/Makefile
+++ b/src/libs/protoboard/Makefile
@@ -1,0 +1,57 @@
+#*****************************************************************************
+#           Makefile Build System for Fawkes: protoboard Library
+#                            -------------------
+#   Created on Wed Jan 30 16:37:24 2013
+#   Copyright (C) 2013 by Tim Niemueller, AllemaniACs RoboCup Team
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../..
+include $(BASEDIR)/etc/buildsys/config.mk
+include $(BUILDSYSDIR)/protobuf.mk
+include $(BUILDSYSDIR)/boost.mk
+
+CFLAGS   += $(CFLAGS_CPP11)
+
+ifeq ($(CC),gcc)
+  ifneq ($(call gcc_atleast_version,4,8),1)
+    GCC_TOO_OLD=1
+  endif
+endif
+
+LIBS_libfawkesprotoboard = \
+  fawkescore fawkesaspects \
+  fawkesblackboard fawkesinterface \
+  fawkes_protobuf_comm \
+  ProtobufPeerInterface
+
+OBJS_libfawkesprotoboard = protobuf_thread.o protobuf_to_bb.o
+ 
+LIBS_all = $(LIBDIR)/libfawkesprotoboard.$(SOEXT)
+OBJS_all = $(OBJS_libfawkesprotoboard)
+
+
+ifneq ($(GCC_TOO_OLD),1)
+  LIBS_build  = $(LIBS_all)
+else
+  WARN_TARGETS += warning_old_gcc
+endif
+
+ALLOW_UNDEF_libfawkesprotoboard = 1
+
+ifeq ($(OBJSSUBMAKE),1)
+all: $(WARN_TARGETS) $(WARN_TARGETS_BOOST)
+.PHONY: $(WARN_TARGETS)
+warning_old_gcc:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Can't build protoboard plugin$(TNORMAL) (GCC too old, have $(GCC_VERSION), required 4.8)"
+endif
+
+include $(BUILDSYSDIR)/base.mk
+

--- a/src/libs/protoboard/Makefile
+++ b/src/libs/protoboard/Makefile
@@ -32,7 +32,7 @@ LIBS_libfawkesprotoboard = \
   fawkes_protobuf_comm \
   ProtobufPeerInterface
 
-OBJS_libfawkesprotoboard = protobuf_thread.o protobuf_to_bb.o
+OBJS_libfawkesprotoboard = protobuf_thread.o protobuf_to_bb.o blackboard_manager.o
  
 LIBS_all = $(LIBDIR)/libfawkesprotoboard.$(SOEXT)
 OBJS_all = $(OBJS_libfawkesprotoboard)

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -56,6 +56,7 @@ BlackboardManager::set_protobuf_sender(AbstractProtobufSender *sender)
 void
 BlackboardManager::init()
 {
+	pb_sender_->init();
 	peer_iface_ = blackboard->open_for_writing<ProtobufPeerInterface>("/protoboard/peers");
 
 	on_message_waker_ = new fawkes::BlackBoardOnMessageWaker(blackboard, peer_iface_, this);

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -94,19 +94,20 @@ BlackboardManager::loop()
 		pb_conversion_map::iterator     it;
 
 		if ((it = bb_receiving_interfaces_.find(inc.msg->GetTypeName()))
-		    == bb_receiving_interfaces_.end())
+		    == bb_receiving_interfaces_.end()) {
 			logger->log_error(name(),
 			                  "Received message of unregistered type `%s'",
 			                  inc.msg->GetTypeName().c_str());
-		else
-			try {
-				it->second->handle(inc.msg);
-			} catch (std::exception &e) {
-				logger->log_error(name(),
-				                  "Exception while handling %s: %s",
-				                  inc.msg->GetTypeName().c_str(),
-				                  e.what());
-			}
+			continue;
+		}
+		try {
+			it->second->handle(inc.msg);
+		} catch (std::exception &e) {
+			logger->log_error(name(),
+			                  "Exception while handling %s: %s",
+			                  inc.msg->GetTypeName().c_str(),
+			                  e.what());
+		}
 
 		did_something = true;
 	}

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -1,0 +1,161 @@
+
+/***************************************************************************
+ * Protoboard plugin template
+ * - blackboard manager implementation: Watch interfaces specified in
+ *   instantiation and call to protobuf sender thread accordingly.
+ *   Also specialize templates for peer handling since that is domain
+ *   independent.
+ *
+ * Copyright 2019 Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "blackboard_manager.h"
+
+#include "protobuf_to_bb.h"
+
+namespace protoboard {
+
+using namespace fawkes;
+
+AbstractProtobufSender::AbstractProtobufSender(BlackboardManager *bb_mgr) : bb_manager(bb_mgr)
+{
+}
+
+BlackboardManager::BlackboardManager(ProtobufThead *msg_handler)
+: fawkes::Thread("ProtoboardBlackboardManager", Thread::OPMODE_WAITFORWAKEUP),
+  message_handler_(msg_handler),
+  bb_receiving_interfaces_(make_receiving_interfaces_map()),
+  on_message_waker_(nullptr),
+  next_peer_idx_(0)
+{
+}
+
+void
+BlackboardManager::set_protobuf_sender(AbstractProtobufSender *sender)
+{
+	pb_sender_.reset(sender);
+}
+
+void
+BlackboardManager::init()
+{
+	peer_iface_ = blackboard->open_for_writing<ProtobufPeerInterface>("/protoboard/peers");
+
+	on_message_waker_ = new fawkes::BlackBoardOnMessageWaker(blackboard, peer_iface_, this);
+
+	for (pb_conversion_map::value_type &c : bb_receiving_interfaces_)
+		c.second->init(blackboard, logger);
+}
+
+void
+BlackboardManager::finalize()
+{
+	delete on_message_waker_;
+	blackboard->close(peer_iface_);
+}
+
+void
+BlackboardManager::loop()
+{
+	// Handle CreatePeer* messages
+	bool did_something = on_interface<ProtobufPeerInterface>{peer_iface_, this}
+	                       .handle_msg_types<ProtobufPeerInterface::CreatePeerMessage,
+	                                         ProtobufPeerInterface::CreatePeerLocalMessage,
+	                                         ProtobufPeerInterface::CreatePeerCryptoMessage,
+	                                         ProtobufPeerInterface::CreatePeerLocalCryptoMessage>();
+
+	// Handle sending blackboard interfaces
+	did_something |= pb_sender_->process_sending_interfaces();
+
+	// Handle receiving blackboard interfaces
+	while (message_handler_->pb_queue_incoming()) {
+		ProtobufThead::incoming_message inc = message_handler_->pb_queue_pop();
+		pb_conversion_map::iterator     it;
+
+		if ((it = bb_receiving_interfaces_.find(inc.msg->GetTypeName()))
+		    == bb_receiving_interfaces_.end())
+			logger->log_error(name(),
+			                  "Received message of unregistered type `%s'",
+			                  inc.msg->GetTypeName().c_str());
+		else
+			try {
+				it->second->handle(inc.msg);
+			} catch (std::exception &e) {
+				logger->log_error(name(),
+				                  "Exception while handling %s: %s",
+				                  inc.msg->GetTypeName().c_str(),
+				                  e.what());
+			}
+
+		did_something = true;
+	}
+
+	if (!did_something)
+		// Thread woke up, but nothing was handled
+		logger->log_warn(name(), "Spurious wakeup. WTF?");
+}
+
+void
+BlackboardManager::add_peer(ProtobufPeerInterface *iface, long peer_id)
+{
+	// TODO: Properly handle overflow.
+	iface->set_peers(next_peer_idx_++ % iface->maxlenof_peers(), peer_id);
+	iface->write();
+}
+
+template <>
+void
+BlackboardManager::handle_message(ProtobufPeerInterface *                   iface,
+                                  ProtobufPeerInterface::CreatePeerMessage *msg)
+{
+	add_peer(iface, message_handler_->peer_create(msg->address(), msg->port()));
+}
+
+template <>
+void
+BlackboardManager::handle_message(ProtobufPeerInterface *                        iface,
+                                  ProtobufPeerInterface::CreatePeerLocalMessage *msg)
+{
+	add_peer(iface,
+	         message_handler_->peer_create_local(msg->address(),
+	                                             msg->send_to_port(),
+	                                             msg->recv_on_port()));
+}
+
+template <>
+void
+BlackboardManager::handle_message(ProtobufPeerInterface *                         iface,
+                                  ProtobufPeerInterface::CreatePeerCryptoMessage *msg)
+{
+	add_peer(iface,
+	         message_handler_->peer_create_crypto(
+	           msg->address(), msg->port(), msg->crypto_key(), msg->cipher()));
+}
+
+template <>
+void
+BlackboardManager::handle_message(ProtobufPeerInterface *                              iface,
+                                  ProtobufPeerInterface::CreatePeerLocalCryptoMessage *msg)
+{
+	add_peer(iface,
+	         message_handler_->peer_create_local_crypto(msg->address(),
+	                                                    msg->send_to_port(),
+	                                                    msg->recv_on_port(),
+	                                                    msg->crypto_key(),
+	                                                    msg->cipher()));
+}
+
+} // namespace protoboard

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -129,6 +129,11 @@ BlackboardManager::add_peer(ProtobufPeerInterface *iface, long peer_id)
 	iface->write();
 }
 
+/**
+ * Local specialization for the CreatePeerMessage that establishes ProtoBuf communication
+ * @param iface The ProtobufPeerInterface
+ * @param msg The incoming CreatePeerMessage
+ */
 template <>
 void
 BlackboardManager::handle_message(ProtobufPeerInterface *                   iface,
@@ -137,6 +142,11 @@ BlackboardManager::handle_message(ProtobufPeerInterface *                   ifac
 	add_peer(iface, message_handler_->peer_create(msg->address(), msg->port()));
 }
 
+/**
+ * Local specialization for the CreatePeerLocalMessage that establishes ProtoBuf communication
+ * @param iface The ProtobufPeerInterface
+ * @param msg The incoming CreatePeerLocalMessage
+ */
 template <>
 void
 BlackboardManager::handle_message(ProtobufPeerInterface *                        iface,
@@ -148,6 +158,11 @@ BlackboardManager::handle_message(ProtobufPeerInterface *                       
 	                                             msg->recv_on_port()));
 }
 
+/**
+ * Local specialization for the CreatePeerCryptoMessage that establishes ProtoBuf communication
+ * @param iface The ProtobufPeerInterface
+ * @param msg The incoming CreatePeerCryptoMessage
+ */
 template <>
 void
 BlackboardManager::handle_message(ProtobufPeerInterface *                         iface,
@@ -158,6 +173,11 @@ BlackboardManager::handle_message(ProtobufPeerInterface *                       
 	           msg->address(), msg->port(), msg->crypto_key(), msg->cipher()));
 }
 
+/**
+ * Local specialization for the CreatePeerLocalCryptoMessage that establishes ProtoBuf communication
+ * @param iface The ProtobufPeerInterface
+ * @param msg The incoming CreatePeerLocalCryptoMessage
+ */
 template <>
 void
 BlackboardManager::handle_message(ProtobufPeerInterface *                              iface,

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -69,6 +69,7 @@ void
 BlackboardManager::finalize()
 {
 	delete on_message_waker_;
+	bb_receiving_interfaces_.clear();
 	blackboard->close(peer_iface_);
 }
 

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -125,8 +125,7 @@ BlackboardManager::get_blackboard()
 void
 BlackboardManager::add_peer(ProtobufPeerInterface *iface, long peer_id)
 {
-	// TODO: Properly handle overflow.
-	iface->set_peers(next_peer_idx_++ % iface->maxlenof_peers(), peer_id);
+	iface->set_peers(next_peer_idx_++, peer_id);
 	iface->write();
 }
 

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -45,6 +45,7 @@ BlackboardManager::BlackboardManager(ProtobufThead *msg_handler)
   on_message_waker_(nullptr),
   next_peer_idx_(0)
 {
+	set_coalesce_wakeups(true);
 }
 
 void

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -71,6 +71,7 @@ BlackboardManager::finalize()
 {
 	delete on_message_waker_;
 	bb_receiving_interfaces_.clear();
+	pb_sender_->finalize();
 	blackboard->close(peer_iface_);
 }
 

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -79,14 +79,14 @@ void
 BlackboardManager::loop()
 {
 	// Handle CreatePeer* messages
-	bool did_something = on_interface<ProtobufPeerInterface>{peer_iface_, this}
-	                       .handle_msg_types<ProtobufPeerInterface::CreatePeerMessage,
-	                                         ProtobufPeerInterface::CreatePeerLocalMessage,
-	                                         ProtobufPeerInterface::CreatePeerCryptoMessage,
-	                                         ProtobufPeerInterface::CreatePeerLocalCryptoMessage>();
+	on_interface<ProtobufPeerInterface>{peer_iface_, this}
+	  .handle_msg_types<ProtobufPeerInterface::CreatePeerMessage,
+	                    ProtobufPeerInterface::CreatePeerLocalMessage,
+	                    ProtobufPeerInterface::CreatePeerCryptoMessage,
+	                    ProtobufPeerInterface::CreatePeerLocalCryptoMessage>();
 
 	// Handle sending blackboard interfaces
-	did_something |= pb_sender_->process_sending_interfaces();
+	pb_sender_->process_sending_interfaces();
 
 	// Handle receiving blackboard interfaces
 	while (message_handler_->pb_queue_incoming()) {
@@ -108,13 +108,7 @@ BlackboardManager::loop()
 			                  inc.msg->GetTypeName().c_str(),
 			                  e.what());
 		}
-
-		did_something = true;
 	}
-
-	if (!did_something)
-		// Thread woke up, but nothing was handled
-		logger->log_warn(name(), "Spurious wakeup. WTF?");
 }
 
 BlackBoard *

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -120,6 +120,12 @@ BlackboardManager::get_blackboard()
 void
 BlackboardManager::add_peer(ProtobufPeerInterface *iface, long peer_id)
 {
+	if (next_peer_idx_ >= iface->maxlenof_peers()) {
+		logger->log_error(name(),
+		                  "Maximum number of peers reached. Can't create new peer with index %d!",
+		                  next_peer_idx_);
+		return;
+	}
 	iface->set_peers(next_peer_idx_++, peer_id);
 	iface->write();
 }

--- a/src/libs/protoboard/blackboard_manager.cpp
+++ b/src/libs/protoboard/blackboard_manager.cpp
@@ -34,6 +34,10 @@ AbstractProtobufSender::AbstractProtobufSender(BlackboardManager *bb_mgr) : bb_m
 {
 }
 
+AbstractProtobufSender::~AbstractProtobufSender()
+{
+}
+
 BlackboardManager::BlackboardManager(ProtobufThead *msg_handler)
 : fawkes::Thread("ProtoboardBlackboardManager", Thread::OPMODE_WAITFORWAKEUP),
   message_handler_(msg_handler),
@@ -106,6 +110,12 @@ BlackboardManager::loop()
 	if (!did_something)
 		// Thread woke up, but nothing was handled
 		logger->log_warn(name(), "Spurious wakeup. WTF?");
+}
+
+BlackBoard *
+BlackboardManager::get_blackboard()
+{
+	return blackboard;
 }
 
 void

--- a/src/libs/protoboard/blackboard_manager.h
+++ b/src/libs/protoboard/blackboard_manager.h
@@ -92,6 +92,8 @@ public:
 	virtual ~AbstractProtobufSender();
 	virtual bool process_sending_interfaces() = 0;
 
+	virtual void init() = 0;
+
 protected:
 	BlackboardManager *bb_manager;
 
@@ -113,6 +115,8 @@ class ProtobufSender : public AbstractProtobufSender
 {
 public:
 	ProtobufSender(BlackboardManager *bb_mgr);
+
+	virtual void init() override;
 
 	virtual bool
 	process_sending_interfaces() override
@@ -189,6 +193,12 @@ private:
 template <class... IfaceManagerTs>
 ProtobufSender<IfaceManagerTs...>::ProtobufSender(BlackboardManager *bb_mgr)
 : AbstractProtobufSender(bb_mgr)
+{
+}
+
+template <class... IfaceManagerTs>
+void
+ProtobufSender<IfaceManagerTs...>::init()
 {
 	boost::fusion::for_each(bb_sending_interfaces_, [this](auto &iface_mgr) {
 		iface_mgr.init(this->bb_manager->get_blackboard(), this->bb_manager);

--- a/src/libs/protoboard/blackboard_manager.h
+++ b/src/libs/protoboard/blackboard_manager.h
@@ -84,8 +84,7 @@ public:
 	void
 	finalize()
 	{
-		if (waker_)
-			delete waker_;
+		delete waker_;
 		if (blackboard_ && interface_)
 			blackboard_->close(interface_);
 	}

--- a/src/libs/protoboard/blackboard_manager.h
+++ b/src/libs/protoboard/blackboard_manager.h
@@ -77,7 +77,12 @@ public:
 	{
 		blackboard_ = blackboard;
 		interface_  = blackboard_->open_for_writing<IfaceT>(iface_id_for_type<IfaceT>().c_str());
-		waker_      = new fawkes::BlackBoardOnMessageWaker(blackboard, interface_, thread);
+
+		// TODO: This rather unspecific waker just triggers a loop(), so we need to go over all the interfaces
+		//       each time and check where there's a message in the queue. This should be converted to a
+		//       BlackBoardInterfaceListener, which calls a specific method and passes in the affected interface
+		//       right away. That should allow significant simplification of all this template hackery.
+		waker_ = new fawkes::BlackBoardOnMessageWaker(blackboard, interface_, thread);
 	}
 
 	/// Cleanup.

--- a/src/libs/protoboard/blackboard_manager.h
+++ b/src/libs/protoboard/blackboard_manager.h
@@ -312,6 +312,7 @@ BlackboardManager::handle_message_type(InterfaceT *iface)
 		while (MessageT *msg = iface->msgq_first_safe(msg)) {
 			try {
 				handle_message(iface, msg);
+				iface->write();
 			} catch (std::exception &e) {
 				logger->log_error(
 				  name(), "Exception handling %s on %s: %s", msg->type(), iface->uid(), e.what());
@@ -319,7 +320,6 @@ BlackboardManager::handle_message_type(InterfaceT *iface)
 			iface->msgq_pop();
 			rv = true;
 		}
-		iface->write();
 		return rv;
 	} else
 		return false;

--- a/src/libs/protoboard/blackboard_manager.h
+++ b/src/libs/protoboard/blackboard_manager.h
@@ -1,0 +1,247 @@
+
+/***************************************************************************
+ * Protoboard plugin template
+ * - Header for the blackboard manager
+ *
+ * Copyright 2019 Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef BLACKBOARD_MANAGER_H
+#define BLACKBOARD_MANAGER_H
+
+#include "protoboard_types.h"
+#include "protobuf_thread.h"
+
+#include <aspect/blackboard.h>
+#include <aspect/blocked_timing.h>
+#include <aspect/clock.h>
+#include <aspect/configurable.h>
+#include <aspect/logging.h>
+#include <blackboard/utils/on_message_waker.h>
+#include <core/threading/thread.h>
+#include <interfaces/ProtobufPeerInterface.h>
+
+#include <boost/fusion/include/any.hpp>
+#include <boost/fusion/include/for_each.hpp>
+#include <boost/fusion/include/std_tuple.hpp>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+namespace protoboard {
+
+template <class IfaceT>
+std::string iface_id_for_type();
+
+template <class IfaceT>
+std::string
+iface_id_for_type(size_t idx)
+{
+	return iface_id_for_type<IfaceT>() + std::to_string(idx);
+}
+
+std::vector<std::string> proto_dirs();
+pb_conversion_map        make_receiving_interfaces_map();
+
+template <class IfaceT, class MessageTypeList>
+class bb_iface_manager
+{
+public:
+	bb_iface_manager() : interface_(nullptr), blackboard_(nullptr), waker_(nullptr)
+	{
+	}
+
+	void
+	init(fawkes::BlackBoard *blackboard, fawkes::Thread *thread)
+	{
+		blackboard_ = blackboard;
+		interface_  = blackboard_->open_for_writing<IfaceT>(iface_id_for_type<IfaceT>().c_str());
+		waker_      = new fawkes::BlackBoardOnMessageWaker(blackboard, interface_, thread);
+	}
+
+	~bb_iface_manager()
+	{
+		if (blackboard_ && interface_)
+			blackboard_->close(interface_);
+		if (waker_)
+			delete waker_;
+	}
+
+	IfaceT *
+	interface() const
+	{
+		return interface_;
+	}
+
+private:
+	IfaceT *                          interface_;
+	fawkes::BlackBoard *              blackboard_;
+	fawkes::BlackBoardOnMessageWaker *waker_;
+};
+
+class AbstractProtobufSender
+{
+public:
+	AbstractProtobufSender(BlackboardManager *bb_mgr);
+	virtual ~AbstractProtobufSender();
+	virtual bool process_sending_interfaces() = 0;
+
+protected:
+	BlackboardManager *bb_manager;
+
+	struct handle_messages
+	{
+		BlackboardManager *manager;
+
+		template <class IfaceT, class MessageT>
+		bool operator()(const bb_iface_manager<IfaceT, type_list<MessageT>> &pair) const;
+
+		template <class IfaceT, class MessageT1, class... MessageTs>
+		bool
+		operator()(const bb_iface_manager<IfaceT, type_list<MessageT1, MessageTs...>> &iface_mgr) const;
+	};
+};
+
+template <class... IfaceManagerTs>
+class ProtobufSender : public AbstractProtobufSender
+{
+public:
+	ProtobufSender(BlackboardManager *bb_mgr);
+
+	virtual bool
+	process_sending_interfaces() override
+	{
+		return boost::fusion::any(bb_sending_interfaces_, handle_messages{this->bb_manager});
+	}
+
+private:
+	std::tuple<IfaceManagerTs...> bb_sending_interfaces_;
+};
+
+class BlackboardManager : public fawkes::Thread,
+                          public fawkes::LoggingAspect,
+                          public fawkes::ConfigurableAspect,
+                          public fawkes::BlackBoardAspect,
+                          public fawkes::ClockAspect
+{
+public:
+	BlackboardManager(ProtobufThead *msg_handler);
+
+	fawkes::BlackBoard *get_blackboard();
+	void                set_protobuf_sender(AbstractProtobufSender *sender);
+
+	friend AbstractProtobufSender;
+
+protected:
+	virtual void init() override;
+	virtual void finalize() override;
+	virtual void loop() override;
+
+	template <class InterfaceT, class MessageT>
+	void handle_message(InterfaceT *iface, MessageT *msg);
+
+private:
+	ProtobufThead *                         message_handler_;
+	fawkes::ProtobufPeerInterface *         peer_iface_;
+	pb_conversion_map                       bb_receiving_interfaces_;
+	fawkes::BlackBoardOnMessageWaker *      on_message_waker_;
+	unsigned int                            next_peer_idx_;
+	std::unique_ptr<AbstractProtobufSender> pb_sender_;
+
+	void add_peer(fawkes::ProtobufPeerInterface *iface, long peer_id);
+
+	template <class MessageT, class InterfaceT>
+	bool handle_message_type(InterfaceT *iface);
+
+	template <class InterfaceT>
+	struct on_interface
+	{
+		InterfaceT *       iface;
+		BlackboardManager *manager;
+
+		on_interface(InterfaceT *iface, BlackboardManager *manager) : iface(iface), manager(manager)
+		{
+		}
+
+		template <class MessageT>
+		bool
+		handle_msg_types()
+		{
+			return manager->handle_message_type<MessageT>(iface);
+		}
+
+		// This template is disabled if MessageTs is {} to resolve ambiguity
+		template <class MessageT1, class... MessageTs>
+		typename std::enable_if<(sizeof...(MessageTs) > 0), bool>::type
+		handle_msg_types()
+		{
+			return handle_msg_types<MessageTs...>() || handle_msg_types<MessageT1>();
+		}
+	};
+};
+
+template <class... IfaceManagerTs>
+ProtobufSender<IfaceManagerTs...>::ProtobufSender(BlackboardManager *bb_mgr)
+: AbstractProtobufSender(bb_mgr)
+{
+	boost::fusion::for_each(bb_sending_interfaces_, [this](auto &iface_mgr) {
+		iface_mgr.init(this->bb_manager->get_blackboard(), this->bb_manager);
+	});
+}
+
+template <class IfaceT, class MessageT>
+bool
+AbstractProtobufSender::handle_messages::
+operator()(const bb_iface_manager<IfaceT, type_list<MessageT>> &pair) const
+{
+	return manager->handle_message_type<MessageT>(pair.interface());
+}
+
+template <class IfaceT, class MessageT1, class... MessageTs>
+bool
+AbstractProtobufSender::handle_messages::
+operator()(const bb_iface_manager<IfaceT, type_list<MessageT1, MessageTs...>> &iface_mgr) const
+{
+	return BlackboardManager::on_interface<IfaceT>{iface_mgr.interface(), manager}
+	         .template handle_msg_types<MessageTs...>()
+	       || manager->handle_message_type<MessageT1>(iface_mgr.interface());
+}
+
+template <class MessageT, class InterfaceT>
+bool
+BlackboardManager::handle_message_type(InterfaceT *iface)
+{
+	if (!iface->msgq_empty()) {
+		bool rv = false;
+		while (MessageT *msg = iface->msgq_first_safe(msg)) {
+			try {
+				handle_message(iface, msg);
+			} catch (std::exception &e) {
+				logger->log_error(
+				  name(), "Exception handling %s on %s: %s", msg->type(), iface->uid(), e.what());
+			}
+			iface->msgq_pop();
+			rv = true;
+		}
+		iface->write();
+		return rv;
+	} else
+		return false;
+}
+
+} // namespace protoboard
+
+#endif // BLACKBOARD_MANAGER_H

--- a/src/libs/protoboard/blackboard_manager.h
+++ b/src/libs/protoboard/blackboard_manager.h
@@ -46,13 +46,6 @@ namespace protoboard {
 template <class IfaceT>
 std::string iface_id_for_type();
 
-template <class IfaceT>
-std::string
-iface_id_for_type(size_t idx)
-{
-	return iface_id_for_type<IfaceT>() + std::to_string(idx);
-}
-
 std::vector<std::string> proto_dirs();
 pb_conversion_map        make_receiving_interfaces_map();
 

--- a/src/libs/protoboard/plugin.h
+++ b/src/libs/protoboard/plugin.h
@@ -28,10 +28,19 @@
 
 #include <core/plugin.h>
 
+/**
+ * The main class template that generates a domain-specific plugin
+ * @tparam IfaceManagerTs A list of @a bb_iface_manager instantiations that specify
+ * what message types should be handled on a given interface type.
+ */
 template <class... IfaceManagerTs>
 class ProtoboardPlugin : public fawkes::Plugin
 {
 public:
+	/**
+	 * Initializes all threads required for the plugin.
+	 * @param cfg The fawkes config
+	 */
 	ProtoboardPlugin(fawkes::Configuration *cfg) : Plugin(cfg)
 	{
 		protoboard::ProtobufThead *    protobuf_thread = new protoboard::ProtobufThead();

--- a/src/libs/protoboard/plugin.h
+++ b/src/libs/protoboard/plugin.h
@@ -35,9 +35,7 @@ public:
 	ProtoboardPlugin(fawkes::Configuration *cfg) : Plugin(cfg)
 	{
 		protoboard::ProtobufThead *    protobuf_thread = new protoboard::ProtobufThead();
-		protoboard::BlackboardManager *bb_mgr          = new protoboard::BlackboardManager{
-      protobuf_thread,
-    };
+		protoboard::BlackboardManager *bb_mgr = new protoboard::BlackboardManager(protobuf_thread);
 		bb_mgr->set_protobuf_sender(new protoboard::ProtobufSender<IfaceManagerTs...>(bb_mgr));
 		protobuf_thread->set_bb_manager(bb_mgr);
 		thread_list.push_back(bb_mgr);

--- a/src/libs/protoboard/plugin.h
+++ b/src/libs/protoboard/plugin.h
@@ -1,0 +1,48 @@
+
+/***************************************************************************
+ * Protoboard plugin template
+ * - Main plugin template: Instantiate this with the appropriate interface
+ *   handler mappings to create a domain-specific plugin.
+ *
+ * Copyright 2019 Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef PROTOBOARD_PLUGIN_H
+#define PROTOBOARD_PLUGIN_H
+
+#include "blackboard_manager.h"
+#include "protobuf_thread.h"
+
+#include <core/plugin.h>
+
+template <class... IfaceManagerTs>
+class ProtoboardPlugin : public fawkes::Plugin
+{
+public:
+	ProtoboardPlugin(fawkes::Configuration *cfg) : Plugin(cfg)
+	{
+		protoboard::ProtobufThead *    protobuf_thread = new protoboard::ProtobufThead();
+		protoboard::BlackboardManager *bb_mgr          = new protoboard::BlackboardManager{
+      protobuf_thread,
+    };
+		bb_mgr->set_protobuf_sender(new protoboard::ProtobufSender<IfaceManagerTs...>(bb_mgr));
+		protobuf_thread->set_bb_manager(bb_mgr);
+		thread_list.push_back(bb_mgr);
+		thread_list.push_back(protobuf_thread);
+	}
+};
+
+#endif // PROTOBOARD_PLUGIN_H

--- a/src/libs/protoboard/protoboard_types.h
+++ b/src/libs/protoboard/protoboard_types.h
@@ -1,0 +1,74 @@
+
+/***************************************************************************
+ * Protoboard plugin template
+ * - General forward declarations
+ *
+ * Copyright 2019 Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef PROTOBOARD_TYPES_H_
+#define PROTOBOARD_TYPES_H_
+
+#include <boost/bimap.hpp>
+#include <memory>
+#include <unordered_map>
+
+namespace protoboard {
+
+class pb_convert;
+
+typedef std::unordered_map<std::string, std::shared_ptr<pb_convert>> pb_conversion_map;
+
+template <typename... Ts>
+struct type_list
+{
+};
+
+class BlackboardManager;
+
+template <class IfaceT>
+struct InterfaceMessageHandler;
+
+template <class pbEnumT, class bbEnumT>
+class enum_map
+{
+public:
+	typedef boost::bimap<pbEnumT, bbEnumT> bimapT;
+	constexpr enum_map(std::initializer_list<typename bimapT::value_type> init)
+	: list(init), map(list.begin(), list.end())
+	{
+	}
+
+	constexpr bbEnumT
+	of(pbEnumT v) const
+	{
+		return map.left.at(v);
+	}
+
+	constexpr pbEnumT
+	of(bbEnumT v) const
+	{
+		return map.right.at(v);
+	}
+
+private:
+	const std::vector<typename bimapT::value_type> list;
+	const bimapT                                   map;
+};
+
+} // namespace protoboard
+
+#endif // PROTOBOARD_TYPES_H_

--- a/src/libs/protoboard/protoboard_types.h
+++ b/src/libs/protoboard/protoboard_types.h
@@ -71,7 +71,7 @@ public:
 	 * @param v a ProtoBuf enum value
 	 * @return the mapped blackboard interface enum value
 	 */
-	constexpr bbEnumT
+	constexpr const bbEnumT &
 	of(pbEnumT v) const
 	{
 		return map.left.at(v);
@@ -81,7 +81,7 @@ public:
 	 * @param v a blackboard interface enum value
 	 * @return the mapped ProtoBuf enum value
 	 */
-	constexpr pbEnumT
+	constexpr const pbEnumT &
 	of(bbEnumT v) const
 	{
 		return map.right.at(v);

--- a/src/libs/protoboard/protoboard_types.h
+++ b/src/libs/protoboard/protoboard_types.h
@@ -32,6 +32,9 @@ class pb_convert;
 
 typedef std::unordered_map<std::string, std::shared_ptr<pb_convert>> pb_conversion_map;
 
+/**
+ * Helper structure to wrap a list of types into a single type.
+ */
 template <typename... Ts>
 struct type_list
 {
@@ -42,22 +45,42 @@ class BlackboardManager;
 template <class IfaceT>
 struct InterfaceMessageHandler;
 
+/**
+ * A compile-time constant bidirectional map that can be used to match blackboard interface enum
+ * values to ProtoBuf's enum values
+ * @tparam pbEnumT a ProtoBuf enum type
+ * @tparam bbEnumT a blackboard interface enum type
+ */
 template <class pbEnumT, class bbEnumT>
 class enum_map
 {
-public:
+private:
 	typedef boost::bimap<pbEnumT, bbEnumT> bimapT;
+
+public:
+	/**
+	 * constexpr constructor
+	 * @param init A curly-brace initializer list that defines the entire mapping
+	 */
 	constexpr enum_map(std::initializer_list<typename bimapT::value_type> init)
 	: list(init), map(list.begin(), list.end())
 	{
 	}
 
+	/**
+	 * @param v a ProtoBuf enum value
+	 * @return the mapped blackboard interface enum value
+	 */
 	constexpr bbEnumT
 	of(pbEnumT v) const
 	{
 		return map.left.at(v);
 	}
 
+	/**
+	 * @param v a blackboard interface enum value
+	 * @return the mapped ProtoBuf enum value
+	 */
 	constexpr pbEnumT
 	of(bbEnumT v) const
 	{

--- a/src/libs/protoboard/protobuf_thread.cpp
+++ b/src/libs/protoboard/protobuf_thread.cpp
@@ -28,7 +28,6 @@
 #include <google/protobuf/descriptor.h>
 #include <protobuf_comm/client.h>
 #include <protobuf_comm/peer.h>
-#include <protobuf_comm/server.h>
 
 using namespace google::protobuf;
 using namespace protobuf_comm;
@@ -38,7 +37,6 @@ namespace protoboard {
 ProtobufThead::ProtobufThead()
 : Thread("ProtoboardMessageHandler", Thread::OPMODE_CONTINUOUS),
   message_register_(nullptr),
-  server_(nullptr),
   next_client_id_(0),
   bb_manager_(nullptr)
 {
@@ -47,7 +45,6 @@ ProtobufThead::ProtobufThead()
 ProtobufThead::~ProtobufThead()
 {
 	delete message_register_;
-	delete server_;
 }
 
 void

--- a/src/libs/protoboard/protobuf_thread.cpp
+++ b/src/libs/protoboard/protobuf_thread.cpp
@@ -1,0 +1,275 @@
+
+/***************************************************************************
+ * Protoboard plugin template
+ * - Implementation of the ProtoBuf thread: protobuf_comm to actually send
+ *   messages.
+ *
+ * Copyright 2019 Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "protobuf_thread.h"
+
+#include "blackboard_manager.h"
+
+#include <core/threading/mutex_locker.h>
+#include <google/protobuf/descriptor.h>
+#include <protobuf_comm/client.h>
+#include <protobuf_comm/peer.h>
+#include <protobuf_comm/server.h>
+
+using namespace google::protobuf;
+using namespace protobuf_comm;
+
+namespace protoboard {
+
+ProtobufThead::ProtobufThead()
+: Thread("ProtoboardMessageHandler", Thread::OPMODE_CONTINUOUS),
+  bb_manager_(nullptr),
+  message_register_(nullptr),
+  server_(nullptr),
+  next_client_id_(0)
+{
+}
+
+ProtobufThead::~ProtobufThead()
+{
+	delete message_register_;
+	delete server_;
+}
+
+void
+ProtobufThead::init()
+{
+	message_register_ = new MessageRegister(proto_dirs());
+
+	if (!bb_manager_)
+		throw fawkes::Exception(
+		  "BUG: %s's reference to blackboard manager thread hasn't been initialized", name());
+}
+
+bool
+ProtobufThead::pb_queue_incoming()
+{
+	fawkes::MutexLocker lock(&msgq_mutex_);
+	return !pb_queue_.empty();
+}
+
+ProtobufThead::incoming_message
+ProtobufThead::pb_queue_pop()
+{
+	fawkes::MutexLocker lock(&msgq_mutex_);
+	incoming_message    msg = pb_queue_.front();
+	pb_queue_.pop();
+	return msg;
+}
+
+/** Enable protobuf peer.
+ * @param address IP address to send messages to
+ * @param send_port UDP port to send messages to
+ * @param recv_port UDP port to receive messages on, 0 to use the same as the @p send_port
+ * @param crypto_key encryption key
+ * @param cipher cipher suite, see BufferEncryptor for supported types
+ * @return peer identifier
+ */
+long int
+ProtobufThead::peer_create_local_crypto(const std::string &address,
+                                        int                send_to_port,
+                                        int                recv_on_port,
+                                        const std::string &crypto_key,
+                                        const std::string &cipher)
+{
+	if (recv_on_port <= 0)
+		recv_on_port = send_to_port;
+
+	if (send_to_port > 0) {
+		protobuf_comm::ProtobufBroadcastPeer *peer = new protobuf_comm::ProtobufBroadcastPeer(
+		  address, send_to_port, recv_on_port, message_register_, crypto_key, cipher);
+
+		long int peer_id;
+		{
+			fawkes::MutexLocker lock(&map_mutex_);
+			peer_id         = ++next_client_id_;
+			peers_[peer_id] = peer;
+		}
+
+		peer->signal_received().connect(
+		  boost::bind(&ProtobufThead::handle_peer_msg, this, peer_id, _1, _2, _3, _4));
+		peer->signal_recv_error().connect(
+		  boost::bind(&ProtobufThead::handle_peer_recv_error, this, peer_id, _1, _2));
+		peer->signal_send_error().connect(
+		  boost::bind(&ProtobufThead::handle_peer_send_error, this, peer_id, _1));
+
+		return peer_id;
+	} else {
+		return 0;
+	}
+}
+
+/** Enable protobuf peer.
+ * @param address IP address to send messages to
+ * @param port UDP port to send and receive messages
+ * @param crypto_key encryption key
+ * @param cipher cipher suite, see BufferEncryptor for supported types
+ * @return peer identifier
+ */
+long int
+ProtobufThead::peer_create_crypto(const std::string &address,
+                                  int                port,
+                                  const std::string &crypto_key,
+                                  const std::string &cipher)
+{
+	return peer_create_local_crypto(address, port, port, crypto_key, cipher);
+}
+
+/** Enable protobuf peer.
+ * @param address IP address to send messages to
+ * @param port UDP port to send and receive messages
+ * @return peer identifier
+ */
+long int
+ProtobufThead::peer_create(const std::string &address, int port)
+{
+	return peer_create_local_crypto(address, port, port);
+}
+
+/** Enable protobuf peer.
+ * @param address IP address to send messages to
+ * @param send_port UDP port to send messages to
+ * @param recv_port UDP port to receive messages on, 0 to use the same as the @p send_port
+ * @return peer identifier
+ */
+long int
+ProtobufThead::peer_create_local(const std::string &address, int send_to_port, int recv_on_port)
+{
+	return peer_create_local_crypto(address, send_to_port, recv_on_port);
+}
+
+/** Disable peer.
+ * @param peer_id ID of the peer to destroy
+ */
+void
+ProtobufThead::peer_destroy(long int peer_id)
+{
+	if (peers_.find(peer_id) != peers_.end()) {
+		delete peers_[peer_id];
+		peers_.erase(peer_id);
+	}
+}
+
+/** Setup crypto for peer.
+ * @param peer_id ID of the peer to destroy
+ * @param crypto_key encryption key
+ * @param cipher cipher suite, see BufferEncryptor for supported types
+ */
+void
+ProtobufThead::peer_setup_crypto(long int           peer_id,
+                                 const std::string &crypto_key,
+                                 const std::string &cipher)
+{
+	if (peers_.find(peer_id) != peers_.end()) {
+		peers_[peer_id]->setup_crypto(crypto_key, cipher);
+	}
+}
+
+void
+ProtobufThead::send(long int peer_id, std::shared_ptr<google::protobuf::Message> m)
+{
+	if (!m) {
+		if (logger) {
+			logger->log_warn(name(), "Cannot send broadcast: invalid message");
+		}
+		return;
+	}
+
+	fawkes::MutexLocker lock(&map_mutex_);
+	if (peers_.find(peer_id) == peers_.end())
+		return;
+
+	//logger->log_info(name(), "Broadcasting %s", (*m)->GetTypeName().c_str());
+	try {
+		peers_[peer_id]->send(m);
+	} catch (google::protobuf::FatalException &e) {
+		if (logger) {
+			logger->log_warn(name(),
+			                 "Failed to broadcast message of type %s: %s",
+			                 m->GetTypeName().c_str(),
+			                 e.what());
+		}
+	} catch (fawkes::Exception &e) {
+		if (logger) {
+			logger->log_warn(name(),
+			                 "Failed to broadcast message of type %s: %s",
+			                 m->GetTypeName().c_str(),
+			                 e.what_no_backtrace());
+		}
+	} catch (std::runtime_error &e) {
+		if (logger) {
+			logger->log_warn(name(),
+			                 "Failed to broadcast message of type %s: %s",
+			                 m->GetTypeName().c_str(),
+			                 e.what());
+		}
+	}
+}
+
+/** Handle message that came from a peer/robot
+ * @param endpoint the endpoint from which the message was received
+ * @param component_id component the message was addressed to
+ * @param msg_type type of the message
+ * @param msg the message
+ */
+void
+ProtobufThead::handle_peer_msg(long int                        peer_id,
+                               boost::asio::ip::udp::endpoint &endpoint,
+                               uint16_t                        component_id,
+                               uint16_t                        msg_type,
+                               std::shared_ptr<Message>        msg)
+{
+	fawkes::MutexLocker lock(&msgq_mutex_);
+	pb_queue_.push({peer_id, endpoint, component_id, msg_type, std::move(msg)});
+	bb_manager_->wakeup();
+}
+
+/** Handle error during peer message processing.
+ * @param endpoint endpoint of incoming message
+ * @param msg error message
+ */
+void
+ProtobufThead::handle_peer_recv_error(long int                        peer_id,
+                                      boost::asio::ip::udp::endpoint &endpoint,
+                                      std::string                     msg)
+{
+	if (logger) {
+		logger->log_warn(name(),
+		                 "Failed to receive peer message from %s:%u: %s",
+		                 endpoint.address().to_string().c_str(),
+		                 endpoint.port(),
+		                 msg.c_str());
+	}
+}
+
+/** Handle error during peer message processing.
+ * @param msg error message
+ */
+void
+ProtobufThead::handle_peer_send_error(long int peer_id, std::string msg)
+{
+	if (logger) {
+		logger->log_warn(name(), "Failed to send peer message: %s", msg.c_str());
+	}
+}
+
+} // namespace protoboard

--- a/src/libs/protoboard/protobuf_thread.cpp
+++ b/src/libs/protoboard/protobuf_thread.cpp
@@ -37,10 +37,10 @@ namespace protoboard {
 
 ProtobufThead::ProtobufThead()
 : Thread("ProtoboardMessageHandler", Thread::OPMODE_CONTINUOUS),
-  bb_manager_(nullptr),
   message_register_(nullptr),
   server_(nullptr),
-  next_client_id_(0)
+  next_client_id_(0),
+  bb_manager_(nullptr)
 {
 }
 
@@ -78,8 +78,8 @@ ProtobufThead::pb_queue_pop()
 
 /** Enable protobuf peer.
  * @param address IP address to send messages to
- * @param send_port UDP port to send messages to
- * @param recv_port UDP port to receive messages on, 0 to use the same as the @p send_port
+ * @param send_to_port UDP port to send messages to
+ * @param recv_on_port UDP port to receive messages on, 0 to use the same as the @p send_port
  * @param crypto_key encryption key
  * @param cipher cipher suite, see BufferEncryptor for supported types
  * @return peer identifier
@@ -147,8 +147,8 @@ ProtobufThead::peer_create(const std::string &address, int port)
 
 /** Enable protobuf peer.
  * @param address IP address to send messages to
- * @param send_port UDP port to send messages to
- * @param recv_port UDP port to receive messages on, 0 to use the same as the @p send_port
+ * @param send_to_port UDP port to send messages to
+ * @param recv_on_port UDP port to receive messages on, 0 to use the same as the @p send_port
  * @return peer identifier
  */
 long int

--- a/src/libs/protoboard/protobuf_thread.h
+++ b/src/libs/protoboard/protobuf_thread.h
@@ -1,0 +1,157 @@
+
+/***************************************************************************
+ * Protoboard plugin template
+ * - Header for the ProtoBuf thread
+ *
+ * Copyright 2019 Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef MESSAGE_HANDLER_H
+#define MESSAGE_HANDLER_H
+
+#include <aspect/blackboard.h>
+#include <aspect/configurable.h>
+#include <aspect/logging.h>
+#include <core/threading/mutex.h>
+#include <core/threading/thread.h>
+#include <protobuf_comm/server.h>
+
+#include <list>
+#include <map>
+#include <queue>
+
+#define CFG_PREFIX "/plugins/protoboard"
+
+namespace protobuf_comm {
+class ProtobufStreamClient;
+class ProtobufBroadcastPeer;
+} // namespace protobuf_comm
+
+namespace protoboard {
+
+class BlackboardManager;
+
+class ProtobufThead : public fawkes::Thread,
+                      public fawkes::LoggingAspect,
+                      public fawkes::ConfigurableAspect,
+                      public fawkes::BlackBoardAspect
+{
+public:
+	ProtobufThead();
+	virtual ~ProtobufThead() override;
+
+	bool pb_queue_incoming();
+
+	struct incoming_message
+	{
+		long int                                   peer_id;
+		boost::asio::ip::udp::endpoint             endpoint;
+		uint16_t                                   component_id;
+		uint16_t                                   msg_type;
+		std::shared_ptr<google::protobuf::Message> msg;
+	};
+
+	incoming_message pb_queue_pop();
+
+	long int peer_create(const std::string &host, int port);
+	long int peer_create_local(const std::string &host, int send_to_port, int recv_on_port);
+	long int peer_create_crypto(const std::string &host,
+	                            int                port,
+	                            const std::string &crypto_key = "",
+	                            const std::string &cipher     = "");
+	long int peer_create_local_crypto(const std::string &host,
+	                                  int                send_to_port,
+	                                  int                recv_on_port,
+	                                  const std::string &crypto_key = "",
+	                                  const std::string &cipher     = "");
+	void     peer_destroy(long int peer_id);
+
+	void send(long int peer_id, std::shared_ptr<google::protobuf::Message> msg);
+
+	/** Get the communicator's message register.
+   * @return message register */
+	protobuf_comm::MessageRegister &
+	message_register()
+	{
+		return *message_register_;
+	}
+
+	void
+	set_bb_manager(BlackboardManager *bb_manager)
+	{
+		bb_manager_ = bb_manager;
+	}
+
+	fawkes::BlackBoard *
+	get_blackboard()
+	{
+		return blackboard;
+	}
+
+protected:
+	virtual void init() override;
+
+private:
+	/** Get protobuf_comm peers.
+   * @return protobuf_comm peer */
+	const std::map<long int, protobuf_comm::ProtobufBroadcastPeer *> &
+	peers() const
+	{
+		return peers_;
+	}
+
+	BlackboardManager *bb_manager_;
+
+	/** Signal invoked for a message that has been sent via broadcast.
+   * @return signal
+   */
+	boost::signals2::signal<void(long, std::shared_ptr<google::protobuf::Message>)> &
+	signal_peer_sent()
+	{
+		return sig_peer_sent_;
+	}
+
+	void
+	peer_setup_crypto(long int peer_id, const std::string &crypto_key, const std::string &cipher);
+
+	void handle_peer_msg(long int                                   peer_id,
+	                     boost::asio::ip::udp::endpoint &           endpoint,
+	                     uint16_t                                   component_id,
+	                     uint16_t                                   msg_type,
+	                     std::shared_ptr<google::protobuf::Message> msg);
+	void handle_peer_recv_error(long int                        peer_id,
+	                            boost::asio::ip::udp::endpoint &endpoint,
+	                            std::string                     msg);
+	void handle_peer_send_error(long int peer_id, std::string msg);
+
+	protobuf_comm::MessageRegister *     message_register_;
+	protobuf_comm::ProtobufStreamServer *server_;
+
+	boost::signals2::signal<void(long int, std::shared_ptr<google::protobuf::Message>)>
+	  sig_peer_sent_;
+
+	fawkes::Mutex map_mutex_;
+	fawkes::Mutex msgq_mutex_;
+	long int      next_client_id_;
+
+	std::map<long int, protobuf_comm::ProtobufBroadcastPeer *> peers_;
+
+	std::queue<incoming_message> pb_queue_;
+};
+
+} // namespace protoboard
+
+#endif // MESSAGE_HANDLER_H

--- a/src/libs/protoboard/protobuf_thread.h
+++ b/src/libs/protoboard/protobuf_thread.h
@@ -154,8 +154,7 @@ private:
 	                            std::string                     msg);
 	void handle_peer_send_error(long int peer_id, std::string msg);
 
-	protobuf_comm::MessageRegister *     message_register_;
-	protobuf_comm::ProtobufStreamServer *server_;
+	protobuf_comm::MessageRegister *message_register_;
 
 	boost::signals2::signal<void(long int, std::shared_ptr<google::protobuf::Message>)>
 	  sig_peer_sent_;

--- a/src/libs/protoboard/protobuf_to_bb.cpp
+++ b/src/libs/protoboard/protobuf_to_bb.cpp
@@ -34,7 +34,7 @@ pb_convert::~pb_convert()
 }
 
 void
-pb_convert::init(fawkes::BlackBoard *blackboard, fawkes::Logger *logger, size_t)
+pb_convert::init(fawkes::BlackBoard *blackboard, fawkes::Logger *logger, const std::string &)
 {
 	blackboard_ = blackboard;
 	logger_     = logger;

--- a/src/libs/protoboard/protobuf_to_bb.cpp
+++ b/src/libs/protoboard/protobuf_to_bb.cpp
@@ -1,0 +1,54 @@
+
+/***************************************************************************
+ * Protoboard plugin template
+ * - Templates that implement translation of incoming ProtoBuf messages
+ *   to BlackBoard interfaces according to the appropriate template
+ *   specializations
+ *
+ * Copyright 2019 Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "protobuf_to_bb.h"
+
+namespace protoboard {
+
+pb_convert::pb_convert() : blackboard_(nullptr), logger_(nullptr)
+{
+}
+
+pb_convert::~pb_convert()
+{
+}
+
+void
+pb_convert::init(fawkes::BlackBoard *blackboard, fawkes::Logger *logger, size_t)
+{
+	blackboard_ = blackboard;
+	logger_     = logger;
+}
+
+void
+pb_convert::handle(std::shared_ptr<google::protobuf::Message> msg)
+{
+	handle(*msg);
+}
+
+void
+pb_convert::handle(const google::protobuf::Message &)
+{
+}
+
+} // namespace protoboard

--- a/src/libs/protoboard/protobuf_to_bb.h
+++ b/src/libs/protoboard/protobuf_to_bb.h
@@ -38,8 +38,6 @@ namespace protoboard {
 
 template <class IfaceT>
 std::string iface_id_for_type();
-template <class IfaceT>
-std::string iface_id_for_type(size_t idx);
 
 class pb_convert : public std::enable_shared_from_this<pb_convert>
 {
@@ -102,10 +100,16 @@ public:
 	init(fawkes::BlackBoard *blackboard, fawkes::Logger *logger, size_t id = 0) override
 	{
 		pb_convert::init(blackboard, logger);
-		interface_ = blackboard_->open_for_writing<IfaceT>(iface_id_for_type<IfaceT>(id).c_str());
+		std::string iface_id = iface_id_for_type<IfaceT>();
+
+		if (iface_id.back() != '/')
+			iface_id += '/';
+		iface_id += std::to_string(id);
+
+		interface_ = blackboard_->open_for_writing<IfaceT>(iface_id.c_str());
 		logger->log_info(boost::core::demangle(typeid(*this).name()).c_str(),
 		                 "Initialized %s.",
-		                 iface_id_for_type<IfaceT>(id).c_str());
+		                 iface_id.c_str());
 	}
 
 	virtual void

--- a/src/libs/protoboard/protobuf_to_bb.h
+++ b/src/libs/protoboard/protobuf_to_bb.h
@@ -1,0 +1,217 @@
+
+/***************************************************************************
+ * Protoboard plugin template
+ * - Templates that implement translation of incoming ProtoBuf messages
+ *   to BlackBoard interfaces according to the appropriate template
+ *   specializations
+ *
+ * Copyright 2019 Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef PROTOBUF_TO_BB_H_
+#define PROTOBUF_TO_BB_H_
+
+#include "protoboard_types.h"
+
+#include <blackboard/blackboard.h>
+#include <google/protobuf/message.h>
+#include <logging/logger.h>
+
+#include <boost/bimap.hpp>
+#include <boost/core/demangle.hpp>
+#include <memory>
+
+namespace protoboard {
+
+template <class IfaceT>
+std::string iface_id_for_type();
+template <class IfaceT>
+std::string iface_id_for_type(size_t idx);
+
+class pb_convert : public std::enable_shared_from_this<pb_convert>
+{
+public:
+	pb_convert();
+
+	pb_convert(const pb_convert &) = default;
+	pb_convert &operator=(const pb_convert &) = default;
+
+	virtual ~pb_convert();
+
+	virtual void init(fawkes::BlackBoard *blackboard, fawkes::Logger *logger, size_t = 0);
+
+	virtual void handle(std::shared_ptr<google::protobuf::Message> msg);
+
+	virtual void handle(const google::protobuf::Message &);
+
+protected:
+	fawkes::BlackBoard *blackboard_;
+	fawkes::Logger *    logger_;
+};
+
+template <class ProtoT, class IfaceT>
+class pb_converter : public pb_convert
+{
+public:
+	typedef ProtoT input_type;
+	typedef IfaceT output_type;
+
+	pb_converter() : pb_convert(), interface_(nullptr)
+	{
+	}
+
+	// Don't copy this
+	pb_converter(const pb_converter<ProtoT, IfaceT> &) = delete;
+	pb_converter<ProtoT, IfaceT> &operator=(const pb_converter<ProtoT, IfaceT> &) = delete;
+
+	// Only move!
+	pb_converter(pb_converter<ProtoT, IfaceT> &&o)
+	: pb_convert(o), interface_(std::move(o.interface_))
+	{
+		o.interface_ = nullptr;
+	}
+
+	pb_converter<ProtoT, IfaceT> &
+	operator=(pb_converter<ProtoT, IfaceT> &&o)
+	{
+		pb_convert::operator=(o);
+		this->interface_    = o.interface_;
+		o.interface_        = nullptr;
+		return *this;
+	}
+
+	virtual ~pb_converter()
+	{
+		close();
+	}
+
+	virtual void
+	init(fawkes::BlackBoard *blackboard, fawkes::Logger *logger, size_t id = 0) override
+	{
+		pb_convert::init(blackboard, logger);
+		interface_ = blackboard_->open_for_writing<IfaceT>(iface_id_for_type<IfaceT>(id).c_str());
+		logger->log_info(boost::core::demangle(typeid(*this).name()).c_str(),
+		                 "Initialized %s.",
+		                 iface_id_for_type<IfaceT>(id).c_str());
+	}
+
+	virtual void
+	handle(const google::protobuf::Message &msg) override
+	{
+		handle(dynamic_cast<const ProtoT &>(msg));
+	}
+
+	virtual void
+	handle(const ProtoT &msg)
+	{
+		handle(msg, interface_);
+		interface_->write();
+	}
+
+	virtual bool
+	is_open()
+	{
+		return interface_;
+	}
+
+	virtual void
+	close()
+	{
+		if (is_open()) {
+			blackboard_->close(interface_);
+			interface_ = nullptr;
+		}
+	}
+
+	IfaceT *
+	interface()
+	{
+		return interface_;
+	}
+
+	virtual bool
+	corresponds_to(const ProtoT &msg)
+	{
+		if (is_open()) {
+			interface()->read();
+			return corresponds(msg, interface());
+		} else
+			return true;
+	}
+
+protected:
+	virtual void handle(const ProtoT &msg, IfaceT *iface);
+	static bool
+	corresponds(const ProtoT &, const IfaceT *)
+	{
+		throw fawkes::Exception(
+		  boost::core::demangle(typeid(pb_converter<ProtoT, IfaceT>).name()).c_str(),
+		  "BUG: corresponds(...) must "
+		  "be overridden for every converter used in a sequence.");
+	}
+
+private:
+	IfaceT *interface_;
+};
+
+template <class ProtoT, class OutputT>
+class pb_sequence_converter : public pb_convert
+{
+public:
+	typedef google::protobuf::RepeatedPtrField<typename OutputT::input_type> sequence_type;
+
+	pb_sequence_converter() : sub_converters_(), seq_id_(0)
+	{
+	}
+
+	virtual void
+	handle(const google::protobuf::Message &msg) override
+	{
+		typename std::vector<OutputT>::iterator out_it = sub_converters_.begin();
+		sequence_type fields = extract_sequence(dynamic_cast<const ProtoT &>(msg));
+		typename sequence_type::const_iterator field_it = fields.begin();
+
+		for (; field_it != fields.end(); ++field_it) {
+			// Try to find a corresponding output converter
+			for (out_it = sub_converters_.begin(); out_it != sub_converters_.end(); ++out_it) {
+				if (out_it->corresponds_to(*field_it))
+					break;
+			}
+
+			if (out_it == sub_converters_.end()) {
+				// No corresponding converter found, create new
+				sub_converters_.emplace_back();
+				out_it = --sub_converters_.end();
+			}
+
+			if (!out_it->is_open())
+				out_it->init(blackboard_, logger_, seq_id_++);
+			out_it->handle(*field_it);
+		}
+
+		sub_converters_.erase(out_it + 1, sub_converters_.end());
+	}
+
+	virtual const sequence_type &extract_sequence(const ProtoT &msg);
+
+private:
+	std::vector<OutputT> sub_converters_;
+	size_t               seq_id_;
+};
+
+} // namespace protoboard
+
+#endif //PROTOBUF_TO_BB_H_

--- a/src/libs/protoboard/protobuf_to_bb.h
+++ b/src/libs/protoboard/protobuf_to_bb.h
@@ -177,7 +177,7 @@ class pb_sequence_converter : public pb_convert
 public:
 	typedef google::protobuf::RepeatedPtrField<typename OutputT::input_type> sequence_type;
 
-	pb_sequence_converter() : sub_converters_(), seq_id_(0)
+	pb_sequence_converter() : seq_id_(0)
 	{
 	}
 
@@ -186,6 +186,15 @@ public:
 	{
 		typename std::vector<OutputT>::iterator out_it = sub_converters_.begin();
 		sequence_type fields = extract_sequence(dynamic_cast<const ProtoT &>(msg));
+
+		if (fields.empty()) {
+			logger_->log_warn(
+			  boost::core::demangle(typeid(pb_sequence_converter<ProtoT, OutputT>).name()).c_str(),
+			  "Received empty sequence of %s",
+			  sequence_type::value_type::descriptor()->name().c_str());
+			return;
+		}
+
 		typename sequence_type::const_iterator field_it = fields.begin();
 
 		for (; field_it != fields.end(); ++field_it) {


### PR DESCRIPTION
This should be close to merge ready. It could benefit from an internal redesign to simplify the call structure within the template code, but the external interface is fine. Only thing that's missing is an explicit documentation of the external interface, but we do have the [`protobuf-rcll` plugin](https://github.com/carologistics/fawkes-robotino/pull/328) as an example in fawkes-robotino.