### PR TITLE
Rework robotmemory collection dump and restore

### DIFF
--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.cpp
@@ -130,6 +130,13 @@ ClipsRobotMemoryThread::clips_context_init(const std::string &          env_name
 	                    sigc::slot<CLIPS::Value, std::string, void *, void *>(
 	                      sigc::mem_fun(*this,
 	                                    &ClipsRobotMemoryThread::clips_robotmemory_query_sort)));
+	clips->add_function("robmem-dump-collection",
+	                    sigc::slot<CLIPS::Value, std::string, std::string>(
+	                      sigc::mem_fun(*this,
+	                                    &ClipsRobotMemoryThread::clips_robotmemory_dump_collection)));
+	clips->add_function("robmem-restore-collection",
+	                    sigc::slot<CLIPS::Value, std::string, std::string, std::string>(sigc::mem_fun(
+	                      *this, &ClipsRobotMemoryThread::clips_robotmemory_restore_collection)));
 	clips->add_function("robmem-cursor-destroy",
 	                    sigc::slot<void, void *>(
 	                      sigc::mem_fun(*this,
@@ -579,6 +586,49 @@ ClipsRobotMemoryThread::clips_robotmemory_query_sort(std::string collection,
 		                    CLIPS::TYPE_EXTERNAL_ADDRESS);
 	} catch (std::system_error &e) {
 		logger->log_warn("MongoDB", "Query failed: %s", e.what());
+		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
+	}
+}
+
+CLIPS::Value
+ClipsRobotMemoryThread::clips_robotmemory_dump_collection(std::string collection,
+                                                          std::string directory)
+{
+	try {
+		int succ = robot_memory->dump_collection(collection, directory);
+		if (succ == 1) {
+			return CLIPS::Value("TRUE", CLIPS::TYPE_SYMBOL);
+		} else {
+			return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
+		}
+	} catch (mongocxx::exception &e) {
+		logger->log_error("MongoDB",
+		                  "Dumping collection %s to %s failed: \n %s",
+		                  collection.c_str(),
+		                  directory.c_str(),
+		                  e.what());
+		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
+	}
+}
+
+CLIPS::Value
+ClipsRobotMemoryThread::clips_robotmemory_restore_collection(std::string collection,
+                                                             std::string directory,
+                                                             std::string target_collection)
+{
+	try {
+		int succ = robot_memory->restore_collection(collection, directory, target_collection);
+		if (succ == 1) {
+			return CLIPS::Value("TRUE", CLIPS::TYPE_SYMBOL);
+		} else {
+			return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
+		}
+	} catch (mongocxx::exception &e) {
+		logger->log_error("MongoDB",
+		                  "Restoring collection %s to %s failed: \n %s",
+		                  collection.c_str(),
+		                  directory.c_str(),
+		                  e.what());
 		return CLIPS::Value("FALSE", CLIPS::TYPE_SYMBOL);
 	}
 }

--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.h
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.h
@@ -104,6 +104,10 @@ private:
 	CLIPS::Value clips_robotmemory_cursor_more(void *cursor);
 	CLIPS::Value clips_robotmemory_cursor_next(void *cursor);
 	void         clips_robotmemory_cursor_destroy(void *cursor);
+	CLIPS::Value clips_robotmemory_dump_collection(std::string collection, std::string directory);
+	CLIPS::Value clips_robotmemory_restore_collection(std::string collection,
+	                                                  std::string directory,
+	                                                  std::string target_collection);
 
 	CLIPS::Value clips_robotmemory_mutex_create(std::string name);
 	CLIPS::Value clips_robotmemory_mutex_destroy(std::string name);

--- a/src/plugins/robot-memory/robot_memory.h
+++ b/src/plugins/robot-memory/robot_memory.h
@@ -88,7 +88,8 @@ public:
 	int              drop_collection(const std::string &collection);
 	int              clear_memory();
 	int              restore_collection(const std::string &collection,
-	                                    const std::string &directory = "@CONFDIR@/robot-memory");
+	                                    const std::string &directory = "@CONFDIR@/robot-memory",
+	                                    const std::string &target_collection = "noop");
 	int              dump_collection(const std::string &collection,
 	                                 const std::string &directory = "@CONFDIR@/robot-memory");
 	int              create_index(bsoncxx::document::view keys,


### PR DESCRIPTION
This PR reworks the way robot-memory utilizes mongocxx to dump monogdb collections to a file and restore them. Additionally, it adds the clips bindings for the dumping and restoring functionality.

Help needed: For dumping, the ip and the port of the database has to be passed. I am struggeling to find a way to determine the ip  and the port of the corresponding database of the collection that should be dumped on the fly.