### PR TITLE
interfaces: notify of change only if true

### DIFF
--- a/src/libs/interface/interface.cpp
+++ b/src/libs/interface/interface.cpp
@@ -499,6 +499,7 @@ Interface::write()
 
 	rwlock_->lock_for_write();
 	data_mutex_->lock();
+	bool do_notify = false;
 	if (valid_) {
 		if (data_changed) {
 			if (auto_timestamping_)
@@ -508,6 +509,7 @@ Interface::write()
 			data_ts->timestamp_sec  = sec;
 			data_ts->timestamp_usec = usec;
 			data_changed            = false;
+			do_notify               = true;
 		}
 		memcpy(mem_data_ptr_, data_ptr, data_size);
 	} else {
@@ -518,7 +520,8 @@ Interface::write()
 	data_mutex_->unlock();
 	rwlock_->unlock();
 
-	interface_mediator_->notify_of_data_change(this);
+	if (do_notify)
+		interface_mediator_->notify_of_data_change(this);
 }
 
 /** Get data size.

--- a/src/libs/interface/message.h
+++ b/src/libs/interface/message.h
@@ -29,6 +29,9 @@
 #include <interface/field_iterator.h>
 #include <interface/types.h>
 
+#include <cstring>
+#include <type_traits>
+
 #define INTERFACE_MESSAGE_TYPE_SIZE_ 64
 
 namespace fawkes {
@@ -152,6 +155,66 @@ Message::as_type()
 	} else {
 		throw fawkes::TypeMismatchException("Message is not of requested type");
 	}
+}
+
+/** Set a field and return whether it changed
+ * @param field The interface field to change
+ * @param value The new value
+ * @return Whether the new value is different from the old
+ */
+template <class FieldT, class DataT>
+bool
+change_field(FieldT &field, const DataT &value)
+{
+	bool rv = field != value;
+	field   = value;
+	return rv;
+}
+
+/** Set a string field and return whether it changed
+ * @param field The interface field to change
+ * @param value The new value
+ * @return Whether the new value is different from the old
+ */
+template <class FieldT, std::size_t Size>
+bool
+change_field(FieldT (&field)[Size], const char *value)
+{
+	bool change = ::strncmp(field, value, Size);
+	::strncpy(field, value, Size - 1);
+	field[Size - 1] = 0;
+	return change;
+}
+
+/** Set an array field and return whether it changed
+ * @param field The interface field to change
+ * @param value The new value
+ * @return Whether the new value is different from the old
+ */
+template <class FieldT, std::size_t Size, class DataT>
+typename std::enable_if<!std::is_same<FieldT, char>::value, bool>::type
+change_field(FieldT (&field)[Size], const DataT *value)
+{
+	bool change = ::memcmp(field, value, Size);
+	::memcpy(field, value, sizeof(FieldT) * Size);
+	return change;
+}
+
+/** Set an array field value at a certain index and return whether it changed
+ * @param field The interface field to change
+ * @param index Index into the array field
+ * @param value The new value
+ * @return Whether the new value is different from the old
+ */
+template <class FieldT, std::size_t Size, class DataT>
+bool
+change_field(FieldT (&field)[Size], unsigned int index, const DataT &value)
+{
+	if (index >= Size)
+		throw Exception("Index value %u is out of bounds (0..%u)", index, Size - 1);
+	bool change  = field[index] != value;
+	field[index] = value;
+	return change;
 }
 
 } // end namespace fawkes

--- a/src/libs/interfaces/generator/cpp_generator.cpp
+++ b/src/libs/interfaces/generator/cpp_generator.cpp
@@ -1022,26 +1022,17 @@ CppInterfaceGenerator::write_methods_cpp(FILE *                      f,
 		        (*i).getName().c_str(),
 		        (*i).getAccessType().c_str(),
 		        (*i).getName().c_str());
-		if ((*i).getType() == "string") {
-			fprintf(f,
-			        "  strncpy(data->%s, new_%s, sizeof(data->%s)-1);\n"
-			        "  data->%s[sizeof(data->%s)-1] = 0;\n",
-			        (*i).getName().c_str(),
-			        (*i).getName().c_str(),
-			        (*i).getName().c_str(),
-			        (*i).getName().c_str(),
-			        (*i).getName().c_str());
-		} else if ((*i).getLength() != "") {
-			fprintf(f,
-			        "  memcpy(data->%s, new_%s, sizeof(%s) * %s);\n",
-			        (*i).getName().c_str(),
-			        (*i).getName().c_str(),
-			        (*i).getPlainAccessType().c_str(),
-			        (*i).getLength().c_str());
-		} else {
-			fprintf(f, "  data->%s = new_%s;\n", (*i).getName().c_str(), (*i).getName().c_str());
-		}
-		fprintf(f, "%s}\n\n", write_data_changed ? "  data_changed = true;\n" : "");
+
+		if (write_data_changed)
+			fprintf(f, "  data_changed |= ");
+		else
+			fprintf(f, "  ");
+
+		fprintf(f,
+		        "change_field(data->%s, new_%s);\n"
+		        "}\n\n",
+		        (*i).getName().c_str(),
+		        (*i).getName().c_str());
 
 		if (((*i).getType() != "string") && ((*i).getLengthValue() > 0)) {
 			fprintf(f,
@@ -1053,11 +1044,7 @@ CppInterfaceGenerator::write_methods_cpp(FILE *                      f,
 			        "void\n"
 			        "%s%s::set_%s(unsigned int index, const %s new_%s)\n"
 			        "{\n"
-			        "  if (index > %s) {\n"
-			        "    throw Exception(\"Index value %%u out of bounds (0..%s)\", index);\n"
-			        "  }\n"
-			        "  data->%s[index] = new_%s;\n"
-			        "%s"
+			        "  %schange_field(data->%s, index, new_%s);\n"
 			        "}\n",
 			        (*i).getName().c_str(),
 			        (*i).getComment().c_str(),
@@ -1068,11 +1055,9 @@ CppInterfaceGenerator::write_methods_cpp(FILE *                      f,
 			        (*i).getName().c_str(),
 			        (*i).getPlainAccessType().c_str(),
 			        i->getName().c_str(),
-			        i->getMaxIdx().c_str(),
-			        i->getMaxIdx().c_str(),
+			        write_data_changed ? "  data_changed |= " : "",
 			        i->getName().c_str(),
-			        i->getName().c_str(),
-			        write_data_changed ? "  data_changed = true;\n" : "");
+			        i->getName().c_str());
 		}
 	}
 }


### PR DESCRIPTION
So here's a crazy late-night idea: What if blackboard interfaces only reported change when the data *actually changed*, and not whenever any setter has been called? Turns out it's relatively easy to implement, and in my tests so far it's looking good. But obviously this affects everything and will need to be tested in the real world as well. Just putting this out there ;-)