### PR TITLE
format-scripts: do not fail if file does not exist

### DIFF
--- a/etc/format-scripts/check-file.sh
+++ b/etc/format-scripts/check-file.sh
@@ -18,6 +18,10 @@ set -eu
 
 FILE=$1
 
+if [ ! -e $FILE ] ; then
+	exit 0
+fi
+
 if ! cmp -s <(clang-format $FILE) $FILE; then
 	echo $FILE
 fi


### PR DESCRIPTION
A non-existing file cannot be in the wrong format, so the
`check-file.sh` script should not fail, but exit with success.

This fixes an issue where the check-format build target passes a deleted
file to the script. Rather than filtering out those files in the caller,
also accept non-existing files and immediately succeed.

This fixes #182.