### PR TITLE
Add hardware model parsing

### DIFF
--- a/cfg/conf.d/hardware-models.yaml
+++ b/cfg/conf.d/hardware-models.yaml
@@ -1,0 +1,6 @@
+hardware-models:
+  models-dir: /hardware-models
+  components:
+    - move-base
+    - gripper
+    - navgraph

--- a/cfg/conf.d/hardware-models.yaml
+++ b/cfg/conf.d/hardware-models.yaml
@@ -1,3 +1,8 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+---
+doc-url: !url http://trac.fawkesrobotics.org/wiki/Plugins/hardware-models
+---
 hardware-models:
   models-dir: /hardware-models
   components:

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -5,6 +5,9 @@
 include:
   # reads files ending in .yaml from modules.d config subdir
   - !ignore-missing conf.d/
+  # reads host-specific config files from host.d subdir
+  - !ignore-missing host.d/
+  - hardware-models/
   # Reads the host-specific configuration file, no failure if missing
   - !host-specific host.yaml
 ---

--- a/cfg/hardware-models/gripper.yaml
+++ b/cfg/hardware-models/gripper.yaml
@@ -1,0 +1,26 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+
+gripper:
+  states:
+    - INIT
+    - CALIBRATED
+    - BROKEN
+
+  INIT:
+    edges:
+      - CALIBRATED
+      - BROKEN
+    CALIBRATED: calibrate()
+    BROKEN: break()
+
+  CALIBRATED:
+    edges:
+      - INIT
+      - BROKEN
+    INIT: uncalibrate()
+    BROKEN: break()
+
+  BROKEN:
+    edges:
+

--- a/cfg/hardware-models/move-base.yaml
+++ b/cfg/hardware-models/move-base.yaml
@@ -1,0 +1,25 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+move-base:
+  states:
+    - INIT
+    - LOCKED
+    - BROKEN
+
+  INIT:
+    edges:
+      - LOCKED
+      - BROKEN
+    LOCKED: lock()
+    BROKEN: break()
+
+  LOCKED:
+    edges:
+      - INIT
+      - BROKEN
+    INIT: unlock()
+    BROKEN: break()
+
+  BROKEN:
+    edges:
+

--- a/src/plugins/Makefile
+++ b/src/plugins/Makefile
@@ -31,7 +31,7 @@ SUBDIRS	= bbsync bblogger webview ttmainloop rrd \
 	  openrave-robot-memory openni refboxcomm ros player xmlrpc gossip \
 	  robot_state_publisher gazebo dynamixel navgraph-interactive \
 	  pddl-planner stn-generator clips-executive \
-	  asp plexil cedar gologpp
+	  asp plexil cedar gologpp hardware-models
 
 include $(BUILDSYSDIR)/rules.mk
 

--- a/src/plugins/hardware-models/Makefile
+++ b/src/plugins/hardware-models/Makefile
@@ -1,0 +1,47 @@
+#*****************************************************************************
+#           Makefile Build System for Fawkes: Hardware Models Plugin
+#                            -------------------
+#   Created on Sun Mar 24 11:50:46 2019
+#   Copyright (C) 2019 by Tim Niemueller
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../..
+include $(BASEDIR)/etc/buildsys/config.mk
+include $(BUILDSYSDIR)/clips.mk
+
+LIBS_hardware_models = \
+	fawkescore fawkesutils fawkesaspects fawkesblackboard \
+        fawkesinterface fawkesclipsaspect
+OBJS_hardware_models = hardware_models_plugin.o hardware_models_thread.o
+
+OBJS_all    = $(OBJS_hardware_models)
+PLUGINS_all = $(PLUGINDIR)/hardware-models.so
+
+ifeq ($(HAVE_CLIPS),1)
+  CFLAGS  += $(CFLAGS_CLIPS)
+  LDFLAGS += $(LDFLAGS_CLIPS)
+
+  PLUGINS_build = $(PLUGINS_all)
+
+	INSTALL_extra = clips_files
+else
+  WARN_TARGETS += warning_clips
+endif
+
+ifeq ($(OBJSSUBMAKE),1)
+all: $(WARN_TARGETS)
+
+.PHONY: warning_clips
+warning_clips:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting hardware-models plugin$(TNORMAL) ($(CLIPS_ERROR))"
+endif
+
+include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/hardware-models/Makefile
+++ b/src/plugins/hardware-models/Makefile
@@ -17,9 +17,11 @@ BASEDIR = ../../..
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(BUILDSYSDIR)/clips.mk
 
+PRESUBDIRS = interfaces
+
 LIBS_hardware_models = \
 	fawkescore fawkesutils fawkesaspects fawkesblackboard \
-        fawkesinterface fawkesclipsaspect
+        fawkesinterface fawkesclipsaspect HardwareModelsInterface
 OBJS_hardware_models = hardware_models_plugin.o hardware_models_thread.o
 
 OBJS_all    = $(OBJS_hardware_models)

--- a/src/plugins/hardware-models/hardware_models.clp
+++ b/src/plugins/hardware-models/hardware_models.clp
@@ -1,0 +1,22 @@
+
+;---------------------------------------------------------------------------
+;  hardware-models.clp - CLIPS hardware models helper functions
+;
+;  Created: Mon Mar 25 17:24:53 2019
+;  Copyright  2019  Daniel Habering
+;  Licensed under GPLv2+ license, cf. LICENSE file
+;---------------------------------------------------------------------------
+
+(deftemplate hm-component
+  (slot name (type STRING))
+  (slot state (type STRING))
+)
+
+(deftemplate hm-edge
+  (slot component (type STRING))
+  (slot from (type STRING))
+  (slot to (type STRING))
+  (slot transisiton (type STRING))
+  (slot executable (type SYMBOL) (allowed-values FALSE TRUE))
+)
+

--- a/src/plugins/hardware-models/hardware_models.clp
+++ b/src/plugins/hardware-models/hardware_models.clp
@@ -9,6 +9,11 @@
 
 (deftemplate hm-component
   (slot name (type SYMBOL))
+  (slot initial-state (type SYMBOL))
+)
+
+(deftemplate hm-terminal-state
+  (slot name (type SYMBOL))
   (slot state (type SYMBOL))
 )
 

--- a/src/plugins/hardware-models/hardware_models.clp
+++ b/src/plugins/hardware-models/hardware_models.clp
@@ -17,6 +17,29 @@
   (slot from (type STRING))
   (slot to (type STRING))
   (slot transition (type STRING))
+  (slot probability (type FLOAT) (default 0.0))
   (slot executable (type SYMBOL) (allowed-values FALSE TRUE))
 )
 
+(deftemplate hm-transition
+  (slot component (type STRING))
+  (slot transition (type STRING))
+)
+
+(defrule hm-execute-transition
+  ?t <- (hm-transition (component ?comp) (transition ?trans))
+  ?c <- (hm-component (name ?comp) (state ?state))
+  (hm-edge (component ?comp) (from ?state) (to ?to) (transition ?trans))
+  =>
+  (modify ?c (state ?to))
+  (retract ?t)
+)
+
+(defrule hm-invalid-transition
+  ?t <- (hm-transition (component ?comp) (transition ?trans))
+  (hm-component (name ?comp) (state ?state))
+  (not (hm-edge (component ?comp) (from ?state) (transition ?trans)))
+  =>
+  (retract ?t)
+  (printout error "Invalid transition " ?trans " for component " ?comp " in state " ?state crlf)
+)

--- a/src/plugins/hardware-models/hardware_models.clp
+++ b/src/plugins/hardware-models/hardware_models.clp
@@ -16,7 +16,7 @@
   (slot component (type STRING))
   (slot from (type STRING))
   (slot to (type STRING))
-  (slot transisiton (type STRING))
+  (slot transition (type STRING))
   (slot executable (type SYMBOL) (allowed-values FALSE TRUE))
 )
 

--- a/src/plugins/hardware-models/hardware_models.clp
+++ b/src/plugins/hardware-models/hardware_models.clp
@@ -8,38 +8,21 @@
 ;---------------------------------------------------------------------------
 
 (deftemplate hm-component
-  (slot name (type STRING))
-  (slot state (type STRING))
+  (slot name (type SYMBOL))
+  (slot state (type SYMBOL))
 )
 
 (deftemplate hm-edge
-  (slot component (type STRING))
-  (slot from (type STRING))
-  (slot to (type STRING))
-  (slot transition (type STRING))
+  (slot component (type SYMBOL))
+  (slot from (type SYMBOL))
+  (slot to (type SYMBOL))
+  (slot transition (type SYMBOL))
   (slot probability (type FLOAT) (default 0.0))
   (slot executable (type SYMBOL) (allowed-values FALSE TRUE))
 )
 
 (deftemplate hm-transition
-  (slot component (type STRING))
-  (slot transition (type STRING))
+  (slot component (type SYMBOL))
+  (slot transition (type SYMBOL))
 )
 
-(defrule hm-execute-transition
-  ?t <- (hm-transition (component ?comp) (transition ?trans))
-  ?c <- (hm-component (name ?comp) (state ?state))
-  (hm-edge (component ?comp) (from ?state) (to ?to) (transition ?trans))
-  =>
-  (modify ?c (state ?to))
-  (retract ?t)
-)
-
-(defrule hm-invalid-transition
-  ?t <- (hm-transition (component ?comp) (transition ?trans))
-  (hm-component (name ?comp) (state ?state))
-  (not (hm-edge (component ?comp) (from ?state) (transition ?trans)))
-  =>
-  (retract ?t)
-  (printout error "Invalid transition " ?trans " for component " ?comp " in state " ?state crlf)
-)

--- a/src/plugins/hardware-models/hardware_models_plugin.cpp
+++ b/src/plugins/hardware-models/hardware_models_plugin.cpp
@@ -1,0 +1,45 @@
+
+/***************************************************************************
+ *  hardware_models_plugin.cpp - Hardware Models
+ *
+ *  Created: Sun Mar 24 11:51:53 2019
+ *  Copyright  2019 Daniel Habering (daniel@habering.de)
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "hardware_models_thread.h"
+#include <core/plugin.h>
+
+using namespace fawkes;
+
+/** Hardware Models plugin.
+ * @author Daniel Habering
+ */
+class HardwareModelsPlugin : public fawkes::Plugin
+{
+public:
+	/** Constructor.
+	 * @param config Fawkes configuration
+	 */
+	explicit HardwareModelsPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new HardwareModelsThread());
+	}
+};
+
+
+PLUGIN_DESCRIPTION("Hardware Models")
+EXPORT_PLUGIN(HardwareModelsPlugin)

--- a/src/plugins/hardware-models/hardware_models_plugin.cpp
+++ b/src/plugins/hardware-models/hardware_models_plugin.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "hardware_models_thread.h"
+
 #include <core/plugin.h>
 
 using namespace fawkes;
@@ -39,7 +40,6 @@ public:
 		thread_list.push_back(new HardwareModelsThread());
 	}
 };
-
 
 PLUGIN_DESCRIPTION("Hardware Models")
 EXPORT_PLUGIN(HardwareModelsPlugin)

--- a/src/plugins/hardware-models/hardware_models_thread.cpp
+++ b/src/plugins/hardware-models/hardware_models_thread.cpp
@@ -39,7 +39,7 @@ using namespace fawkes;
 /** Constructor. */
 HardwareModelsThread::HardwareModelsThread()
 	: Thread("HardwareModelsThread", Thread::OPMODE_WAITFORWAKEUP),
-	  CLIPSFeature("hardware-models"), CLIPSFeatureAspect(this)
+	CLIPSFeature("hardware-models"), CLIPSFeatureAspect(this)
 {
 }
 
@@ -48,6 +48,12 @@ void
 HardwareModelsThread::init()
 {
 
+  std::string cfg_interface_ = "HardwareModels";
+  if (config->exists("/hardware-models/interface")) {
+    cfg_interface_ = config->get_string("/hardware-models/interface");
+  }
+
+  hm_if_ = blackboard->open_for_writing<HardwareModelsInterface>(cfg_interface_.c_str());
 }
 
 
@@ -55,20 +61,21 @@ void
 HardwareModelsThread::clips_context_init(const std::string &env_name,
           LockPtr<CLIPS::Environment> &clips)
 {
-	std::string models_dir;
+	std::string models_dir_;
 
-  models_dir = config->get_string("/hardware-models/models-dir");
-  if (models_dir[models_dir.size()-1] != '/') {
-      models_dir += "/";
+  models_dir_ = config->get_string("/hardware-models/models-dir");
+  if (models_dir_[models_dir_.size()-1] != '/') {
+      models_dir_ += "/";
   }
+  clips_ = clips;
 
-  clips->batch_evaluate(SRCDIR"/hardware_models.clp");
+  clips_->batch_evaluate(SRCDIR"/hardware_models.clp");
 
-  std::vector<std::string> components  = config->get_strings("/hardware-models/components");
-  for (const auto c : components) {
+  components_  = config->get_strings("/hardware-models/components");
+  for (const auto c : components_) {
     logger->log_info(name(),c.c_str());
     if (!config->exists(std::string(c + "/states").c_str())) {
-      logger->log_warn(name(),"Component config file is missing in %s : %s", models_dir.c_str(),c.c_str());
+      logger->log_warn(name(),"Component config file is missing in %s : %s", models_dir_.c_str(),c.c_str());
       continue;
     }
     std::vector<std::string> states = config->get_strings(std::string(c + "/states").c_str());
@@ -78,15 +85,15 @@ HardwareModelsThread::clips_context_init(const std::string &env_name,
           std::vector<std::string> edges = config->get_strings(std::string(c + "/" + state + "/edges").c_str());
           for (const auto edge : edges) {
               std::string transition = config->get_string(std::string(c + "/" + state + "/" + edge).c_str());
-              clips_add_edge(clips,c,state,edge,transition);
+              clips_add_edge(c,state,edge,transition);
               logger->log_debug(name(),"Edge from %s to %s via %s",state.c_str(),edge.c_str(),transition.c_str());
           }
         }
         logger->log_debug(name(),state.c_str());
       }
-      clips_add_component(clips,c,states[0]);
+      clips_add_component(c,states[0]);
     } else {
-      logger->log_warn(name(),"No states for component %s in %s",c.c_str(),models_dir.c_str());
+      logger->log_warn(name(),"No states for component %s in %s",c.c_str(),models_dir_.c_str());
     }
   }
 }
@@ -101,15 +108,15 @@ HardwareModelsThread::clips_context_destroyed(const std::string &env_name)
 
 
 void
-HardwareModelsThread::clips_add_component(LockPtr<CLIPS::Environment> &clips, const std::string& component,const std::string& init_state)
+HardwareModelsThread::clips_add_component(const std::string& component,const std::string& init_state)
 {
-  CLIPS::Template::pointer temp = clips->get_template("hm-component");
+  CLIPS::Template::pointer temp = clips_->get_template("hm-component");
   if (temp) {
-    CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips, temp);
+    CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips_, temp);
     fact->set_slot("name",component.c_str());
     fact->set_slot("state",init_state.c_str());
 
-    CLIPS::Fact::pointer new_fact = clips->assert_fact(fact);
+    CLIPS::Fact::pointer new_fact = clips_->assert_fact(fact);
 
     if (!new_fact) {
       logger->log_warn(name(), "Asserting component %s failed", component.c_str());
@@ -121,20 +128,42 @@ HardwareModelsThread::clips_add_component(LockPtr<CLIPS::Environment> &clips, co
 }
 
 void
-HardwareModelsThread::clips_add_edge(LockPtr<CLIPS::Environment> &clips, const std::string& component, const std::string& from, const std::string& to, const std::string& trans)
+HardwareModelsThread::clips_add_edge(const std::string& component, const std::string& from, const std::string& to, const std::string& trans)
 {
-  CLIPS::Template::pointer temp = clips->get_template("hm-edge");
+  CLIPS::Template::pointer temp = clips_->get_template("hm-edge");
   if (temp) {
-    CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips, temp);
+    CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips_, temp);
     fact->set_slot("component",component.c_str());
     fact->set_slot("from",from.c_str());
     fact->set_slot("to",to.c_str());
     fact->set_slot("transition",trans.c_str());
 
-    CLIPS::Fact::pointer new_fact = clips->assert_fact(fact);
+    CLIPS::Fact::pointer new_fact = clips_->assert_fact(fact);
 
     if (!new_fact) {
       logger->log_warn(name(), "Asserting edge from %s to %s failed", from.c_str(),to.c_str());
+    }
+
+  } else {
+    logger->log_warn(name(),"Did not get edge template, did you load hardware_models.clp?");
+  }
+
+
+}
+
+void
+HardwareModelsThread::clips_add_transaction(const std::string& component, const std::string& transaction)
+{
+  CLIPS::Template::pointer temp = clips_->get_template("hm-transaction");
+  if (temp) {
+    CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips_, temp);
+    fact->set_slot("component",component.c_str());
+    fact->set_slot("transition",transaction.c_str());
+
+    CLIPS::Fact::pointer new_fact = clips_->assert_fact(fact);
+
+    if (!new_fact) {
+      logger->log_warn(name(), "Asserting transaction of %s: %s failed", component.c_str(),transaction.c_str());
     }
 
   } else {
@@ -153,6 +182,23 @@ HardwareModelsThread::finalize()
 void
 HardwareModelsThread::loop()
 {
+  hm_if_->read();
+  while (!hm_if_->msgq_empty())
+  {
+    if (hm_if_->msgq_first_is<HardwareModelsInterface::StateChangeMessage>())
+    {
+      HardwareModelsInterface::StateChangeMessage *msg = hm_if_->msgq_first(msg);
+
+      std::string comp = std::string(msg->component());
+      std::string trans = std::string(msg->transaction());
+
+      logger->log_debug(name(),"Component: %s changed state by executing transaction: %s",comp.c_str(),trans.c_str());
+
+      clips_add_transaction(comp.c_str(),trans.c_str());
+    } else {
+      logger->log_error(name(),"Recieved unknown message type");
+    }
+  }
 }
 
 

--- a/src/plugins/hardware-models/hardware_models_thread.cpp
+++ b/src/plugins/hardware-models/hardware_models_thread.cpp
@@ -34,6 +34,20 @@ using namespace fawkes;
 /** @class HardwareModelsThread "hardware_models_thread.h"
  * Main thread of Hardware Models Plugin.
  *
+ * Parses yaml files that are assumend to have the following format:
+ * COMPONENT-NAME:
+ *  states:
+ *      <List of states, the first state is assumed to be the initial state>
+ * 
+ *  STATE_1:
+ *   edges:
+ *    <List of states the state has an edge to>
+ *   edge_1:
+ *    transition: <name of the action that causes the transition>
+ *    (optional)probability: <probability of the transition if it is an exogenous action>
+ *     
+ *  Any component plugin can inform the HardwareModel Plugin about state changes
+ *  by sending a HardwareModelInterfaceMessage.
  * @author Daniel Habering
  */
 
@@ -49,7 +63,6 @@ HardwareModelsThread::HardwareModelsThread()
 void
 HardwareModelsThread::init()
 {
-
   std::string cfg_interface_ = "HardwareModels";
   if (config->exists("/hardware-models/interface")) {
     cfg_interface_ = config->get_string("/hardware-models/interface");
@@ -61,7 +74,12 @@ HardwareModelsThread::init()
   bbil_add_message_interface(hm_if_);
 }
 
-
+/**
+ * @brief Initializes hardware components from yaml files for a clips environment
+ * 
+ * @param env_name Name of clips environment
+ * @param clips Pointer to clips environment
+ */
 void
 HardwareModelsThread::clips_context_init(const std::string &env_name,
           LockPtr<CLIPS::Environment> &clips)
@@ -70,8 +88,9 @@ HardwareModelsThread::clips_context_init(const std::string &env_name,
 
   models_dir_ = config->get_string("/hardware-models/models-dir");
   if (models_dir_[models_dir_.size()-1] != '/') {
-      models_dir_ += "/";
+    models_dir_ += "/";
   }
+
 
   envs_[env_name] = clips;
 
@@ -79,11 +98,14 @@ HardwareModelsThread::clips_context_init(const std::string &env_name,
 
   components_  = config->get_strings("/hardware-models/components");
   for (const auto c : components_) {
+
     logger->log_info(name(),c.c_str());
     if (!config->exists(std::string(c + "/states").c_str())) {
       logger->log_warn(name(),"Component config file is missing in %s : %s", models_dir_.c_str(),c.c_str());
       continue;
     }
+
+    //First state in the config file is assumend to be the initial state
     std::vector<std::string> states = config->get_strings(std::string(c + "/states").c_str());
     if (!states.empty()) {
       for (const auto state : states) {
@@ -95,7 +117,8 @@ HardwareModelsThread::clips_context_init(const std::string &env_name,
               try{
                 transition = config->get_string(std::string(c + "/" + state + "/" + edge + "/transition").c_str());
               } catch (...){
-                logger->log_error(name(),"Cant find transition value in %s",std::string(c+"/"+state+"/"+edge).c_str());
+                logger->log_warn(name(),"Cant find transition value in %s",std::string(c+"/"+state+"/"+edge).c_str());
+                continue;
               }
 
               double prob = 0.0;
@@ -106,7 +129,11 @@ HardwareModelsThread::clips_context_init(const std::string &env_name,
               clips_add_edge(clips,c,state,edge,transition,prob);
               logger->log_debug(name(),"Edge from %s to %s via %s",state.c_str(),edge.c_str(),transition.c_str());
           }
+        } else {
+          logger->log_warn(name(),"State %s of %s needs edges field",state.c_str(),c.c_str());
+          continue;
         }
+
         logger->log_debug(name(),state.c_str());
       }
       clips_add_component(clips,c,states[0]);
@@ -114,7 +141,7 @@ HardwareModelsThread::clips_context_init(const std::string &env_name,
       logger->log_warn(name(),"No states for component %s in %s",c.c_str(),models_dir_.c_str());
     }
   }
-  hm_if_->set_result("Ready");
+  hm_if_->set_busy(false);
   hm_if_->write();
 }
 
@@ -125,8 +152,13 @@ HardwareModelsThread::clips_context_destroyed(const std::string &env_name)
   logger->log_error(name(), "Removing environment %s", env_name.c_str());
 }
 
-
-
+/**
+ * @brief Adds a hardware component fact to the given clips environment
+ * 
+ * @param clips Pointer to clips environment
+ * @param component Name of the hardware component
+ * @param init_state Name of the initial state of the component
+ */
 void
 HardwareModelsThread::clips_add_component(LockPtr<CLIPS::Environment> &clips,const std::string& component,const std::string& init_state)
 {
@@ -147,8 +179,22 @@ HardwareModelsThread::clips_add_component(LockPtr<CLIPS::Environment> &clips,con
   }
 }
 
+/**
+ * @brief Adds a hardware component edge fact to the given clips environment
+ * 
+ * @param clips Pointer to the clips environment
+ * @param component Name of the component the edge belongs to
+ * @param from Name of the origin state
+ * @param to Name of the destination state
+ * @param trans Label/Transition action that triggers the edge
+ * @param prob Probability of the action if it is an exogenous action
+ */
 void
-HardwareModelsThread::clips_add_edge(LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& from, const std::string& to, const std::string& trans, const double prob)
+HardwareModelsThread::clips_add_edge(LockPtr<CLIPS::Environment> &clips,const std::string& component, 
+                                                  const std::string& from, 
+                                                  const std::string& to, 
+                                                  const std::string& trans, 
+                                                  const double prob)
 {
   CLIPS::Template::pointer temp = clips->get_template("hm-edge");
   if (temp) {
@@ -172,8 +218,15 @@ HardwareModelsThread::clips_add_edge(LockPtr<CLIPS::Environment> &clips,const st
 
 }
 
+/**
+ * @brief Adds a transition fact to all registered clips environments. This represents that
+ *        the given component changed its state by executing the transition.
+ * 
+ * @param component Name of the component that executed the transition
+ * @param transition Name of the transition action
+ */
 void
-HardwareModelsThread::clips_add_transaction(const std::string& component, const std::string& transaction) throw()
+HardwareModelsThread::clips_add_transition(const std::string& component, const std::string& transition) throw()
 {
   for (const auto e : envs_) {
     fawkes::LockPtr<CLIPS::Environment> clips = e.second;
@@ -182,19 +235,19 @@ HardwareModelsThread::clips_add_transaction(const std::string& component, const 
     if (temp) {
       CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips, temp);
       fact->set_slot("component",component.c_str());
-      fact->set_slot("transition",transaction.c_str());
+      fact->set_slot("transition",transition.c_str());
 
       CLIPS::Fact::pointer new_fact = clips->assert_fact(fact);
 
       if (!new_fact) {
-        logger->log_warn(name(), "Asserting transaction of %s: %s failed", component.c_str(),transaction.c_str());
+        logger->log_warn(name(), "Asserting transition of %s: %s failed", component.c_str(),transition.c_str());
       }
 
     } else {
       logger->log_warn(name(),"Did not get edge template, did you load hardware_models.clp?");
     }
     clips.unlock();
-    logger->log_error(name(),"Added transaction in env: %s",e.first.c_str());
+    logger->log_error(name(),"Added transition in env: %s",e.first.c_str());
   }
   logger->log_error(name(),"Done");
 }
@@ -204,15 +257,13 @@ HardwareModelsThread::finalize()
 {
 }
 
-
+/**
+ * @brief Loop function to be executed when a new HardwareInterfaceMessage is recieved
+ * 
+ */
 void
 HardwareModelsThread::loop()
 {
-
-while ( hm_if_->msgq_empty() ) {
-     usleep(100);
-}
-
   hm_if_->read();
   while (!hm_if_->msgq_empty())
   {
@@ -221,11 +272,11 @@ while ( hm_if_->msgq_empty() ) {
       HardwareModelsInterface::StateChangeMessage *msg = hm_if_->msgq_first(msg);
 
       std::string comp = std::string(msg->component());
-      std::string trans = std::string(msg->transaction());
+      std::string trans = std::string(msg->transition());
 
-      logger->log_error(name(),"Component: %s changed state by executing transaction: %s",comp.c_str(),trans.c_str());
+      logger->log_error(name(),"Component: %s changed state by executing transition: %s",comp.c_str(),trans.c_str());
 
-      clips_add_transaction(comp.c_str(),trans.c_str());
+      clips_add_transition(comp.c_str(),trans.c_str());
     } else {
       logger->log_error(name(),"Recieved unknown message type");
     }

--- a/src/plugins/hardware-models/hardware_models_thread.cpp
+++ b/src/plugins/hardware-models/hardware_models_thread.cpp
@@ -1,0 +1,148 @@
+
+/***************************************************************************
+ *  hardware_models_thread.cpp -  Hardware Models
+ *
+ *  Created: Sun Mar 24 12:00:06 2019
+ *  Copyright  2019  Daniel Habering (daniel@habering.de)
+ *  ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "hardware_models_thread.h"
+
+#include <utils/misc/string_conversions.h>
+#include <utils/misc/string_split.h>
+#include <utils/misc/map_skill.h>
+#include <interfaces/SwitchInterface.h>
+#include <core/threading/mutex_locker.h>
+#include <config/yaml.h>
+
+using namespace fawkes;
+
+/** @class HardwareModelsThread "hardware_models_thread.h"
+ * Main thread of Hardware Models Plugin.
+ *
+ * @author Daniel Habering
+ */
+
+/** Constructor. */
+HardwareModelsThread::HardwareModelsThread()
+	: Thread("HardwareModelsThread", Thread::OPMODE_WAITFORWAKEUP),
+	  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_THINK),
+	  CLIPSAspect("executive", "CLIPS (executive)")
+{
+}
+
+
+/** Destructor. */
+HardwareModelsThread::~HardwareModelsThread()
+{
+}
+
+
+void
+HardwareModelsThread::init()
+{
+	std::string models_dir;
+
+  models_dir = config->get_string("/hardware-models/models-dir");
+  if (models_dir[models_dir.size()-1] != '/') {
+      models_dir += "/";
+  }
+
+  clips->batch_evaluate(SRCDIR"/hardware_models.clp");
+
+  std::vector<std::string> components  = config->get_strings("/hardware-models/components");
+  for (const auto c : components) {
+    logger->log_info(name(),c.c_str());
+    if (!config->exists(std::string(c + "/states").c_str())) {
+      logger->log_warn(name(),"Component config file is missing in %s : %s", models_dir.c_str(),c.c_str());
+      continue;
+    }
+    std::vector<std::string> states = config->get_strings(std::string(c + "/states").c_str());
+    if (!states.empty()) {
+      for (const auto state : states) {
+        if (config->is_list(std::string(c + "/" + state + "/edges").c_str())) {
+          std::vector<std::string> edges = config->get_strings(std::string(c + "/" + state + "/edges").c_str());
+          for (const auto edge : edges) {
+              std::string transition = config->get_string(std::string(c + "/" + state + "/" + edge).c_str());
+              logger->log_info(name(),"Edge from %s to %s via %s",state.c_str(),edge.c_str(),transition.c_str());
+          }
+        }
+        logger->log_info(name(),state.c_str());
+      }
+      clips_add_component(c,states[0]);
+    } else {
+      logger->log_warn(name(),"No states for component %s in %s",c.c_str(),models_dir.c_str());
+    }
+  }
+}
+
+void
+HardwareModelsThread::clips_add_component(const std::string& component,const std::string& init_state)
+{
+  CLIPS::Template::pointer temp = clips->get_template("hm-component");
+  if (temp) {
+    CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips, temp);
+    fact->set_slot("name",component.c_str());
+    fact->set_slot("state",init_state.c_str());
+
+    CLIPS::Fact::pointer new_fact = clips->assert_fact(fact);
+
+    if (!new_fact) {
+      logger->log_warn(name(), "Asserting component %s failed", component.c_str());
+    }
+
+  } else {
+    logger->log_warn(name(),"Did not get component template, did you load hardware_models.clp?");
+  }
+}
+
+void
+HardwareModelsThread::clips_add_edge(const std::string& component, const std::string& from, const std::string& to, const std::string& trans)
+{
+  CLIPS::Template::pointer temp = clips->get_template("hm-edge");
+  if (temp) {
+    CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips, temp);
+    fact->set_slot("component",component.c_str());
+    fact->set_slot("from",from.c_str());
+    fact->set_slot("to",to.c_str());
+    fact->set_slot("transition",trans.c_str());
+
+    CLIPS::Fact::pointer new_fact = clips->assert_fact(fact);
+
+    if (!new_fact) {
+      logger->log_warn(name(), "Asserting edge from %s to %s failed", from.c_str(),to.c_str());
+    }
+
+  } else {
+    logger->log_warn(name(),"Did not get edge template, did you load hardware_models.clp?");
+  }
+
+
+}
+
+void
+HardwareModelsThread::finalize()
+{
+}
+
+
+void
+HardwareModelsThread::loop()
+{
+}
+
+
+

--- a/src/plugins/hardware-models/hardware_models_thread.cpp
+++ b/src/plugins/hardware-models/hardware_models_thread.cpp
@@ -57,7 +57,6 @@ HardwareModelsThread::init()
 
   hm_if_ = blackboard->open_for_writing<HardwareModelsInterface>(cfg_interface_.c_str());
   blackboard->register_listener(this);
-  logger->log_error(name(),"Init done");
   wakeup();
   bbil_add_message_interface(hm_if_);
 }
@@ -134,8 +133,8 @@ HardwareModelsThread::clips_add_component(LockPtr<CLIPS::Environment> &clips,con
   CLIPS::Template::pointer temp = clips->get_template("hm-component");
   if (temp) {
     CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips, temp);
-    fact->set_slot("name",component.c_str());
-    fact->set_slot("state",init_state.c_str());
+    fact->set_slot("name",CLIPS::Value(component.c_str(),CLIPS::TYPE_SYMBOL));
+    fact->set_slot("state",CLIPS::Value(init_state.c_str(),CLIPS::TYPE_SYMBOL));
 
     CLIPS::Fact::pointer new_fact = clips->assert_fact(fact);
 
@@ -154,10 +153,10 @@ HardwareModelsThread::clips_add_edge(LockPtr<CLIPS::Environment> &clips,const st
   CLIPS::Template::pointer temp = clips->get_template("hm-edge");
   if (temp) {
     CLIPS::Fact::pointer fact = CLIPS::Fact::create(**clips, temp);
-    fact->set_slot("component",component.c_str());
-    fact->set_slot("from",from.c_str());
-    fact->set_slot("to",to.c_str());
-    fact->set_slot("transition",trans.c_str());
+    fact->set_slot("component",CLIPS::Value(component.c_str(),CLIPS::TYPE_SYMBOL));
+    fact->set_slot("from",CLIPS::Value(from.c_str(),CLIPS::TYPE_SYMBOL));
+    fact->set_slot("to",CLIPS::Value(to.c_str(),CLIPS::TYPE_SYMBOL));
+    fact->set_slot("transition",CLIPS::Value(trans.c_str(),CLIPS::TYPE_SYMBOL));
     fact->set_slot("probability",prob);
 
     CLIPS::Fact::pointer new_fact = clips->assert_fact(fact);

--- a/src/plugins/hardware-models/hardware_models_thread.h
+++ b/src/plugins/hardware-models/hardware_models_thread.h
@@ -25,11 +25,14 @@
 
 #include <core/threading/thread.h>
 #include <aspect/blocked_timing.h>
+#include <aspect/blackboard.h>
 #include <aspect/clock.h>
 #include <aspect/logging.h>
 #include <aspect/configurable.h>
+#include <blackboard/interface_listener.h>
 #include <plugins/clips/aspect/clips_feature.h>
 #include <utils/time/time.h>
+#include <interfaces/HardwareModelsInterface.h>
 
 #include <clipsmm.h>
 #include <memory>
@@ -40,6 +43,7 @@ namespace fawkes {
 class HardwareModelsThread
 : public fawkes::Thread,
 	public fawkes::LoggingAspect,
+	public fawkes::BlackBoardAspect,
 	public fawkes::ConfigurableAspect,
 	public fawkes::CLIPSFeature,
 	public fawkes::CLIPSFeatureAspect
@@ -63,8 +67,15 @@ class HardwareModelsThread
  private:
     std::map<std::string, fawkes::LockPtr<CLIPS::Environment> >  envs_;
 
-    void  clips_add_component(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& init_state);
-    void  clips_add_edge(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& from, const std::string& to, const std::string& trans);
+    fawkes::LockPtr<CLIPS::Environment> clips_;
+
+    std::vector<std::string> components_;
+
+    fawkes::HardwareModelsInterface *hm_if_;
+
+    void  clips_add_component(const std::string& component, const std::string& init_state);
+    void  clips_add_edge(const std::string& component, const std::string& from, const std::string& to, const std::string& trans);
+    void  clips_add_transaction(const std::string& component, const std::string& transaction);
 };
 
 #endif

--- a/src/plugins/hardware-models/hardware_models_thread.h
+++ b/src/plugins/hardware-models/hardware_models_thread.h
@@ -1,0 +1,64 @@
+
+/***************************************************************************
+ *  hardware_models_thread.h - Hardware Models plugin
+ *
+ *  Created: Sun Mar 24 11:59:44 2019
+ *  Copyright  2019  Daniel Habering [daniel@habering.de]
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef _PLUGINS_HARDWARE_MODELS_HARDWARE_MODELS_THREAD_H_
+#define _PLUGINS_HARDWARE_MODELS_HARDWARE_MODELS_THREAD_H_
+
+#include <core/threading/thread.h>
+#include <aspect/blocked_timing.h>
+#include <aspect/clock.h>
+#include <aspect/logging.h>
+#include <aspect/configurable.h>
+#include <plugins/clips/aspect/clips.h>
+#include <utils/time/time.h>
+
+#include <clipsmm.h>
+#include <memory>
+
+namespace fawkes {
+}
+
+class HardwareModelsThread
+: public fawkes::Thread,
+	public fawkes::BlockedTimingAspect,
+	public fawkes::LoggingAspect,
+	public fawkes::ConfigurableAspect,
+	public fawkes::ClockAspect,
+	public fawkes::CLIPSAspect
+{
+ public:
+	HardwareModelsThread();
+	virtual ~HardwareModelsThread();
+
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
+
+	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
+ protected: virtual void run() { Thread::run(); }
+
+ private:
+    void  clips_add_component(const std::string& component, const std::string& init_state);
+    void  clips_add_edge(const std::string& component, const std::string& from, const std::string& to, const std::string& trans);
+};
+
+#endif

--- a/src/plugins/hardware-models/hardware_models_thread.h
+++ b/src/plugins/hardware-models/hardware_models_thread.h
@@ -72,6 +72,7 @@ class HardwareModelsThread
 
     fawkes::HardwareModelsInterface *hm_if_;
 
+    void  clips_add_terminal_state(fawkes::LockPtr<CLIPS::Environment> &clips, const std::string& component, const std::string& state);
     void  clips_add_component(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& init_state);
     void  clips_add_edge(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& from, const std::string& to, const std::string& trans, const double prob);
     void  clips_add_transition(const std::string& component, const std::string& transition) throw();

--- a/src/plugins/hardware-models/hardware_models_thread.h
+++ b/src/plugins/hardware-models/hardware_models_thread.h
@@ -74,7 +74,7 @@ class HardwareModelsThread
 
     void  clips_add_component(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& init_state);
     void  clips_add_edge(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& from, const std::string& to, const std::string& trans, const double prob);
-    void  clips_add_transaction(const std::string& component, const std::string& transaction) throw();
+    void  clips_add_transition(const std::string& component, const std::string& transition) throw();
 };
 
 #endif

--- a/src/plugins/hardware-models/hardware_models_thread.h
+++ b/src/plugins/hardware-models/hardware_models_thread.h
@@ -46,7 +46,8 @@ class HardwareModelsThread
 	public fawkes::BlackBoardAspect,
 	public fawkes::ConfigurableAspect,
 	public fawkes::CLIPSFeature,
-	public fawkes::CLIPSFeatureAspect
+	public fawkes::CLIPSFeatureAspect,
+	public fawkes::BlackBoardInterfaceListener
 {
  public:
 	HardwareModelsThread();
@@ -67,15 +68,13 @@ class HardwareModelsThread
  private:
     std::map<std::string, fawkes::LockPtr<CLIPS::Environment> >  envs_;
 
-    fawkes::LockPtr<CLIPS::Environment> clips_;
-
     std::vector<std::string> components_;
 
     fawkes::HardwareModelsInterface *hm_if_;
 
-    void  clips_add_component(const std::string& component, const std::string& init_state);
-    void  clips_add_edge(const std::string& component, const std::string& from, const std::string& to, const std::string& trans);
-    void  clips_add_transaction(const std::string& component, const std::string& transaction);
+    void  clips_add_component(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& init_state);
+    void  clips_add_edge(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& from, const std::string& to, const std::string& trans, const double prob);
+    void  clips_add_transaction(const std::string& component, const std::string& transaction) throw();
 };
 
 #endif

--- a/src/plugins/hardware-models/hardware_models_thread.h
+++ b/src/plugins/hardware-models/hardware_models_thread.h
@@ -28,7 +28,7 @@
 #include <aspect/clock.h>
 #include <aspect/logging.h>
 #include <aspect/configurable.h>
-#include <plugins/clips/aspect/clips.h>
+#include <plugins/clips/aspect/clips_feature.h>
 #include <utils/time/time.h>
 
 #include <clipsmm.h>
@@ -39,26 +39,32 @@ namespace fawkes {
 
 class HardwareModelsThread
 : public fawkes::Thread,
-	public fawkes::BlockedTimingAspect,
 	public fawkes::LoggingAspect,
 	public fawkes::ConfigurableAspect,
-	public fawkes::ClockAspect,
-	public fawkes::CLIPSAspect
+	public fawkes::CLIPSFeature,
+	public fawkes::CLIPSFeatureAspect
 {
  public:
 	HardwareModelsThread();
-	virtual ~HardwareModelsThread();
 
 	virtual void init();
 	virtual void loop();
 	virtual void finalize();
 
+    // for CLIPSFeature
+  virtual void clips_context_init(const std::string &env_name,
+          fawkes::LockPtr<CLIPS::Environment> &clips);
+  virtual void clips_context_destroyed(const std::string &env_name);
+
+
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
  protected: virtual void run() { Thread::run(); }
 
  private:
-    void  clips_add_component(const std::string& component, const std::string& init_state);
-    void  clips_add_edge(const std::string& component, const std::string& from, const std::string& to, const std::string& trans);
+    std::map<std::string, fawkes::LockPtr<CLIPS::Environment> >  envs_;
+
+    void  clips_add_component(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& init_state);
+    void  clips_add_edge(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& from, const std::string& to, const std::string& trans);
 };
 
 #endif

--- a/src/plugins/hardware-models/hardware_models_thread.h
+++ b/src/plugins/hardware-models/hardware_models_thread.h
@@ -23,16 +23,16 @@
 #ifndef _PLUGINS_HARDWARE_MODELS_HARDWARE_MODELS_THREAD_H_
 #define _PLUGINS_HARDWARE_MODELS_HARDWARE_MODELS_THREAD_H_
 
-#include <core/threading/thread.h>
-#include <aspect/blocked_timing.h>
 #include <aspect/blackboard.h>
+#include <aspect/blocked_timing.h>
 #include <aspect/clock.h>
-#include <aspect/logging.h>
 #include <aspect/configurable.h>
+#include <aspect/logging.h>
 #include <blackboard/interface_listener.h>
+#include <core/threading/thread.h>
+#include <interfaces/HardwareModelsInterface.h>
 #include <plugins/clips/aspect/clips_feature.h>
 #include <utils/time/time.h>
-#include <interfaces/HardwareModelsInterface.h>
 
 #include <clipsmm.h>
 #include <memory>
@@ -40,42 +40,53 @@
 namespace fawkes {
 }
 
-class HardwareModelsThread
-: public fawkes::Thread,
-	public fawkes::LoggingAspect,
-	public fawkes::BlackBoardAspect,
-	public fawkes::ConfigurableAspect,
-	public fawkes::CLIPSFeature,
-	public fawkes::CLIPSFeatureAspect,
-	public fawkes::BlackBoardInterfaceListener
+class HardwareModelsThread : public fawkes::Thread,
+                             public fawkes::LoggingAspect,
+                             public fawkes::BlackBoardAspect,
+                             public fawkes::ConfigurableAspect,
+                             public fawkes::CLIPSFeature,
+                             public fawkes::CLIPSFeatureAspect,
+                             public fawkes::BlackBoardInterfaceListener
 {
- public:
+public:
 	HardwareModelsThread();
 
 	virtual void init();
 	virtual void loop();
 	virtual void finalize();
 
-    // for CLIPSFeature
-  virtual void clips_context_init(const std::string &env_name,
-          fawkes::LockPtr<CLIPS::Environment> &clips);
-  virtual void clips_context_destroyed(const std::string &env_name);
-
+	// for CLIPSFeature
+	virtual void clips_context_init(const std::string &                  env_name,
+	                                fawkes::LockPtr<CLIPS::Environment> &clips);
+	virtual void clips_context_destroyed(const std::string &env_name);
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
- protected: virtual void run() { Thread::run(); }
+protected:
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
 
- private:
-    std::map<std::string, fawkes::LockPtr<CLIPS::Environment> >  envs_;
+private:
+	std::map<std::string, fawkes::LockPtr<CLIPS::Environment>> envs_;
 
-    std::vector<std::string> components_;
+	std::vector<std::string> components_;
 
-    fawkes::HardwareModelsInterface *hm_if_;
+	fawkes::HardwareModelsInterface *hm_if_;
 
-    void  clips_add_terminal_state(fawkes::LockPtr<CLIPS::Environment> &clips, const std::string& component, const std::string& state);
-    void  clips_add_component(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& init_state);
-    void  clips_add_edge(fawkes::LockPtr<CLIPS::Environment> &clips,const std::string& component, const std::string& from, const std::string& to, const std::string& trans, const double prob);
-    void  clips_add_transition(const std::string& component, const std::string& transition) throw();
+	void clips_add_terminal_state(fawkes::LockPtr<CLIPS::Environment> &clips,
+	                              const std::string &                  component,
+	                              const std::string &                  state);
+	void clips_add_component(fawkes::LockPtr<CLIPS::Environment> &clips,
+	                         const std::string &                  component,
+	                         const std::string &                  init_state);
+	void clips_add_edge(fawkes::LockPtr<CLIPS::Environment> &clips,
+	                    const std::string &                  component,
+	                    const std::string &                  from,
+	                    const std::string &                  to,
+	                    const std::string &                  trans);
+	void clips_add_transition(const std::string &component, const std::string &transition) throw();
 };
 
 #endif

--- a/src/plugins/hardware-models/interfaces/HardwareModelsInterface.xml
+++ b/src/plugins/hardware-models/interfaces/HardwareModelsInterface.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE interface SYSTEM "interface.dtd">
+<interface name="HardwareModelsInterface" author="Daniel Habering" year="2019">
+  <data>
+    <comment>
+      Interface to inform the plugin about state changes in components
+    </comment>
+
+    <field type="string" length="1024" name="error">Error of last query</field>
+    <field type="string" length="1024" name="result">Result of last query</field>
+  </data>
+
+  <message name="StateChange">
+    <comment>
+      A component changed its state, by executing the transaction. 
+      Has to match the transactions defined in the yaml hardware model definitions
+    </comment>
+    <field type="string" length="1024" name="component">The component that changed its state</field>
+    <field type="string" length="1024" name="transaction">The transaction executed by the component</field>
+  </message>
+</interface>

--- a/src/plugins/hardware-models/interfaces/HardwareModelsInterface.xml
+++ b/src/plugins/hardware-models/interfaces/HardwareModelsInterface.xml
@@ -6,16 +6,16 @@
       Interface to inform the plugin about state changes in components
     </comment>
 
-    <field type="string" length="1024" name="error">Error of last query</field>
-    <field type="string" length="1024" name="result">Result of last query</field>
+    <field type="string" length="1024" name="error">Error state of the plugin</field>
+    <field type="bool" name="busy">Busy flag</field>
   </data>
 
   <message name="StateChange">
     <comment>
-      A component changed its state, by executing the transaction. 
-      Has to match the transactions defined in the yaml hardware model definitions
+      A component changed its state, by executing the transition. 
+      Has to match the transitions defined in the yaml hardware model definitions
     </comment>
     <field type="string" length="1024" name="component">The component that changed its state</field>
-    <field type="string" length="1024" name="transaction">The transaction executed by the component</field>
+    <field type="string" length="1024" name="transition">The transition executed by the component</field>
   </message>
 </interface>

--- a/src/plugins/hardware-models/interfaces/Makefile
+++ b/src/plugins/hardware-models/interfaces/Makefile
@@ -1,0 +1,25 @@
+#*****************************************************************************
+#              Makefile Build System for Fawkes: RobotMemoryInterface
+#                            -------------------
+#   Created on Sun May 01 20:25:42 2016
+#   Copyright (C) 2016 Frederik Zwilling
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../../..
+
+include $(BASEDIR)/etc/buildsys/config.mk
+
+INTERFACES_all = $(notdir $(patsubst %.xml,%,$(wildcard $(SRCDIR)/*.xml)))
+
+include $(BUILDSYSDIR)/interface.mk
+
+include $(BUILDSYSDIR)/base.mk
+


### PR DESCRIPTION
This PR adds a plugin which parses Config files defining models for hardware components given as finite state machines. These finite state machines are added to a clips environment.
Additionally, this plugin offers an interface, which can be used for informing about state changes