### PR TITLE
Golog++ remote execution for a central multi-agent approach

### DIFF
--- a/cfg/conf.d/gologpp.yaml
+++ b/cfg/conf.d/gologpp.yaml
@@ -9,3 +9,14 @@
       action-mapping:
         stack: say{text="Stacking ?(x)y on ?(y)y", wait=true}
         unstack: say{text="Unstacking ?(x)y", wait=true}
+    blocksworld-multi-agent:
+      agents:
+        names: [robot1, robot2]
+        robot1:
+          host: localhost
+          port: 1921
+        robot2:
+          port: 1922
+      action-mapping:
+        stack: say{text="Stacking ?(x)y on ?(y)y", wait=true}
+        unstack: say{text="Unstacking ?(x)y", wait=true}

--- a/cfg/conf.d/gologpp.yaml
+++ b/cfg/conf.d/gologpp.yaml
@@ -12,6 +12,7 @@
     blocksworld-multi-agent:
       agents:
         names: [robot1, robot2]
+        # Network config for each agent name. Defaults to localhost:1910.
         robot1:
           host: localhost
           port: 1921

--- a/cfg/conf.d/gologpp.yaml
+++ b/cfg/conf.d/gologpp.yaml
@@ -10,6 +10,8 @@
         stack: say{text="Stacking ?(x)y on ?(y)y", wait=true}
         unstack: say{text="Unstacking ?(x)y", wait=true}
     blocksworld-multi-agent:
+      # Set to false if you do not want to use the local skiller.
+      use_local_skiller: true
       agents:
         names: [robot1, robot2]
         # Network config for each agent name. Defaults to localhost:1910.

--- a/src/plugins/gologpp/Makefile
+++ b/src/plugins/gologpp/Makefile
@@ -20,7 +20,8 @@ LIBS_gologpp = fawkescore fawkesutils fawkesblackboard \
 OBJS_gologpp = plugin.o execution_thread.o gologpp_fawkes_backend.o exog_manager.o \
                action_executor.o skiller_action_executor.o \
                aspect/action_executor_dispatcher.o aspect/action_executor_dispatcher_inifin.o \
-               utils.o message_action_executor.o sleep_action_executor.o print_action_executor.o
+               utils.o message_action_executor.o sleep_action_executor.o print_action_executor.o \
+               remote_skiller_executor.o
 
 OBJS_all    = $(OBJS_gologpp)
 PLUGINS_all = $(PLUGINDIR)/gologpp.so

--- a/src/plugins/gologpp/gologpp_fawkes_backend.cpp
+++ b/src/plugins/gologpp/gologpp_fawkes_backend.cpp
@@ -67,8 +67,10 @@ GologppFawkesBackend::GologppFawkesBackend(Configuration *config,
 		action_dispatcher_.register_executor(std::make_shared<RemoteSkillerActionExecutor>(
 		  logger, "robot", robot, hostname, port, config, cfg_prefix));
 	}
-	action_dispatcher_.register_executor(
-	  std::make_shared<SkillerActionExecutor>(logger, blackboard, config, cfg_prefix));
+	if (config->get_bool_or_default((cfg_prefix + "/use_local_skiller").c_str(), true)) {
+		action_dispatcher_.register_executor(
+		  std::make_shared<SkillerActionExecutor>(logger, blackboard, config, cfg_prefix));
+	}
 	action_dispatcher_.register_executor(
 	  std::make_shared<BBMessageActionExecutor>(logger, blackboard, config, cfg_prefix));
 	action_dispatcher_.register_executor(std::make_shared<SleepActionExecutor>(logger));

--- a/src/plugins/gologpp/gologpp_fawkes_backend.cpp
+++ b/src/plugins/gologpp/gologpp_fawkes_backend.cpp
@@ -61,7 +61,7 @@ GologppFawkesBackend::GologppFawkesBackend(Configuration *config,
 	     config->get_strings_or_defaults((cfg_prefix + "/agents/names").c_str(), {})) {
 		const std::string  agent_prefix = cfg_prefix + "/agents/" + robot;
 		const std::string &hostname =
-		  config->get_string_or_default((agent_prefix + "/hostname").c_str(), "localhost");
+		  config->get_string_or_default((agent_prefix + "/host").c_str(), "localhost");
 		const unsigned short int &port =
 		  config->get_uint_or_default((agent_prefix + "/port").c_str(), 1911);
 		action_dispatcher_.register_executor(std::make_shared<RemoteSkillerActionExecutor>(

--- a/src/plugins/gologpp/gologpp_fawkes_backend.cpp
+++ b/src/plugins/gologpp/gologpp_fawkes_backend.cpp
@@ -23,9 +23,11 @@
 
 #include "message_action_executor.h"
 #include "print_action_executor.h"
+#include "remote_skiller_executor.h"
 #include "skiller_action_executor.h"
 #include "sleep_action_executor.h"
 
+#include <config/config.h>
 #include <golog++/model/activity.h>
 #include <golog++/model/transition.h>
 
@@ -52,6 +54,19 @@ GologppFawkesBackend::GologppFawkesBackend(Configuration *config,
                                            BlackBoard *   blackboard)
 : AspectProviderAspect(&dispatcher_inifin_), logger_(logger), blackboard_(blackboard)
 {
+	// Register RemoteSkillerActionExecutors before the local
+	// SkillerActionExecutor. This way, any action that cannot be executed on any
+	// remote will be tried locally.
+	for (const string &robot :
+	     config->get_strings_or_defaults((cfg_prefix + "/agents/names").c_str(), {})) {
+		const std::string  agent_prefix = cfg_prefix + "/agents/" + robot;
+		const std::string &hostname =
+		  config->get_string_or_default((agent_prefix + "/hostname").c_str(), "localhost");
+		const unsigned short int &port =
+		  config->get_uint_or_default((agent_prefix + "/port").c_str(), 1911);
+		action_dispatcher_.register_executor(std::make_shared<RemoteSkillerActionExecutor>(
+		  logger, "robot", robot, hostname, port, config, cfg_prefix));
+	}
 	action_dispatcher_.register_executor(
 	  std::make_shared<SkillerActionExecutor>(logger, blackboard, config, cfg_prefix));
 	action_dispatcher_.register_executor(

--- a/src/plugins/gologpp/gologpp_fawkes_backend.cpp
+++ b/src/plugins/gologpp/gologpp_fawkes_backend.cpp
@@ -63,7 +63,7 @@ GologppFawkesBackend::GologppFawkesBackend(Configuration *config,
 		const std::string &hostname =
 		  config->get_string_or_default((agent_prefix + "/host").c_str(), "localhost");
 		const unsigned short int &port =
-		  config->get_uint_or_default((agent_prefix + "/port").c_str(), 1911);
+		  config->get_uint_or_default((agent_prefix + "/port").c_str(), 1910);
 		action_dispatcher_.register_executor(std::make_shared<RemoteSkillerActionExecutor>(
 		  logger, "robot", robot, hostname, port, config, cfg_prefix));
 	}

--- a/src/plugins/gologpp/remote_skiller_executor.cpp
+++ b/src/plugins/gologpp/remote_skiller_executor.cpp
@@ -38,23 +38,23 @@ namespace gpp {
 /** Constructor.
  * Connect to the given remote host and use that host's skiller interface.
  * @param logger The logger instance to use
- * @param agent_name_key The parameter key to use for checking if this action should be executed on this agent
- * @param agent_name_value The name of the remote agent; only execute the action if it matches this agent name
+ * @param agent_param_name The parameter key to use for checking if this action should be executed on this agent
+ * @param agent_param_value The name of the remote agent; only execute the action if it matches this agent name
  * @param hostname The remote hostname to connect to
  * @param port The port to connect to
  * @param config The config to read the skill mapping from
  * @param cfg_prefix The spec-specific config prefix to use
  */
 RemoteSkillerActionExecutor::RemoteSkillerActionExecutor(Logger *           logger,
-                                                         const std::string &agent_name_key,
-                                                         const std::string &agent_name_value,
+                                                         const std::string &agent_param_name,
+                                                         const std::string &agent_param_value,
                                                          const std::string &hostname,
                                                          unsigned short int port,
                                                          Configuration *    config,
                                                          const std::string &cfg_prefix)
 : SkillerActionExecutor(logger, new RemoteBlackBoard(hostname.c_str(), port), config, cfg_prefix),
-  agent_name_key_(agent_name_key),
-  agent_name_value_(agent_name_value)
+  agent_param_name_(agent_param_name),
+  agent_param_value_(agent_param_value)
 {
 	blackboard_owner_ = true;
 }
@@ -69,11 +69,11 @@ RemoteSkillerActionExecutor::can_execute_activity(std::shared_ptr<gologpp::Activ
 	if (!SkillerActionExecutor::can_execute_activity(activity)) {
 		return false;
 	}
-	if (!activity->target()->mapping().is_mapped(agent_name_key_)) {
+	if (!activity->target()->mapping().is_mapped(agent_param_name_)) {
 		return false;
 	}
-	return (static_cast<std::string>(activity->mapped_arg_value(agent_name_key_))
-	        == agent_name_value_);
+	return (static_cast<std::string>(activity->mapped_arg_value(agent_param_name_))
+	        == agent_param_value_);
 }
 
 /** Get the name of the executor; mainly used for logging.

--- a/src/plugins/gologpp/remote_skiller_executor.cpp
+++ b/src/plugins/gologpp/remote_skiller_executor.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+ *  remote_skiller_executor.cpp - Execute Golog++ actions as skills remotely
+ *
+ *  Created: Tue 03 Dec 2019 14:33:43 CET 14:33
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "remote_skiller_executor.h"
+
+#include <blackboard/remote.h>
+#include <golog++/model/activity.h>
+
+namespace fawkes {
+namespace gpp {
+
+/** @class RemoteSkillerActionExecutor
+ * An ActionExecutor that executes an activity using a Skiller on a remote.
+ * The executor connects to a remote blackboard and instructs the remote to execute the respective skill.
+ * The mapping of an activity to a skill works the same way as for local skills.
+ * @author Till Hofmann
+ * @see SkillerActionExecutor
+ * @see ActionSkillMapping
+ */
+
+/** Constructor.
+ * Connect to the given remote host and use that host's skiller interface.
+ * @param logger The logger instance to use
+ * @param agent_name_key The parameter key to use for checking if this action should be executed on this agent
+ * @param agent_name_value The name of the remote agent; only execute the action if it matches this agent name
+ * @param hostname The remote hostname to connect to
+ * @param port The port to connect to
+ * @param config The config to read the skill mapping from
+ * @param cfg_prefix The spec-specific config prefix to use
+ */
+RemoteSkillerActionExecutor::RemoteSkillerActionExecutor(Logger *           logger,
+                                                         const std::string &agent_name_key,
+                                                         const std::string &agent_name_value,
+                                                         const std::string &hostname,
+                                                         unsigned short int port,
+                                                         Configuration *    config,
+                                                         const std::string &cfg_prefix)
+: SkillerActionExecutor(logger, new RemoteBlackBoard(hostname.c_str(), port), config, cfg_prefix),
+  agent_name_key_(agent_name_key),
+  agent_name_value_(agent_name_value)
+{
+}
+
+RemoteSkillerActionExecutor::~RemoteSkillerActionExecutor()
+{
+	// We manually created a remote blackboard, so we also need to delete it manually.
+	delete blackboard_;
+}
+
+bool
+RemoteSkillerActionExecutor::can_execute_activity(std::shared_ptr<gologpp::Activity> activity) const
+{
+	if (!SkillerActionExecutor::can_execute_activity(activity)) {
+		return false;
+	}
+	if (!activity->target()->mapping().is_mapped(agent_name_key_)) {
+		return false;
+	}
+	return (static_cast<std::string>(activity->mapped_arg_value(agent_name_key_))
+	        == agent_name_value_);
+}
+
+/** Get the name of the executor; mainly used for logging.
+ * @return The human-readable name of the executor
+ */
+const char *
+RemoteSkillerActionExecutor::name() const
+{
+	return "RemoteSkillerActionExecutor";
+}
+
+} // namespace gpp
+} // namespace fawkes

--- a/src/plugins/gologpp/remote_skiller_executor.cpp
+++ b/src/plugins/gologpp/remote_skiller_executor.cpp
@@ -56,12 +56,11 @@ RemoteSkillerActionExecutor::RemoteSkillerActionExecutor(Logger *           logg
   agent_name_key_(agent_name_key),
   agent_name_value_(agent_name_value)
 {
+	blackboard_owner_ = true;
 }
 
 RemoteSkillerActionExecutor::~RemoteSkillerActionExecutor()
 {
-	// We manually created a remote blackboard, so we also need to delete it manually.
-	delete blackboard_;
 }
 
 bool

--- a/src/plugins/gologpp/remote_skiller_executor.h
+++ b/src/plugins/gologpp/remote_skiller_executor.h
@@ -41,8 +41,8 @@ protected:
 	const char *name() const;
 
 private:
-	const std::string agent_name_key_;
-	const std::string agent_name_value_;
+	const std::string agent_param_name_;
+	const std::string agent_param_value_;
 };
 } // namespace gpp
 } // namespace fawkes

--- a/src/plugins/gologpp/remote_skiller_executor.h
+++ b/src/plugins/gologpp/remote_skiller_executor.h
@@ -1,0 +1,48 @@
+/***************************************************************************
+ *  remote_skiller_executor.h - Execute Golog++ actions as skills remotely
+ *
+ *  Created: Tue 03 Dec 2019 14:33:42 CET 14:33
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include "skiller_action_executor.h"
+
+namespace fawkes {
+namespace gpp {
+class RemoteSkillerActionExecutor : public SkillerActionExecutor
+{
+public:
+	RemoteSkillerActionExecutor(Logger *           logger,
+	                            const std::string &agent_name_key,
+	                            const std::string &agent_name_value,
+	                            const std::string &hostname,
+	                            unsigned short int port,
+	                            Configuration *    config,
+	                            const std::string &cfg_prefix);
+	virtual ~RemoteSkillerActionExecutor() override;
+	bool can_execute_activity(std::shared_ptr<gologpp::Activity> activity) const override;
+
+protected:
+	const char *name() const;
+
+private:
+	const std::string agent_name_key_;
+	const std::string agent_name_value_;
+};
+} // namespace gpp
+} // namespace fawkes

--- a/src/plugins/gologpp/skiller_action_executor.cpp
+++ b/src/plugins/gologpp/skiller_action_executor.cpp
@@ -159,6 +159,9 @@ SkillerActionExecutor::stop(std::shared_ptr<gologpp::Grounding<gologpp::Action>>
 	}
 }
 
+/** Get the name of the executor; mainly used for logging.
+ * @return The human-readable name of the executor
+ */
 const char *
 SkillerActionExecutor::name() const
 {

--- a/src/plugins/gologpp/skiller_action_executor.cpp
+++ b/src/plugins/gologpp/skiller_action_executor.cpp
@@ -52,6 +52,12 @@ InvalidArgumentException::InvalidArgumentException(const char *format, ...) : Ex
  * If the Skiller's status changes, the activity's status is updated accordingly.
  * @author Till Hofmann
  * @see ActionSkillMapping
+ *
+ * @var SkillerActionExecutor::blackboard_
+ * The blackboard to use to access the skiller.
+ *
+ * @var SkillerActionExecutor::blackboard_owner_
+ * True if this executor is owning its blackboard.
  */
 
 /** Constructor.
@@ -69,6 +75,7 @@ SkillerActionExecutor::SkillerActionExecutor(Logger *           logger,
 : ActionExecutor(logger),
   BlackBoardInterfaceListener("Golog++SkillerActionExecutor"),
   blackboard_(blackboard),
+  blackboard_owner_(false),
   config_(config),
   cfg_prefix_(cfg_prefix)
 {
@@ -111,6 +118,9 @@ SkillerActionExecutor::~SkillerActionExecutor()
 	skiller_if_->msgq_enqueue(new SkillerInterface::ReleaseControlMessage());
 	blackboard_->unregister_listener(this);
 	blackboard_->close(skiller_if_);
+	if (blackboard_owner_) {
+		delete blackboard_;
+	}
 }
 
 /** Check if we can execute the given activity.

--- a/src/plugins/gologpp/skiller_action_executor.h
+++ b/src/plugins/gologpp/skiller_action_executor.h
@@ -54,12 +54,14 @@ public:
 	bool         can_execute_activity(std::shared_ptr<gologpp::Activity> activity) const override;
 	virtual void bb_interface_data_changed(Interface *) throw() override;
 
-private:
+protected:
 	const char *       name() const;
+	BlackBoard *       blackboard_;
+
+private:
 	void               initialize_action_skill_mapping();
 	std::string        map_activity_to_skill(std::shared_ptr<gologpp::Activity> activity);
 	ActionSkillMapping action_skill_mapping_;
-	BlackBoard *       blackboard_;
 	SkillerInterface * skiller_if_;
 	Configuration *    config_;
 	const std::string  cfg_prefix_;

--- a/src/plugins/gologpp/skiller_action_executor.h
+++ b/src/plugins/gologpp/skiller_action_executor.h
@@ -55,8 +55,9 @@ public:
 	virtual void bb_interface_data_changed(Interface *) throw() override;
 
 protected:
-	const char *       name() const;
-	BlackBoard *       blackboard_;
+	const char *name() const;
+	BlackBoard *blackboard_;
+	bool        blackboard_owner_;
 
 private:
 	void               initialize_action_skill_mapping();

--- a/src/plugins/gologpp/test-scenarios/blocksworld-multi-agent/blocksworld-multi-agent.gpp
+++ b/src/plugins/gologpp/test-scenarios/blocksworld-multi-agent/blocksworld-multi-agent.gpp
@@ -1,0 +1,93 @@
+#include "logger.gpp"
+
+symbol domain blocks = {a, b, c}
+symbol domain robots = { robot1, robot2 }
+symbol domain locations = blocks | robots | {table}
+
+symbol fluent loc(symbol x) {
+domain:
+	x in blocks;
+initially:
+	(a) = c;
+	(b) = table;
+	(c) = b;
+// 	(d) = a; //*/
+}
+
+action stack(symbol robot, symbol x, symbol y) {
+domain:
+	robot in robots;
+	x in blocks;
+	y in locations;
+precondition:
+	loc(x) == robot
+	& x != y // Can't stack x on x
+	& x != table // Can't stack table
+	& (
+		y == table // either y is the table...
+		| !exists(symbol z) loc(z) == y // or nothing is on y
+	)
+
+effect:
+	loc(x) = y;
+
+mapping:
+  "stack" {
+    robot = robot,
+    x = x,
+    y = y
+  }
+}
+
+action unstack(symbol robot, symbol x, symbol y) {
+domain:
+	robot in robots;
+	x in blocks;
+	y in locations;
+precondition:
+	loc(x) == y
+	// The robot is not holding anything
+	& !exists(symbol z) loc(z) == robot
+	// There is nothing on x
+	& !exists(symbol z) loc(z) == x
+
+effect:
+	loc(x) = robot;
+
+mapping:
+	"unstack" {
+    robot = robot,
+		x = x
+	}
+}
+
+
+procedure bla() {
+	stack(robot1, a,b);
+	stack(robot1, a,table);
+}
+
+
+bool function goal() {
+	return loc(a) == table & loc(b) == a & loc(c) == b
+// 	& loc(d) == c
+	;
+}
+
+number function reward() {
+	if (goal())
+		return 100;
+	else
+		return -1;
+}
+
+
+{
+  unstack(robot1, a, c);
+  unstack(robot2, c, b);
+  stack(robot2, c, table);
+  unstack(robot2, b, table);
+  stack(robot2, b, c);
+  stack(robot1, a, b);
+  test(loc(c) == table & loc(b) == c & loc(a) == b);
+}

--- a/src/plugins/gologpp/test-scenarios/blocksworld-multi-agent/logger.gpp
+++ b/src/plugins/gologpp/test-scenarios/blocksworld-multi-agent/logger.gpp
@@ -1,0 +1,31 @@
+action log_debug(string msg) {
+mapping:
+  "print" {
+    level = "debug",
+    message = msg
+  }
+}
+
+action log_info(string msg) {
+mapping:
+  "print" {
+    level = "info",
+    message = msg
+  }
+}
+
+action log_warn(string msg) {
+mapping:
+  "print" {
+    level = "warn",
+    message = msg
+  }
+}
+
+action log_error(string msg) {
+mapping:
+  "print" {
+    level = "error",
+    message = msg
+  }
+}


### PR DESCRIPTION
Provide a simple way to use Golog++ in a multi-agent setting with a central reasoner by allowing remote skill execution. In particular, add a `RemoteSkillerActionExecutor` that executes a skill on a remote fawkes instance by connecting to the remote blackboard.

Each `RemoteSkillerActionExecutor` instance is created with an agent name and it only executes a given activity if the activity's agent parameter (`robot` by default) matches the name of the remote agent. The remote agents are defined in the config.

If none of the remote agents can execute the activity, the local `SkillerActionExecutor` will be tried.

Also extend the blocksworld test scenario to a multi-agent system. To run it, do the following:
1. Change the spec in the config to `blocksworld-multi-agent`
2. Start a first fawkes instance listening on port `1921`:
    ```
    $ ./fawkes -P 1921 flite skiller
    ```
3. Start a second fawkes instance listening on port `1922`:
    ```
    $ ./fawkes -P 1922 flite skiller
    ```
4. Run the main agent:
    ```
    ./fawkes skiller gologpp
    ```

Kudos to @vmatare for the initial idea.