### PR TITLE
Add skill execution time estimates to the skiller simulator

### DIFF
--- a/cfg/conf.d/skiller-simulator.yaml
+++ b/cfg/conf.d/skiller-simulator.yaml
@@ -1,0 +1,12 @@
+%YAML 1.2
+%TAG ! tag:fawkesrobotics.org,cfg/
+---
+plugins/skiller-simulator:
+  execution-times:
+    default: 1
+    say: 2.5
+  estimators:
+    navgraph:
+      speed: 0.5
+      skills:
+        - goto

--- a/src/plugins/Makefile
+++ b/src/plugins/Makefile
@@ -21,7 +21,7 @@ SUBDIRS	= bbsync bblogger webview ttmainloop rrd \
 	  laser imu flite festival joystick openrave \
 	  katana jaco pantilt roomba nao robotino \
 	  bumblebee2 realsense realsense2 perception amcl \
-	  skiller skiller-simulator luaagent \
+	  skiller skiller-simulator skiller-simulator-navgraph luaagent \
 	  laser-filter laser-lines laser-cluster laser-pointclouds \
 	  static_transforms navgraph navgraph-clusters navgraph-generator colli \
 	  clips clips-agent clips-protobuf clips-navgraph \
@@ -52,6 +52,7 @@ pddl-planner: robot-memory
 gazebo: robotino
 skiller: navgraph
 skiller-simulator: skiller
+skiller-simulator-navgraph: skiller-simulator
 perception: mongodb
 navgraph-generator: navgraph amcl
 openprs-agent: openprs

--- a/src/plugins/skiller-simulator-navgraph/Makefile
+++ b/src/plugins/skiller-simulator-navgraph/Makefile
@@ -24,9 +24,22 @@ OBJS_skiller_simulator_navgraph = skiller_simulator_navgraph_plugin.o \
                                   skiller_simulator_navgraph_thread.o \
                                   navgraph_estimator.o
 
-CFLAGS       += $(CFLAGS_CPP17)
 OBJS_all      = $(OBJS_skiller_simulator_navgraph)
 PLUGINS_all   = $(PLUGINDIR)/skiller-simulator-navgraph.so
-PLUGINS_build = $(PLUGINS_all)
+
+ifeq ($(HAVE_CPP17),1)
+  CFLAGS       += $(CFLAGS_CPP17)
+  PLUGINS_build = $(PLUGINS_all)
+else
+  WARN_TARGETS += warning_cpp17
+endif
+
+ifeq ($(OBJSSUBMAKE),1)
+all: $(WARN_TARGETS)
+.PHONY: $(WARN_TARGETS)
+
+warning_cpp17:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting skiller simulator navgraph$(TNORMAL) (C++17 not supported)"
+endif
 
 include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/skiller-simulator-navgraph/Makefile
+++ b/src/plugins/skiller-simulator-navgraph/Makefile
@@ -1,0 +1,33 @@
+#*****************************************************************************
+#                      Makefile Build System for Fawkes
+#                            -------------------
+#   Created on Tue 07 Jan 2020 16:04:34 CET
+#   Copyright (C) 2020 by Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../..
+
+include $(BASEDIR)/etc/buildsys/config.mk
+
+LIBS_skiller_simulator_navgraph = fawkescore fawkesutils fawkesaspects \
+																	fawkesblackboard fawkesinterface \
+																	Position3DInterface \
+                                  fawkeslogging fawkes_skiller_time_estimator
+OBJS_skiller_simulator_navgraph = skiller_simulator_navgraph_plugin.o \
+                                  skiller_simulator_navgraph_thread.o \
+                                  navgraph_estimator.o
+
+CFLAGS       += $(CFLAGS_CPP17)
+OBJS_all      = $(OBJS_skiller_simulator_navgraph)
+PLUGINS_all   = $(PLUGINDIR)/skiller-simulator-navgraph.so
+PLUGINS_build = $(PLUGINS_all)
+
+include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/skiller-simulator-navgraph/Makefile
+++ b/src/plugins/skiller-simulator-navgraph/Makefile
@@ -18,7 +18,7 @@ BASEDIR = ../../..
 include $(BASEDIR)/etc/buildsys/config.mk
 
 LIBS_skiller_simulator_navgraph = fawkescore fawkesutils fawkesaspects \
-																	fawkesblackboard fawkesinterface \
+                                  fawkesblackboard fawkesinterface \
                                   fawkeslogging fawkes_skiller_time_estimator
 OBJS_skiller_simulator_navgraph = skiller_simulator_navgraph_plugin.o \
                                   skiller_simulator_navgraph_thread.o \

--- a/src/plugins/skiller-simulator-navgraph/Makefile
+++ b/src/plugins/skiller-simulator-navgraph/Makefile
@@ -19,7 +19,6 @@ include $(BASEDIR)/etc/buildsys/config.mk
 
 LIBS_skiller_simulator_navgraph = fawkescore fawkesutils fawkesaspects \
 																	fawkesblackboard fawkesinterface \
-																	Position3DInterface \
                                   fawkeslogging fawkes_skiller_time_estimator
 OBJS_skiller_simulator_navgraph = skiller_simulator_navgraph_plugin.o \
                                   skiller_simulator_navgraph_thread.o \

--- a/src/plugins/skiller-simulator-navgraph/navgraph_estimator.cpp
+++ b/src/plugins/skiller-simulator-navgraph/navgraph_estimator.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *  navgraph_estimator.cpp - Estimate skill exec times from the navgraph
+ *
+ *  Created: Tue 07 Jan 2020 16:35:31 CET 16:35
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "navgraph_estimator.h"
+
+namespace fawkes {
+namespace skiller_simulator {
+
+/** @class NavGraphEstimator
+ * Estimate the execution time for the skill goto by querying the distance from
+ * the navgraph.
+ */
+
+/** Constructor.
+ * @param navgraph The navgraph to read the node positions from
+ * @param pose The Position3DInterface to read the current position from
+ */
+NavGraphEstimator::NavGraphEstimator(LockPtr<NavGraph> navgraph, Position3DInterface *pose)
+: navgraph_(navgraph), pose_(pose)
+{
+}
+
+bool
+NavGraphEstimator::can_execute(const Skill &skill) const
+{
+	return skill.skill_name == "goto" && navgraph_->node_exists(skill.skill_args.at("place"));
+}
+
+float
+NavGraphEstimator::get_execution_time(const Skill &skill) const
+{
+	pose_->read();
+	return navgraph_->node(skill.skill_args.at("place"))
+	  .distance(pose_->translation(0), pose_->translation(1));
+}
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator-navgraph/navgraph_estimator.cpp
+++ b/src/plugins/skiller-simulator-navgraph/navgraph_estimator.cpp
@@ -37,6 +37,8 @@ NavGraphEstimator::NavGraphEstimator(LockPtr<NavGraph> navgraph, Configuration *
 {
 	last_pose_x_ = config->get_float_or_default("plugins/amcl/init_pose_x", 0);
 	last_pose_y_ = config->get_float_or_default("plugins/amcl/init_pose_y", 0);
+	speed_ =
+	  config->get_float_or_default("plugins/skiller-simulation/estimators/navgraph/speed", 0.5);
 }
 
 bool
@@ -48,7 +50,8 @@ NavGraphEstimator::can_execute(const Skill &skill) const
 float
 NavGraphEstimator::get_execution_time(const Skill &skill) const
 {
-	return navgraph_->node(skill.skill_args.at("place")).distance(last_pose_x_, last_pose_y_);
+	return navgraph_->node(skill.skill_args.at("place")).distance(last_pose_x_, last_pose_y_)
+	       / speed_;
 }
 
 void

--- a/src/plugins/skiller-simulator-navgraph/navgraph_estimator.cpp
+++ b/src/plugins/skiller-simulator-navgraph/navgraph_estimator.cpp
@@ -39,12 +39,15 @@ NavGraphEstimator::NavGraphEstimator(LockPtr<NavGraph> navgraph, Configuration *
 	last_pose_y_ = config->get_float_or_default("plugins/amcl/init_pose_y", 0);
 	speed_ =
 	  config->get_float_or_default("plugins/skiller-simulation/estimators/navgraph/speed", 0.5);
+	skills_ = config->get_strings_or_defaults("plugins/skiller-simulation/estimators/navgraph/skills",
+	                                          {"goto"});
 }
 
 bool
 NavGraphEstimator::can_execute(const Skill &skill) const
 {
-	return skill.skill_name == "goto" && navgraph_->node_exists(skill.skill_args.at("place"));
+	return std::find(skills_.begin(), skills_.end(), skill.skill_name) != skills_.end()
+	       && navgraph_->node_exists(skill.skill_args.at("place"));
 }
 
 float

--- a/src/plugins/skiller-simulator-navgraph/navgraph_estimator.cpp
+++ b/src/plugins/skiller-simulator-navgraph/navgraph_estimator.cpp
@@ -37,9 +37,8 @@ NavGraphEstimator::NavGraphEstimator(LockPtr<NavGraph> navgraph, Configuration *
 {
 	last_pose_x_ = config->get_float_or_default("plugins/amcl/init_pose_x", 0);
 	last_pose_y_ = config->get_float_or_default("plugins/amcl/init_pose_y", 0);
-	speed_ =
-	  config->get_float_or_default("plugins/skiller-simulation/estimators/navgraph/speed", 0.5);
-	skills_ = config->get_strings_or_defaults("plugins/skiller-simulation/estimators/navgraph/skills",
+	speed_ = config->get_float_or_default("plugins/skiller-simulator/estimators/navgraph/speed", 0.5);
+	skills_ = config->get_strings_or_defaults("plugins/skiller-simulator/estimators/navgraph/skills",
 	                                          {"goto"});
 }
 

--- a/src/plugins/skiller-simulator-navgraph/navgraph_estimator.h
+++ b/src/plugins/skiller-simulator-navgraph/navgraph_estimator.h
@@ -26,6 +26,9 @@
 #include <navgraph/navgraph.h>
 #include <plugins/skiller-simulator/execution_time_estimator.h>
 
+#include <string>
+#include <vector>
+
 namespace fawkes {
 namespace skiller_simulator {
 class NavGraphEstimator : public ExecutionTimeEstimator
@@ -37,10 +40,11 @@ public:
 	void  execute(const Skill &skill) override;
 
 private:
-	LockPtr<NavGraph> navgraph_;
-	float             last_pose_x_;
-	float             last_pose_y_;
-	float             speed_;
+	LockPtr<NavGraph>        navgraph_;
+	std::vector<std::string> skills_;
+	float                    last_pose_x_;
+	float                    last_pose_y_;
+	float                    speed_;
 };
 } // namespace skiller_simulator
 } // namespace fawkes

--- a/src/plugins/skiller-simulator-navgraph/navgraph_estimator.h
+++ b/src/plugins/skiller-simulator-navgraph/navgraph_estimator.h
@@ -40,6 +40,7 @@ private:
 	LockPtr<NavGraph> navgraph_;
 	float             last_pose_x_;
 	float             last_pose_y_;
+	float             speed_;
 };
 } // namespace skiller_simulator
 } // namespace fawkes

--- a/src/plugins/skiller-simulator-navgraph/navgraph_estimator.h
+++ b/src/plugins/skiller-simulator-navgraph/navgraph_estimator.h
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *  navgraph_estimator.h - Estimate skill exec times from the navgraph
+ *
+ *  Created: Tue 07 Jan 2020 16:18:59 CET 16:18
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include "interfaces/Position3DInterface.h"
+
+#include <navgraph/navgraph.h>
+#include <plugins/skiller-simulator/execution_time_estimator.h>
+
+namespace fawkes {
+namespace skiller_simulator {
+class NavGraphEstimator : public ExecutionTimeEstimator
+{
+public:
+	NavGraphEstimator(LockPtr<NavGraph> navgraph, Position3DInterface *pose);
+	float get_execution_time(const Skill &skill) const override;
+	bool  can_execute(const Skill &skill) const override;
+
+private:
+	LockPtr<NavGraph>    navgraph_;
+	Position3DInterface *pose_;
+};
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator-navgraph/navgraph_estimator.h
+++ b/src/plugins/skiller-simulator-navgraph/navgraph_estimator.h
@@ -22,6 +22,7 @@
 
 #include "interfaces/Position3DInterface.h"
 
+#include <config/config.h>
 #include <navgraph/navgraph.h>
 #include <plugins/skiller-simulator/execution_time_estimator.h>
 
@@ -30,13 +31,15 @@ namespace skiller_simulator {
 class NavGraphEstimator : public ExecutionTimeEstimator
 {
 public:
-	NavGraphEstimator(LockPtr<NavGraph> navgraph, Position3DInterface *pose);
+	NavGraphEstimator(LockPtr<NavGraph> navgraph, Configuration *config);
 	float get_execution_time(const Skill &skill) const override;
 	bool  can_execute(const Skill &skill) const override;
+	void  execute(const Skill &skill) override;
 
 private:
-	LockPtr<NavGraph>    navgraph_;
-	Position3DInterface *pose_;
+	LockPtr<NavGraph> navgraph_;
+	float             last_pose_x_;
+	float             last_pose_y_;
 };
 } // namespace skiller_simulator
 } // namespace fawkes

--- a/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_plugin.cpp
+++ b/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_plugin.cpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *  skiller_simulator_navgraph_plugin.cpp - Skill exec times from navgraph
+ *
+ *  Created: Tue 07 Jan 2020 15:36:35 CET 15:36
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "skiller_simulator_navgraph_thread.h"
+
+#include <core/plugin.h>
+
+/** @class SkillerSimulatorNavgraphPlugin
+ * Plugin to get estimates for skill execution times from the navgraph.
+ */
+
+class SkillerSimulatorNavgraphPlugin : public fawkes::Plugin
+{
+public:
+	/** Constructor.
+   * @param config The fawkes config to use
+   */
+	explicit SkillerSimulatorNavgraphPlugin(fawkes::Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new SkillerSimulatorNavgraphEstimatorThread());
+	}
+};
+
+PLUGIN_DESCRIPTION("Estimate skill execution times with the navgraph")
+EXPORT_PLUGIN(SkillerSimulatorNavgraphPlugin)

--- a/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_thread.cpp
+++ b/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_thread.cpp
@@ -34,16 +34,10 @@ SkillerSimulatorNavgraphEstimatorThread::SkillerSimulatorNavgraphEstimatorThread
 {
 }
 
+/** Initializer. */
 void
 SkillerSimulatorNavgraphEstimatorThread::init()
 {
-	pose_ = blackboard->open_for_reading<fawkes::Position3DInterface>("Pose");
 	execution_time_estimator_manager_->register_provider(
-	  std::make_shared<fawkes::skiller_simulator::NavGraphEstimator>(navgraph, pose_));
-}
-
-void
-SkillerSimulatorNavgraphEstimatorThread::finalize()
-{
-	blackboard->close(pose_);
+	  std::make_shared<fawkes::skiller_simulator::NavGraphEstimator>(navgraph, config));
 }

--- a/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_thread.cpp
+++ b/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_thread.cpp
@@ -1,0 +1,49 @@
+/***************************************************************************
+ *  skiller_simulator_navgraph_thread.cpp - Skill exec times from navgraph
+ *
+ *  Created: Tue 07 Jan 2020 16:02:38 CET 16:02
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "skiller_simulator_navgraph_thread.h"
+
+#include "navgraph_estimator.h"
+
+#include <interfaces/Position3DInterface.h>
+
+/** @class SkillerSimulatorNavgraphEstimatorThread
+ * Get estimates for skill execution times from the navgraph.
+ */
+
+/** Constructor. */
+SkillerSimulatorNavgraphEstimatorThread::SkillerSimulatorNavgraphEstimatorThread()
+: Thread("SkillerSimulatorNavgraphEstimatorThread", Thread::OPMODE_WAITFORWAKEUP)
+{
+}
+
+void
+SkillerSimulatorNavgraphEstimatorThread::init()
+{
+	pose_ = blackboard->open_for_reading<fawkes::Position3DInterface>("Pose");
+	execution_time_estimator_manager_->register_provider(
+	  std::make_shared<fawkes::skiller_simulator::NavGraphEstimator>(navgraph, pose_));
+}
+
+void
+SkillerSimulatorNavgraphEstimatorThread::finalize()
+{
+	blackboard->close(pose_);
+}

--- a/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_thread.h
+++ b/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_thread.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *  skiller_simulator_navgraph_thread.h - Skill exec times from navgraph
+ *
+ *  Created: Tue 07 Jan 2020 15:40:18 CET 15:40
+ *  Copyright  2020  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include "interfaces/Position3DInterface.h"
+#include "navgraph/aspect/navgraph.h"
+
+#include <aspect/blackboard.h>
+#include <core/threading/thread.h>
+#include <plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.h>
+
+class SkillerSimulatorNavgraphEstimatorThread
+: public fawkes::Thread,
+  public fawkes::BlackBoardAspect,
+  public fawkes::NavGraphAspect,
+  public fawkes::skiller_simulator::ExecutionTimeEstimatorsAspect
+{
+public:
+	SkillerSimulatorNavgraphEstimatorThread();
+	virtual void init();
+	virtual void finalize();
+
+private:
+	fawkes::Position3DInterface *pose_;
+};

--- a/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_thread.h
+++ b/src/plugins/skiller-simulator-navgraph/skiller_simulator_navgraph_thread.h
@@ -20,24 +20,20 @@
 
 #pragma once
 
-#include "interfaces/Position3DInterface.h"
-#include "navgraph/aspect/navgraph.h"
-
 #include <aspect/blackboard.h>
+#include <aspect/configurable.h>
 #include <core/threading/thread.h>
+#include <navgraph/aspect/navgraph.h>
 #include <plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.h>
 
 class SkillerSimulatorNavgraphEstimatorThread
 : public fawkes::Thread,
   public fawkes::BlackBoardAspect,
+  public fawkes::ConfigurableAspect,
   public fawkes::NavGraphAspect,
   public fawkes::skiller_simulator::ExecutionTimeEstimatorsAspect
 {
 public:
 	SkillerSimulatorNavgraphEstimatorThread();
-	virtual void init();
-	virtual void finalize();
-
-private:
-	fawkes::Position3DInterface *pose_;
+	void init();
 };

--- a/src/plugins/skiller-simulator/Makefile
+++ b/src/plugins/skiller-simulator/Makefile
@@ -21,7 +21,9 @@ include $(LIBSRCDIR)/utils/utils.mk
 LIBS_skiller_simulator  = fawkescore fawkesutils fawkesaspects \
                           fawkesblackboard fawkesinterface fawkeslogging \
                           SkillerInterface
-OBJS_skiller_simulator  = skiller_simulator_plugin.o exec_thread.o
+OBJS_skiller_simulator  = skiller_simulator_plugin.o exec_thread.o \
+                          execution_time_estimator_aspect/execution_time_estimator_aspect.o \
+                          execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.o
 OBJS_all                = $(OBJS_skiller_simulator)
 PLUGINS_all             = $(PLUGINDIR)/skiller-simulator.so
 PLUGINS_build           = $(PLUGINS_all)

--- a/src/plugins/skiller-simulator/Makefile
+++ b/src/plugins/skiller-simulator/Makefile
@@ -28,7 +28,8 @@ CFLAGS += $(CFLAGS_CPP17)
 
 OBJS_skiller_simulator  = skiller_simulator_plugin.o exec_thread.o \
                           execution_time_estimator_aspect/execution_time_estimator_aspect.o \
-                          execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.o
+                          execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.o \
+                          estimators/config_estimator.o
 OBJS_libfawkes_skiller_time_estimator = execution_time_estimator.o
 
 OBJS_all                = $(OBJS_skiller_simulator) $(OBJS_libfawkes_skiller_time_estimator)

--- a/src/plugins/skiller-simulator/Makefile
+++ b/src/plugins/skiller-simulator/Makefile
@@ -23,10 +23,14 @@ LIBS_skiller_simulator  = fawkescore fawkesutils fawkesaspects \
                           fawkes_skiller_time_estimator \
                           SkillerInterface
 LIBS_libfawkes_skiller_time_estimator = fawkescore
+
+CFLAGS += $(CFLAGS_CPP17)
+
 OBJS_skiller_simulator  = skiller_simulator_plugin.o exec_thread.o \
                           execution_time_estimator_aspect/execution_time_estimator_aspect.o \
                           execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.o
 OBJS_libfawkes_skiller_time_estimator = execution_time_estimator.o
+
 OBJS_all                = $(OBJS_skiller_simulator) $(OBJS_libfawkes_skiller_time_estimator)
 PLUGINS_all             = $(PLUGINDIR)/skiller-simulator.so
 LIBS_all                = $(LIBDIR)/libfawkes_skiller_time_estimator.so

--- a/src/plugins/skiller-simulator/Makefile
+++ b/src/plugins/skiller-simulator/Makefile
@@ -22,7 +22,7 @@ LIBS_skiller_simulator  = fawkescore fawkesutils fawkesaspects \
                           fawkesblackboard fawkesinterface fawkeslogging \
                           fawkes_skiller_time_estimator \
                           SkillerInterface
-LIBS_libfawkes_skiller_time_estimator = fawkescore
+LIBS_libfawkes_skiller_time_estimator = m fawkescore
 
 OBJS_skiller_simulator  = skiller_simulator_plugin.o exec_thread.o \
                           execution_time_estimator_aspect/execution_time_estimator_aspect.o \

--- a/src/plugins/skiller-simulator/Makefile
+++ b/src/plugins/skiller-simulator/Makefile
@@ -24,8 +24,6 @@ LIBS_skiller_simulator  = fawkescore fawkesutils fawkesaspects \
                           SkillerInterface
 LIBS_libfawkes_skiller_time_estimator = fawkescore
 
-CFLAGS += $(CFLAGS_CPP17)
-
 OBJS_skiller_simulator  = skiller_simulator_plugin.o exec_thread.o \
                           execution_time_estimator_aspect/execution_time_estimator_aspect.o \
                           execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.o \
@@ -35,9 +33,23 @@ OBJS_libfawkes_skiller_time_estimator = execution_time_estimator.o
 OBJS_all                = $(OBJS_skiller_simulator) $(OBJS_libfawkes_skiller_time_estimator)
 PLUGINS_all             = $(PLUGINDIR)/skiller-simulator.so
 LIBS_all                = $(LIBDIR)/libfawkes_skiller_time_estimator.so
-LIBS_build              = $(LIBS_all)
-PLUGINS_build           = $(PLUGINS_all)
+
+ifeq ($(HAVE_CPP17),1)
+  CFLAGS        += $(CFLAGS_CPP17)
+  LIBS_build     = $(LIBS_all)
+  PLUGINS_build  = $(PLUGINS_all)
+else
+  WARN_TARGETS += warning_cpp17
+endif
 
 $(PLUGINS_build): | $(LIBDIR)/libfawkes_skiller_time_estimator.$(SOEXT)
+
+ifeq ($(OBJSSUBMAKE),1)
+all: $(WARN_TARGETS)
+.PHONY: $(WARN_TARGETS)
+
+warning_cpp17:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting skiller simulator$(TNORMAL) (C++17 not supported)"
+endif
 
 include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/skiller-simulator/Makefile
+++ b/src/plugins/skiller-simulator/Makefile
@@ -20,12 +20,19 @@ include $(LIBSRCDIR)/utils/utils.mk
 
 LIBS_skiller_simulator  = fawkescore fawkesutils fawkesaspects \
                           fawkesblackboard fawkesinterface fawkeslogging \
+                          fawkes_skiller_time_estimator \
                           SkillerInterface
+LIBS_libfawkes_skiller_time_estimator = fawkescore
 OBJS_skiller_simulator  = skiller_simulator_plugin.o exec_thread.o \
                           execution_time_estimator_aspect/execution_time_estimator_aspect.o \
                           execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.o
-OBJS_all                = $(OBJS_skiller_simulator)
+OBJS_libfawkes_skiller_time_estimator = execution_time_estimator.o
+OBJS_all                = $(OBJS_skiller_simulator) $(OBJS_libfawkes_skiller_time_estimator)
 PLUGINS_all             = $(PLUGINDIR)/skiller-simulator.so
+LIBS_all                = $(LIBDIR)/libfawkes_skiller_time_estimator.so
+LIBS_build              = $(LIBS_all)
 PLUGINS_build           = $(PLUGINS_all)
+
+$(PLUGINS_build): | $(LIBDIR)/libfawkes_skiller_time_estimator.$(SOEXT)
 
 include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/skiller-simulator/estimators/config_estimator.cpp
+++ b/src/plugins/skiller-simulator/estimators/config_estimator.cpp
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *  config_estimator.cpp - Read estimated execution time from config
+ *
+ *  Created: Sun 22 Dec 2019 17:18:10 CET 17:18
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "config_estimator.h"
+
+namespace fawkes {
+namespace skiller_simulator {
+
+constexpr char ConfigExecutionTimeEstimator::cfg_prefix_[];
+
+/** @class ConfigExecutionTimeEstimator
+ * Get a static estimate for the skill execution time from the config.
+ * This simply reads the execution time from the config. It only considers
+ * the skill name, the arguments are ignored.
+ */
+
+/** Constructor
+ * @param config The config to read the execution times from
+ */
+ConfigExecutionTimeEstimator::ConfigExecutionTimeEstimator(Configuration *config) : config_(config)
+{
+}
+
+bool
+ConfigExecutionTimeEstimator::can_execute(const Skill &skill) const
+{
+	return config_->exists(cfg_prefix_ + skill.skill_name);
+}
+
+float
+ConfigExecutionTimeEstimator::get_execution_time(const Skill &skill) const
+{
+	return config_->get_float(cfg_prefix_ + skill.skill_name);
+}
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator/estimators/config_estimator.h
+++ b/src/plugins/skiller-simulator/estimators/config_estimator.h
@@ -35,7 +35,7 @@ public:
 
 private:
 	Configuration *const  config_;
-	constexpr static char cfg_prefix_[] = "/plugins/skiller-simulation/execution-times/";
+	constexpr static char cfg_prefix_[] = "/plugins/skiller-simulator/execution-times/";
 };
 
 } // namespace skiller_simulator

--- a/src/plugins/skiller-simulator/estimators/config_estimator.h
+++ b/src/plugins/skiller-simulator/estimators/config_estimator.h
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *  config_estimator.h - Read estimated execution time from config
+ *
+ *  Created: Sun 22 Dec 2019 17:16:23 CET 17:16
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include "../execution_time_estimator.h"
+
+#include <config/config.h>
+
+namespace fawkes {
+namespace skiller_simulator {
+class ConfigExecutionTimeEstimator : public ExecutionTimeEstimator
+{
+public:
+	ConfigExecutionTimeEstimator(Configuration *config);
+	float get_execution_time(const Skill &skill) const override;
+	bool  can_execute(const Skill &skill) const override;
+
+private:
+	Configuration *const  config_;
+	constexpr static char cfg_prefix_[] = "/plugins/skiller-simulation/execution-times/";
+};
+
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -41,8 +41,9 @@ SkillerSimulatorExecutionThread::SkillerSimulatorExecutionThread()
 void
 SkillerSimulatorExecutionThread::init()
 {
-	skiller_if_      = blackboard->open_for_writing<SkillerInterface>("Skiller");
-	skill_runtime_   = config->get_float_or_default("/plugins/skiller-simulation/skill-runtime", 1);
+	skiller_if_ = blackboard->open_for_writing<SkillerInterface>("Skiller");
+	default_skill_runtime_ =
+	  config->get_float_or_default("/plugins/skiller-simulation/skill-runtime", 1);
 	skill_starttime_ = Time();
 }
 
@@ -145,7 +146,7 @@ SkillerSimulatorExecutionThread::loop()
 	if (!skill_enqueued) {
 		if (skiller_if_->status() == SkillerInterface::S_RUNNING) {
 			Time now = Time();
-			if (Time() > skill_starttime_ + skill_runtime_) {
+			if (Time() > skill_starttime_ + get_skill_runtime(skiller_if_->skill_string())) {
 				logger->log_info(name(), "Skill '%s' is final", skiller_if_->skill_string());
 				skiller_if_->set_skill_string("");
 				skiller_if_->set_status(SkillerInterface::S_FINAL);
@@ -163,4 +164,10 @@ void
 SkillerSimulatorExecutionThread::finalize()
 {
 	blackboard->close(skiller_if_);
+}
+
+float
+SkillerSimulatorExecutionThread::get_skill_runtime(const std::string &skill) const
+{
+	return default_skill_runtime_;
 }

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -34,7 +34,8 @@ using namespace fawkes;
 /** Constructor. */
 SkillerSimulatorExecutionThread::SkillerSimulatorExecutionThread()
 : Thread("SkillerSimulatorExecutionThread", Thread::OPMODE_WAITFORWAKEUP),
-  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL)
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL),
+  AspectProviderAspect(&provider_inifin_)
 {
 }
 

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -122,6 +122,10 @@ SkillerSimulatorExecutionThread::loop()
 			skiller_if_->set_msgid(m->id());
 			skiller_if_->set_error("");
 			skiller_if_->set_status(SkillerInterface::S_RUNNING);
+			logger->log_info(name(),
+			                 "Executing '%s', will take %.2f seconds",
+			                 m->skill_string(),
+			                 get_skill_runtime(m->skill_string()));
 			skill_starttime_ = Time();
 			write_interface  = true;
 			skill_enqueued   = true;

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -47,7 +47,7 @@ SkillerSimulatorExecutionThread::init()
 {
 	skiller_if_ = blackboard->open_for_writing<SkillerInterface>("Skiller");
 	default_skill_runtime_ =
-	  config->get_float_or_default("/plugins/skiller-simulation/execution-times/default", 1);
+	  config->get_float_or_default("/plugins/skiller-simulator/execution-times/default", 1);
 	skill_starttime_ = Time();
 	execution_time_estimator_manager_.register_provider(
 	  std::make_shared<skiller_simulator::ConfigExecutionTimeEstimator>(config));

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -20,6 +20,8 @@
 
 #include "exec_thread.h"
 
+#include "estimators/config_estimator.h"
+
 using namespace std;
 using namespace fawkes;
 
@@ -47,6 +49,8 @@ SkillerSimulatorExecutionThread::init()
 	default_skill_runtime_ =
 	  config->get_float_or_default("/plugins/skiller-simulation/skill-runtime", 1);
 	skill_starttime_ = Time();
+	execution_time_estimator_manager_.register_provider(
+	  std::make_shared<skiller_simulator::ConfigExecutionTimeEstimator>(config));
 }
 
 void

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -47,7 +47,7 @@ SkillerSimulatorExecutionThread::init()
 {
 	skiller_if_ = blackboard->open_for_writing<SkillerInterface>("Skiller");
 	default_skill_runtime_ =
-	  config->get_float_or_default("/plugins/skiller-simulation/skill-runtime", 1);
+	  config->get_float_or_default("/plugins/skiller-simulation/execution-times/default", 1);
 	skill_starttime_ = Time();
 	execution_time_estimator_manager_.register_provider(
 	  std::make_shared<skiller_simulator::ConfigExecutionTimeEstimator>(config));

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -171,5 +171,10 @@ SkillerSimulatorExecutionThread::finalize()
 float
 SkillerSimulatorExecutionThread::get_skill_runtime(const std::string &skill) const
 {
-	return default_skill_runtime_;
+	auto provider = execution_time_estimator_manager_.get_provider(skill);
+	if (provider) {
+		return (*provider)->get_execution_time(skill);
+	} else {
+		return default_skill_runtime_;
+	}
 }

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -158,6 +158,7 @@ SkillerSimulatorExecutionThread::loop()
 			Time now = Time();
 			if (Time() > skill_starttime_ + get_skill_runtime(skiller_if_->skill_string())) {
 				logger->log_info(name(), "Skill '%s' is final", skiller_if_->skill_string());
+				execute_skill(skiller_if_->skill_string());
 				skiller_if_->set_skill_string("");
 				skiller_if_->set_status(SkillerInterface::S_FINAL);
 				write_interface = true;
@@ -184,5 +185,14 @@ SkillerSimulatorExecutionThread::get_skill_runtime(const std::string &skill) con
 		return (*provider)->get_execution_time(skill);
 	} else {
 		return default_skill_runtime_;
+	}
+}
+
+void
+SkillerSimulatorExecutionThread::execute_skill(const std::string &skill)
+{
+	auto provider = execution_time_estimator_manager_.get_provider(skill);
+	if (provider) {
+		(*provider)->execute(skill);
 	}
 }

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -35,7 +35,8 @@ using namespace fawkes;
 SkillerSimulatorExecutionThread::SkillerSimulatorExecutionThread()
 : Thread("SkillerSimulatorExecutionThread", Thread::OPMODE_WAITFORWAKEUP),
   BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SKILL),
-  AspectProviderAspect(&provider_inifin_)
+  AspectProviderAspect(&provider_inifin_),
+  provider_inifin_(&execution_time_estimator_manager_)
 {
 }
 

--- a/src/plugins/skiller-simulator/exec_thread.h
+++ b/src/plugins/skiller-simulator/exec_thread.h
@@ -21,6 +21,10 @@
 #ifndef _PLUGINS_SKILLER_SIMULATOR_EXEC_THREAD_H_
 #define _PLUGINS_SKILLER_SIMULATOR_EXEC_THREAD_H_
 
+#include "execution_time_estimator_aspect/execution_time_estimator_aspect.h"
+#include "execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.h"
+
+#include <aspect/aspect_provider.h>
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
 #include <aspect/clock.h>
@@ -30,11 +34,14 @@
 #include <interfaces/SkillerInterface.h>
 #include <plugins/skiller/skiller_feature.h>
 
-class SkillerSimulatorExecutionThread : public fawkes::Thread,
-                                        public fawkes::BlockedTimingAspect,
-                                        public fawkes::LoggingAspect,
-                                        public fawkes::BlackBoardAspect,
-                                        public fawkes::ConfigurableAspect
+class SkillerSimulatorExecutionThread
+: public fawkes::Thread,
+  public fawkes::BlockedTimingAspect,
+  public fawkes::LoggingAspect,
+  public fawkes::BlackBoardAspect,
+  public fawkes::ConfigurableAspect,
+  public fawkes::skiller_simulator::ExecutionTimeEstimatorsAspect,
+  public fawkes::AspectProviderAspect
 {
 public:
 	SkillerSimulatorExecutionThread();
@@ -55,6 +62,7 @@ private:
 	fawkes::SkillerInterface *skiller_if_;
 	float                     default_skill_runtime_;
 	fawkes::Time              skill_starttime_;
+	fawkes::skiller_simulator::ExecutionTimeEstimatorsAspectIniFin provider_inifin_;
 };
 
 #endif /* !_PLUGINS_SKILLER_SIMULATOR_EXEC_THREAD_H_ */

--- a/src/plugins/skiller-simulator/exec_thread.h
+++ b/src/plugins/skiller-simulator/exec_thread.h
@@ -51,8 +51,9 @@ protected:
 	}
 
 private:
+	float                     get_skill_runtime(const std::string &skill) const;
 	fawkes::SkillerInterface *skiller_if_;
-	double                    skill_runtime_;
+	float                     default_skill_runtime_;
 	fawkes::Time              skill_starttime_;
 };
 

--- a/src/plugins/skiller-simulator/exec_thread.h
+++ b/src/plugins/skiller-simulator/exec_thread.h
@@ -34,14 +34,12 @@
 #include <interfaces/SkillerInterface.h>
 #include <plugins/skiller/skiller_feature.h>
 
-class SkillerSimulatorExecutionThread
-: public fawkes::Thread,
-  public fawkes::BlockedTimingAspect,
-  public fawkes::LoggingAspect,
-  public fawkes::BlackBoardAspect,
-  public fawkes::ConfigurableAspect,
-  public fawkes::skiller_simulator::ExecutionTimeEstimatorsAspect,
-  public fawkes::AspectProviderAspect
+class SkillerSimulatorExecutionThread : public fawkes::Thread,
+                                        public fawkes::BlockedTimingAspect,
+                                        public fawkes::LoggingAspect,
+                                        public fawkes::BlackBoardAspect,
+                                        public fawkes::ConfigurableAspect,
+                                        public fawkes::AspectProviderAspect
 {
 public:
 	SkillerSimulatorExecutionThread();
@@ -62,6 +60,7 @@ private:
 	fawkes::SkillerInterface *skiller_if_;
 	float                     default_skill_runtime_;
 	fawkes::Time              skill_starttime_;
+	fawkes::skiller_simulator::ExecutionTimeEstimatorManager       execution_time_estimator_manager_;
 	fawkes::skiller_simulator::ExecutionTimeEstimatorsAspectIniFin provider_inifin_;
 };
 

--- a/src/plugins/skiller-simulator/exec_thread.h
+++ b/src/plugins/skiller-simulator/exec_thread.h
@@ -57,6 +57,7 @@ protected:
 
 private:
 	float                     get_skill_runtime(const std::string &skill) const;
+	void                      execute_skill(const std::string &skill);
 	fawkes::SkillerInterface *skiller_if_;
 	float                     default_skill_runtime_;
 	fawkes::Time              skill_starttime_;

--- a/src/plugins/skiller-simulator/execution_time_estimator.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator.cpp
@@ -1,0 +1,101 @@
+/***************************************************************************
+ *  execution_time_estimator.cpp - An execution time estimator for skills
+ *
+ *  Created: Sun 22 Dec 2019 17:41:18 CET 17:41
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "execution_time_estimator.h"
+
+#include <core/exception.h>
+
+#include <cassert>
+#include <iostream>
+#include <regex>
+#include <string>
+
+namespace fawkes {
+namespace skiller_simulator {
+
+using Skill = ExecutionTimeEstimator::Skill;
+
+/** @class ExecutionTimeEstimator
+ * An abstract estimator for the execution time of a skill.
+ * Inherit from this class if you want to implement an estimator for a skill or
+ * a set of skills.
+ * @fn float ExecutionTimeEstimator::get_execution_time(const std::string &skill_string) const
+ * Get the estimated execution time for the given skill string.
+ * @param skill_string The skill string to compute the execution time for.
+ * @return The execution time in seconds.
+ *
+ * @fn ExecutionTimeEstimator::can_execute(const std::string &skill_string) const
+ * Check if this estimator can give an estimate for the given
+ * @param skill_string The skill string to check.
+ * @return true if this estimator can give an execution time estimate for the given skill.
+ *
+ * @fn float ExecutionTimeEstimator::get_execution_time(const Skill &skill) const
+ * Get the estimated execution time for the given skill string.
+ * @param skill The skill object to compute the execution time for.
+ * @return The execution time in seconds.
+ *
+ * @fn bool ExecutionTimeEstimator::can_execute(const Skill &skill) const
+ * Check if this estimator can give an estimate for the given
+ * @param skill The skill object to check.
+ * @return true if this estimator can give an execution time estimate for the given skill.
+ */
+
+/** Constructor.
+ * Create a skill from the skill string.
+ * @param skill_string The skill string to create the skill object from.
+ */
+Skill::Skill(const std::string &skill_string)
+{
+	if (skill_string.empty()) {
+		return;
+	}
+	const std::regex regex("(\\w+)(?:\\(\\)|\\{(.+)?})");
+	std::smatch      match;
+	if (std::regex_match(skill_string, match, regex)) {
+		assert(match.size() > 1);
+		skill_name = match[1];
+		if (match.size() > 2) {
+			const std::string args = match[2];
+			parse_args(args);
+		}
+	} else {
+		throw Exception("Unexpected skill string");
+	}
+}
+
+void
+Skill::parse_args(const std::string &args)
+{
+	const std::regex skill_args_regex("(?:([^,]+),\\s*)*?([^,]+)");
+	std::smatch      args_match;
+	if (std::regex_match(args, args_match, skill_args_regex)) {
+		const std::regex skill_arg_regex("(\\w+)=(['\"]?)([^'\"]*)\\2\\s*");
+		for (auto kv_match = std::next(args_match.begin()); kv_match != args_match.end(); kv_match++) {
+			const std::string key_arg = *kv_match;
+			std::smatch       m;
+			if (std::regex_match(key_arg, m, skill_arg_regex)) {
+				skill_args[m[1]] = m[3];
+			}
+		}
+	}
+}
+
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator/execution_time_estimator.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator.cpp
@@ -54,12 +54,15 @@ using Skill = ExecutionTimeEstimator::Skill;
  */
 Skill::Skill(const std::string &skill_string)
 {
-	if (skill_string.empty()) {
+	std::string skill_no_newlines(skill_string);
+	skill_no_newlines.erase(std::remove(skill_no_newlines.begin(), skill_no_newlines.end(), '\n'),
+	                        skill_no_newlines.end());
+	if (skill_no_newlines.empty()) {
 		return;
 	}
 	const std::regex regex("(\\w+)(?:\\(\\)|\\{(.+)?})");
 	std::smatch      match;
-	if (std::regex_match(skill_string, match, regex)) {
+	if (std::regex_match(skill_no_newlines, match, regex)) {
 		assert(match.size() > 1);
 		skill_name = match[1];
 		if (match.size() > 2) {
@@ -67,7 +70,7 @@ Skill::Skill(const std::string &skill_string)
 			parse_args(args);
 		}
 	} else {
-		throw Exception("Unexpected skill string");
+		throw Exception("Unexpected skill string: '%s'", skill_no_newlines.c_str());
 	}
 }
 

--- a/src/plugins/skiller-simulator/execution_time_estimator.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator.cpp
@@ -46,6 +46,11 @@ using Skill = ExecutionTimeEstimator::Skill;
  * Check if this estimator can give an estimate for the given
  * @param skill The skill object to check.
  * @return true if this estimator can give an execution time estimate for the given skill.
+ *
+ * @fn void ExecutionTimeEstimator::execute(const Skill &skill) const
+ * Let the estimator know that we are executing this skill, so it can apply
+ * possible side effects.
+ * @param skill The skill to execute
  */
 
 /** Constructor.

--- a/src/plugins/skiller-simulator/execution_time_estimator.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator.cpp
@@ -36,15 +36,6 @@ using Skill = ExecutionTimeEstimator::Skill;
  * An abstract estimator for the execution time of a skill.
  * Inherit from this class if you want to implement an estimator for a skill or
  * a set of skills.
- * @fn float ExecutionTimeEstimator::get_execution_time(const std::string &skill_string) const
- * Get the estimated execution time for the given skill string.
- * @param skill_string The skill string to compute the execution time for.
- * @return The execution time in seconds.
- *
- * @fn ExecutionTimeEstimator::can_execute(const std::string &skill_string) const
- * Check if this estimator can give an estimate for the given
- * @param skill_string The skill string to check.
- * @return true if this estimator can give an execution time estimate for the given skill.
  *
  * @fn float ExecutionTimeEstimator::get_execution_time(const Skill &skill) const
  * Get the estimated execution time for the given skill string.

--- a/src/plugins/skiller-simulator/execution_time_estimator.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator.cpp
@@ -65,7 +65,7 @@ Skill::Skill(const std::string &skill_string)
 	if (skill_no_newlines.empty()) {
 		return;
 	}
-	const std::regex regex("(\\w+)(?:\\(\\)|\\{(.+)?})");
+	const std::regex regex("(\\w+)(?:\\(\\)|\\{(.+)?\\})");
 	std::smatch      match;
 	if (std::regex_match(skill_no_newlines, match, regex)) {
 		assert(match.size() > 1);

--- a/src/plugins/skiller-simulator/execution_time_estimator.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator.h
@@ -1,0 +1,36 @@
+/***************************************************************************
+ *  execution_time_estimator.h - An execution time estimator for skills
+ *
+ *  Created: Thu 12 Dec 2019 15:10:06 CET 15:10
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace fawkes {
+namespace skiller_simulator {
+
+class ExecutionTimeEstimator
+{
+public:
+	virtual float get_executioN_time(const std::string &skill_string) const = 0;
+	virtual bool  can_execute(const std::string &skill_string) const        = 0;
+};
+
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator/execution_time_estimator.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace fawkes {
 namespace skiller_simulator {
@@ -28,8 +30,25 @@ namespace skiller_simulator {
 class ExecutionTimeEstimator
 {
 public:
-	virtual float get_executioN_time(const std::string &skill_string) const = 0;
-	virtual bool  can_execute(const std::string &skill_string) const        = 0;
+	/** A structured representation of a skill. */
+	class Skill
+	{
+	public:
+		Skill(const std::string &skill_string);
+
+		/** The name of the skill */
+		std::string skill_name = "";
+		/** A map of the skill's argument keys to argument values */
+		std::unordered_map<std::string, std::string> skill_args = {};
+
+	private:
+		void parse_args(const std::string &args);
+	};
+
+	virtual float get_execution_time(const std::string &skill_string) const;
+	virtual bool  can_execute(const std::string &skill_string) const;
+	virtual float get_execution_time(const Skill &skill) const = 0;
+	virtual bool  can_execute(const Skill &skill) const        = 0;
 };
 
 } // namespace skiller_simulator

--- a/src/plugins/skiller-simulator/execution_time_estimator.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator.h
@@ -45,6 +45,9 @@ public:
 		void parse_args(const std::string &args);
 	};
 
+	/** Destructor. */
+	virtual ~ExecutionTimeEstimator() = default;
+
 	virtual float get_execution_time(const Skill &skill) const = 0;
 	virtual bool  can_execute(const Skill &skill) const        = 0;
 	virtual void  execute(const Skill &skill){};

--- a/src/plugins/skiller-simulator/execution_time_estimator.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator.h
@@ -47,6 +47,7 @@ public:
 
 	virtual float get_execution_time(const Skill &skill) const = 0;
 	virtual bool  can_execute(const Skill &skill) const        = 0;
+	virtual void  execute(const Skill &skill){};
 };
 
 } // namespace skiller_simulator

--- a/src/plugins/skiller-simulator/execution_time_estimator.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator.h
@@ -45,8 +45,6 @@ public:
 		void parse_args(const std::string &args);
 	};
 
-	virtual float get_execution_time(const std::string &skill_string) const;
-	virtual bool  can_execute(const std::string &skill_string) const;
 	virtual float get_execution_time(const Skill &skill) const = 0;
 	virtual bool  can_execute(const Skill &skill) const        = 0;
 };

--- a/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+ *  execution_time_estimator_aspect.cpp - Aspect for a running time provider
+ *
+ *  Created: Thu 12 Dec 2019 19:03:19 CET 19:03
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "execution_time_estimator_aspect.h"
+
+#include <core/exception.h>
+
+namespace fawkes {
+namespace skiller_simulator {
+
+/** @class ExecutionTimeEstimatorManager
+ * A manager for a vector of running time providers for skill simulation.
+ */
+
+/** Get the running time provider for the given skill string.
+ * @param skill_string The string to get the running time for
+ * @return a pointer to the provider
+ */
+std::shared_ptr<ExecutionTimeEstimator>
+ExecutionTimeEstimatorManager::get_provider(const std::string &skill_string) const
+{
+	for (auto &provider : execution_time_estimators_) {
+		if (provider->can_execute(skill_string)) {
+			return provider;
+		}
+	}
+	throw Exception(
+	  std::string("No known execution time estimator for skill '" + skill_string + "'").c_str());
+}
+
+/** Add a running time provider.
+ * @param provider The provider to add
+ */
+void
+ExecutionTimeEstimatorManager::register_provider(std::shared_ptr<ExecutionTimeEstimator> provider)
+{
+	execution_time_estimators_.push_back(provider);
+}
+
+/** @class ExecutionTimeEstimatorsAspect
+ * An aspect to give access to the skiller simulator's running time providers.
+ * Use this aspect to add a running time provider.
+ *
+ * @var ExecutionTimeEstimatorsAspect::execution_time_estimator_manager_
+ * The ExecutionTimeEstimatorManager that is used to manage the estimators.
+ * @see ExecutionTimeEstimatorManager
+ */
+
+/** Constructor. */
+ExecutionTimeEstimatorsAspect::ExecutionTimeEstimatorsAspect()
+: execution_time_estimator_manager_(nullptr)
+{
+	add_aspect("SkillExecutionTimeEstimatorAspect");
+}
+
+/** Initialize the aspect with a provider manager.
+ * @param provider_manager The manager of the running time providers
+ */
+void
+ExecutionTimeEstimatorsAspect::init_ExecutionTimeEstimatorsAspect(
+  ExecutionTimeEstimatorManager *provider_manager)
+{
+	execution_time_estimator_manager_ = provider_manager;
+}
+
+/** Finalize the aspect. */
+void
+ExecutionTimeEstimatorsAspect::finalize_ExecutionTimeEstimatorsAspect()
+{
+}
+
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.cpp
@@ -31,18 +31,18 @@ namespace skiller_simulator {
 
 /** Get the running time provider for the given skill string.
  * @param skill_string The string to get the running time for
- * @return a pointer to the provider
+ * @return an optional with a pointer to the provider, an optional without a
+ * value if no provider exists
  */
-std::shared_ptr<ExecutionTimeEstimator>
+std::optional<std::shared_ptr<ExecutionTimeEstimator>>
 ExecutionTimeEstimatorManager::get_provider(const std::string &skill_string) const
 {
 	for (auto &provider : execution_time_estimators_) {
 		if (provider->can_execute(skill_string)) {
-			return provider;
+			return std::make_optional<std::shared_ptr<ExecutionTimeEstimator>>(provider);
 		}
 	}
-	throw Exception(
-	  std::string("No known execution time estimator for skill '" + skill_string + "'").c_str());
+	return std::optional<std::shared_ptr<ExecutionTimeEstimator>>();
 }
 
 /** Add a running time provider.

--- a/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *  execution_time_estimator_aspect.h - Aspect for a running time provider
+ *
+ *  Created: Thu 12 Dec 2019 14:52:41 CET 14:52
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include "../execution_time_estimator.h"
+
+#include <aspect/aspect.h>
+
+#include <memory>
+#include <vector>
+
+namespace fawkes {
+namespace skiller_simulator {
+
+class ExecutionTimeEstimatorManager
+{
+public:
+	std::shared_ptr<ExecutionTimeEstimator> get_provider(const std::string &skill_string) const;
+	void register_provider(std::shared_ptr<ExecutionTimeEstimator> provider);
+
+private:
+	std::vector<std::shared_ptr<ExecutionTimeEstimator>> execution_time_estimators_;
+};
+
+class ExecutionTimeEstimatorsAspect : public virtual Aspect
+{
+public:
+	ExecutionTimeEstimatorsAspect();
+	void init_ExecutionTimeEstimatorsAspect(ExecutionTimeEstimatorManager *provider_manager);
+	void finalize_ExecutionTimeEstimatorsAspect();
+
+protected:
+	ExecutionTimeEstimatorManager *execution_time_estimator_manager_;
+};
+
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect.h
@@ -25,6 +25,7 @@
 #include <aspect/aspect.h>
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace fawkes {
@@ -33,7 +34,8 @@ namespace skiller_simulator {
 class ExecutionTimeEstimatorManager
 {
 public:
-	std::shared_ptr<ExecutionTimeEstimator> get_provider(const std::string &skill_string) const;
+	std::optional<std::shared_ptr<ExecutionTimeEstimator>>
+	     get_provider(const std::string &skill_string) const;
 	void register_provider(std::shared_ptr<ExecutionTimeEstimator> provider);
 
 private:

--- a/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.cpp
@@ -1,0 +1,75 @@
+/***************************************************************************
+ *  execution_time_estimator_aspect_inifin.cpp - Aspect IniFin
+ *
+ *  Created: Thu 12 Dec 2019 19:59:57 CET 19:59
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "execution_time_estimator_aspect_inifin.h"
+
+namespace fawkes {
+namespace skiller_simulator {
+
+/** @class ExecutionTimeEstimatorsAspectIniFin
+ * The Aspect IniFin for the ExecutionTimeEstimatorsAspect.
+ */
+
+/** Constructor. */
+ExecutionTimeEstimatorsAspectIniFin::ExecutionTimeEstimatorsAspectIniFin()
+: AspectIniFin("SkillExecutionTimeEstimatorAspect")
+{
+	execution_time_estimator_manager_ = new ExecutionTimeEstimatorManager();
+}
+
+/** Destructor. */
+ExecutionTimeEstimatorsAspectIniFin::~ExecutionTimeEstimatorsAspectIniFin()
+{
+	delete execution_time_estimator_manager_;
+}
+
+ExecutionTimeEstimatorsAspect *
+ExecutionTimeEstimatorsAspectIniFin::get_aspect(Thread *thread) const
+{
+	ExecutionTimeEstimatorsAspect *exec_thread =
+	  dynamic_cast<ExecutionTimeEstimatorsAspect *>(thread);
+	if (!exec_thread) {
+		throw CannotInitializeThreadException(
+		  "Thread '%s' claims to have the SkillExecutionTimeEstimatorAspect, but RRTI says it has not.",
+		  thread->name());
+	}
+	return exec_thread;
+}
+
+/** Initialize the thread with the aspect.
+ * @param thread The thread to initialize.
+ */
+void
+ExecutionTimeEstimatorsAspectIniFin::init(Thread *thread)
+{
+	get_aspect(thread)->init_ExecutionTimeEstimatorsAspect(execution_time_estimator_manager_);
+}
+
+/** Finalize the aspect of the given thread.
+ * @param thread The thread to finalize.
+ */
+void
+ExecutionTimeEstimatorsAspectIniFin::finalize(Thread *thread)
+{
+	get_aspect(thread)->finalize_ExecutionTimeEstimatorsAspect();
+}
+
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.cpp
+++ b/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.cpp
@@ -27,17 +27,18 @@ namespace skiller_simulator {
  * The Aspect IniFin for the ExecutionTimeEstimatorsAspect.
  */
 
-/** Constructor. */
-ExecutionTimeEstimatorsAspectIniFin::ExecutionTimeEstimatorsAspectIniFin()
+/** Constructor.
+ * @param manager The manager for the time estimators to use in the aspect */
+ExecutionTimeEstimatorsAspectIniFin::ExecutionTimeEstimatorsAspectIniFin(
+  ExecutionTimeEstimatorManager *manager)
 : AspectIniFin("SkillExecutionTimeEstimatorAspect")
 {
-	execution_time_estimator_manager_ = new ExecutionTimeEstimatorManager();
+	execution_time_estimator_manager_ = manager;
 }
 
 /** Destructor. */
 ExecutionTimeEstimatorsAspectIniFin::~ExecutionTimeEstimatorsAspectIniFin()
 {
-	delete execution_time_estimator_manager_;
 }
 
 ExecutionTimeEstimatorsAspect *

--- a/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+ *  execution_time_estimator_aspect_inifin.h - Aspect INiFin
+ *
+ *  Created: Thu 12 Dec 2019 19:00:07 CET 19:00
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include "execution_time_estimator_aspect.h"
+
+#include <aspect/aspect.h>
+#include <aspect/inifins/inifin.h>
+
+namespace fawkes {
+namespace skiller_simulator {
+class ExecutionTimeEstimatorsAspectIniFin : public virtual AspectIniFin
+{
+public:
+	ExecutionTimeEstimatorsAspectIniFin();
+	virtual ~ExecutionTimeEstimatorsAspectIniFin();
+	virtual void init(Thread *thread);
+	virtual void finalize(Thread *thread);
+
+private:
+	ExecutionTimeEstimatorsAspect *get_aspect(Thread *thread) const;
+	ExecutionTimeEstimatorManager *execution_time_estimator_manager_;
+};
+
+} // namespace skiller_simulator
+} // namespace fawkes

--- a/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.h
+++ b/src/plugins/skiller-simulator/execution_time_estimator_aspect/execution_time_estimator_aspect_inifin.h
@@ -30,7 +30,7 @@ namespace skiller_simulator {
 class ExecutionTimeEstimatorsAspectIniFin : public virtual AspectIniFin
 {
 public:
-	ExecutionTimeEstimatorsAspectIniFin();
+	ExecutionTimeEstimatorsAspectIniFin(ExecutionTimeEstimatorManager *manager);
 	virtual ~ExecutionTimeEstimatorsAspectIniFin();
 	virtual void init(Thread *thread);
 	virtual void finalize(Thread *thread);

--- a/src/plugins/skiller-simulator/tests/Makefile
+++ b/src/plugins/skiller-simulator/tests/Makefile
@@ -22,17 +22,23 @@ OBJS_gtest_skiller_simulator_skill_parser = test_skill_parser.o
 OBJS_all = $(OBJS_gtest_skiller_simulator_skill_parser)
 BINS_all = $(BINDIR)/gtest_skiller_simulator_skill_parser
 
-ifeq ($(HAVE_GTEST),1)
-  CFLAGS += $(CFLAGS_GTEST)
-  LDFLAGS += $(LDFLAGS_GTEST)
-  BINS_test = $(BINS_all)
+ifeq ($(HAVE_CPP17),1)
+  ifeq ($(HAVE_GTEST),1)
+    CFLAGS += $(CFLAGS_GTEST)
+    LDFLAGS += $(LDFLAGS_GTEST)
+    BINS_test = $(BINS_all)
+  else
+    WARN_TARGETS += warn_gtest
+  endif
 else
-  WARN_TARGETS += warn_gtest
+  WARN_TARGETS += warning_cpp17
 endif
 
 ifeq ($(OBJSSUBMAKE),1)
 test: $(WARN_TARGETS)
 .PHONY: $(WARN_TARGETS)
+warning_cpp17:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting skiller simulator tests$(TNORMAL) (C++17 not supported)"
 warning_gtest:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build skiller simulator tests$(TNORMAL) (gtest not found)"
 endif

--- a/src/plugins/skiller-simulator/tests/Makefile
+++ b/src/plugins/skiller-simulator/tests/Makefile
@@ -1,0 +1,40 @@
+#*****************************************************************************
+#                      Makefile Build System for Fawkes
+#                            -------------------
+#   Created on Sun 22 Dec 2019 19:38:06 CET
+#   Copyright (C) 2019 by Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+BASEDIR = ../../../..
+include $(BASEDIR)/etc/buildsys/config.mk
+include $(BASEDIR)/etc/buildsys/gtest.mk
+
+LIBS_gtest_skiller_simulator_skill_parser = fawkes_skiller_time_estimator
+OBJS_gtest_skiller_simulator_skill_parser = test_skill_parser.o
+OBJS_all = $(OBJS_gtest_skiller_simulator_skill_parser)
+BINS_all = $(BINDIR)/gtest_skiller_simulator_skill_parser
+
+ifeq ($(HAVE_GTEST),1)
+  CFLAGS += $(CFLAGS_GTEST)
+  LDFLAGS += $(LDFLAGS_GTEST)
+  BINS_test = $(BINS_all)
+else
+  WARN_TARGETS += warn_gtest
+endif
+
+ifeq ($(OBJSSUBMAKE),1)
+test: $(WARN_TARGETS)
+.PHONY: $(WARN_TARGETS)
+warning_gtest:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Cannot build skiller simulator tests$(TNORMAL) (gtest not found)"
+endif
+
+include $(BUILDSYSDIR)/base.mk

--- a/src/plugins/skiller-simulator/tests/Makefile
+++ b/src/plugins/skiller-simulator/tests/Makefile
@@ -17,7 +17,7 @@ BASEDIR = ../../../..
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/etc/buildsys/gtest.mk
 
-LIBS_gtest_skiller_simulator_skill_parser = fawkes_skiller_time_estimator
+LIBS_gtest_skiller_simulator_skill_parser = m fawkes_skiller_time_estimator
 OBJS_gtest_skiller_simulator_skill_parser = test_skill_parser.o
 OBJS_all = $(OBJS_gtest_skiller_simulator_skill_parser)
 BINS_all = $(BINDIR)/gtest_skiller_simulator_skill_parser

--- a/src/plugins/skiller-simulator/tests/test_skill_parser.cpp
+++ b/src/plugins/skiller-simulator/tests/test_skill_parser.cpp
@@ -1,0 +1,68 @@
+/***************************************************************************
+ *  test_skill_parser.cpp - Tests for ExecutionTimeEstimator::Skill
+ *
+ *  Created: Sun 22 Dec 2019 19:23:47 CET 19:23
+ *  Copyright  2019  Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "../execution_time_estimator.h"
+
+#include <gtest/gtest.h>
+
+using Skill = fawkes::skiller_simulator::ExecutionTimeEstimator::Skill;
+
+TEST(SkillParserTest, EmptySkill)
+{
+	Skill s{""};
+	ASSERT_EQ(s.skill_name, "");
+	ASSERT_EQ(s.skill_args.size(), 0);
+}
+
+TEST(SkillParserTest, SkillWithoutArgs)
+{
+	Skill s{"say()"};
+	ASSERT_EQ(s.skill_name, "say");
+	ASSERT_EQ(s.skill_args.size(), 0);
+}
+
+TEST(SkillParserTest, SkillWithIntArg)
+{
+	Skill s{"count{i=1}"};
+	ASSERT_EQ(s.skill_name, "count");
+	ASSERT_EQ(s.skill_args.size(), 1);
+	ASSERT_EQ(s.skill_args["i"], "1");
+}
+
+TEST(SkillParserTest, SkillWithStringArg)
+{
+	Skill s("say{text='hello'}");
+	ASSERT_EQ(s.skill_name, "say");
+	ASSERT_EQ(s.skill_args.size(), 1);
+	ASSERT_EQ(s.skill_args["text"], "hello");
+	s = Skill("say{text=\"hello\"}");
+	ASSERT_EQ(s.skill_name, "say");
+	ASSERT_EQ(s.skill_args.size(), 1);
+	ASSERT_EQ(s.skill_args["text"], "hello");
+}
+
+TEST(SkillParserTest, SkillWithMultipleArgs)
+{
+	Skill s("say{text='hello', second='bye'}");
+	ASSERT_EQ(s.skill_name, "say");
+	ASSERT_EQ(s.skill_args.size(), 2);
+	ASSERT_EQ(s.skill_args["text"], "hello");
+	ASSERT_EQ(s.skill_args["second"], "bye");
+}

--- a/src/plugins/skiller-simulator/tests/test_skill_parser.cpp
+++ b/src/plugins/skiller-simulator/tests/test_skill_parser.cpp
@@ -66,3 +66,11 @@ TEST(SkillParserTest, SkillWithMultipleArgs)
 	ASSERT_EQ(s.skill_args["text"], "hello");
 	ASSERT_EQ(s.skill_args["second"], "bye");
 }
+
+TEST(SkillParserTest, SkillWithNewline)
+{
+	Skill s("say{text=\n\"hello\"}");
+	ASSERT_EQ(s.skill_name, "say");
+	ASSERT_EQ(s.skill_args.size(), 1);
+	ASSERT_EQ(s.skill_args["text"], "hello");
+}


### PR DESCRIPTION
Enhance the skiller simulator with estimated skill execution times. The skills will no longer always execute exactly for 1 second, but instead compute an estimate and run the skill for that estimated time.

To estimate the execution time of a skill, the skiller simulator has a set of estimators:
* Each estimator has a function `can_execute` that returns true if the estimator can give an estimate for the given skill
* It also has a function `get_execution_time` that actually computes the estimated execution time
* Third, it has a function `execute` that is called when the skill has finished executing. This is used to apply possible side effects (e..g, after a `goto`, save the new position)

An estimator can be added by adding the `ExecutionTimeEstimatorsAspect` and calling `register_provder` on the manager that is part of the aspect. This way, we can define additional estimators in separate plugins (as is done with the navgraph estimator).

Also add two estimators:
* The ConfigEstimator simply reads the estimated execution time from the config
* The NavGraphEstimator estimates the execution time for a `goto` by querying the navgraph for the distance between the current position and the target node.

The NavGraphEstimator saves the new position with the `execute` mechanism described above. It only gives a rough estimate, as it simply uses the euclidean distance as estimate for the execution time.