### PR TITLE
github: wait for 90 days before marking an issue as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,10 +2,10 @@
 # https://probot.github.io/apps/stale/
 
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+daysUntilStale: 90
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 14
 
 # Issues with these labels will never be considered stale
 exemptLabels:


### PR DESCRIPTION
This gives more time to work on an issue and seems more realistic with
our usual workflow.