### PR TITLE
Add support for the testing framework catch2

### DIFF
--- a/etc/buildsys/catch2.mk
+++ b/etc/buildsys/catch2.mk
@@ -1,0 +1,32 @@
+#*****************************************************************************
+#                      Makefile Build System for Fawkes
+#                            -------------------
+#   Created on Mon 10 Feb 2020 13:50:59 CET
+#   Copyright (C) 2020 by Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+ifndef __buildsys_config_mk_
+$(error config.mk must be included before catch.mk)
+endif
+
+ifndef __buildsys_catch2_mk_
+__buildsys_catch2_mk_ := 1
+
+ifneq ($(PKGCONFIG),1)
+  HAVE_CATCH2 = $(if $(shell $(PKGCONFIG) --exists 'catch2'; echo $${?/1/}),1,0)
+endif
+
+ifeq ($(HAVE_CATCH2),1)
+  CFLAGS_CATCH2 = $(shell $(PKGCONFIG) --cflags 'catch2')
+  LDFLAGS_CATCH2 = $(shell $(PKGCONFIG) --libs 'catch2')
+endif
+
+endif # __buildsys_catch2_mk_

--- a/etc/buildsys/rules.mk
+++ b/etc/buildsys/rules.mk
@@ -99,6 +99,8 @@ UNLISTED_libs = $(strip $(filter-out $(LIBS_all:%.so=%.$(SOEXT)),$(LIBS_build:%.
 UNLISTED_plugins = $(strip $(filter-out $(PLUGINS_all:%.so=%.$(SOEXT)),$(PLUGINS_build:%.so=%.$(SOEXT))))
 UNLISTED_all = $(strip $(UNLISTED_bins) $(UNLISTED_libs) $(UNLISTED_plugins))
 
+BINS_test = $(BINS_gtest) $(BINS_catch2test)
+
 all: $(if $(UNLISTED_all),error_unlisted,presubdirs $(PLUGINS_build:%.so=%.$(SOEXT)) $(LIBS_build:%.so=%.$(SOEXT)) $(BINS_build) $(MANPAGES_all) $(TARGETS_all) $(EXTRA_ALL) stats subdirs | silent-nothing-to-do-all)
 gui: $(if $(UNLISTED_all),error_unlisted,presubdirs $(LIBS_gui:%.so=%.$(SOEXT)) $(PLUGINS_gui:%.so=%.$(SOEXT)) $(BINS_gui) $(MANPAGES_gui) $(TARGETS_gui) stats-gui subdirs | silent-nothing-to-do-gui)
 test: $(if $(UNLISTED_all),error_unlisted,presubdirs $(LIBS_test:%.so=%.$(SOEXT)) $(PLUGINS_test:%.so=%.$(SOEXT)) $(BINS_test) $(TARGETS_test) exec_test stats-test subdirs | silent-nothing-to-do-test)

--- a/etc/buildsys/rules.mk
+++ b/etc/buildsys/rules.mk
@@ -284,6 +284,10 @@ exec_gtest_%: $(BINDIR)/gtest_%
 	$(SILENT)exec $(BINDIR)/gtest_$* --gtest_color=yes | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0
 
+exec_test_%: $(BINDIR)/test_%
+	$(SILENT)exec $(BINDIR)/test_$* | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
+		test $${PIPESTATUS[0]} -eq 0
+
 exec_gdb_gtest_%: $(BINDIR)/gtest_%
 	$(eval BUILT_PARTS += $@)
 	$(SILENT)echo -e "$(INDENT_PRINT)[TEST-GDB] $(BINDIR)/gtest_$*"

--- a/etc/buildsys/rules.mk
+++ b/etc/buildsys/rules.mk
@@ -276,26 +276,22 @@ $(foreach MS,$(MANPAGE_SECTIONS),$(MANDIR)/man$(MS)/%.$(MS)): %.txt
 		echo -e "$(INDENT_PRINT)=== $(TYELLOW)Cannot generate man page for $* (asciidoc not installed)$(TNORMAL)"; \
 	fi
 
-# execute every test in $(BINS_test)
+# execute every test
 exec_test: $(patsubst $(BINDIR)/%,exec_gtest_%,$(BINS_gtest)) $(patsubst $(BINDIR)/%,exec_catch2test_%,$(BINS_catch2test))
 
-# execution of a single test.
+# execute a single gtest
 exec_gtest_%: $(BINDIR)/%
 	$(eval BUILT_PARTS += $@)
 	$(SILENT)echo -e "$(INDENT_PRINT)[TEST] Running gtest $(BINDIR)/$*"
 	$(SILENT)exec $(BINDIR)/$* --gtest_color=$(if $(COLORED),yes,no) | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0
 
+# execute a single catch2test
 exec_catch2test_%: $(BINDIR)/%
 	$(eval BUILT_PARTS += $@)
 	$(SILENT)echo -e "$(INDENT_PRINT)[TEST] Running catch2 test $(BINDIR)/$*"
 	$(SILENT)exec $(BINDIR)/$* --use-colour $(if $(COLORED),yes,no) | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0
-
-exec_gdb_gtest_%: $(BINDIR)/gtest_%
-	$(eval BUILT_PARTS += $@)
-	$(SILENT)echo -e "$(INDENT_PRINT)[TEST-GDB] $(BINDIR)/gtest_$*"
-	$(SILENT)exec gdb $(BINDIR)/gtest_$*
 
 .SECONDEXPANSION:
 $(BINDIR)/%: $$(OBJS_$$(call nametr,$$*))

--- a/etc/buildsys/rules.mk
+++ b/etc/buildsys/rules.mk
@@ -281,11 +281,11 @@ exec_test: $(patsubst $(BINDIR)/%,exec_%,$(BINS_test))
 exec_gtest_%: $(BINDIR)/gtest_%
 	$(eval BUILT_PARTS += $@)
 	$(SILENT)echo -e "$(INDENT_PRINT)[TEST] $(BINDIR)/gtest_$*"
-	$(SILENT)exec $(BINDIR)/gtest_$* --gtest_color=yes | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
+	$(SILENT)exec $(BINDIR)/gtest_$* --gtest_color=$(if $(COLORED),yes,no) | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0
 
 exec_c2test_%: $(BINDIR)/c2test_%
-	$(SILENT)exec $(BINDIR)/test_$* --use-colour yes | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
+	$(SILENT)exec $(BINDIR)/test_$* --use-colour $(if $(COLORED),yes,no) | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0
 
 exec_test_%: $(BINDIR)/test_%

--- a/etc/buildsys/rules.mk
+++ b/etc/buildsys/rules.mk
@@ -284,6 +284,10 @@ exec_gtest_%: $(BINDIR)/gtest_%
 	$(SILENT)exec $(BINDIR)/gtest_$* --gtest_color=yes | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0
 
+exec_c2test_%: $(BINDIR)/c2test_%
+	$(SILENT)exec $(BINDIR)/test_$* --use-colour yes | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
+		test $${PIPESTATUS[0]} -eq 0
+
 exec_test_%: $(BINDIR)/test_%
 	$(SILENT)exec $(BINDIR)/test_$* | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0

--- a/etc/buildsys/rules.mk
+++ b/etc/buildsys/rules.mk
@@ -275,21 +275,19 @@ $(foreach MS,$(MANPAGE_SECTIONS),$(MANDIR)/man$(MS)/%.$(MS)): %.txt
 	fi
 
 # execute every test in $(BINS_test)
-exec_test: $(patsubst $(BINDIR)/%,exec_%,$(BINS_test))
+exec_test: $(patsubst $(BINDIR)/%,exec_gtest_%,$(BINS_gtest)) $(patsubst $(BINDIR)/%,exec_catch2test_%,$(BINS_catch2test))
 
 # execution of a single test.
-exec_gtest_%: $(BINDIR)/gtest_%
+exec_gtest_%: $(BINDIR)/%
 	$(eval BUILT_PARTS += $@)
-	$(SILENT)echo -e "$(INDENT_PRINT)[TEST] $(BINDIR)/gtest_$*"
-	$(SILENT)exec $(BINDIR)/gtest_$* --gtest_color=$(if $(COLORED),yes,no) | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
+	$(SILENT)echo -e "$(INDENT_PRINT)[TEST] Running gtest $(BINDIR)/$*"
+	$(SILENT)exec $(BINDIR)/$* --gtest_color=$(if $(COLORED),yes,no) | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0
 
-exec_c2test_%: $(BINDIR)/c2test_%
-	$(SILENT)exec $(BINDIR)/test_$* --use-colour $(if $(COLORED),yes,no) | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
-		test $${PIPESTATUS[0]} -eq 0
-
-exec_test_%: $(BINDIR)/test_%
-	$(SILENT)exec $(BINDIR)/test_$* | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
+exec_catch2test_%: $(BINDIR)/%
+	$(eval BUILT_PARTS += $@)
+	$(SILENT)echo -e "$(INDENT_PRINT)[TEST] Running catch2 test $(BINDIR)/$*"
+	$(SILENT)exec $(BINDIR)/$* --use-colour $(if $(COLORED),yes,no) | sed 's/^/$(INDENT_PRINT)[TEST] /'; \
 		test $${PIPESTATUS[0]} -eq 0
 
 exec_gdb_gtest_%: $(BINDIR)/gtest_%

--- a/src/libs/core/tests/Makefile
+++ b/src/libs/core/tests/Makefile
@@ -47,9 +47,6 @@ else
   WARN_TARGETS += warning_gtest
 endif
 
-BINS_test = $(BINS_gtest) $(BINS_catch2test)
-BINS_all = $(BINS_test)
-
 ifeq ($(OBJSSUBMAKE),1)
 test: $(WARN_TARGETS)
 

--- a/src/libs/core/tests/Makefile
+++ b/src/libs/core/tests/Makefile
@@ -18,7 +18,7 @@ include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/etc/buildsys/gtest.mk
 include $(BASEDIR)/etc/buildsys/catch2.mk
 
-LIBS_test_circular_buffer += stdc++ fawkescore fawkesutils
+LIBS_test_circular_buffer += stdc++ fawkescore m
 OBJS_test_circular_buffer += test_circular_buffer.o
 
 LIBS_test_wait_condition += stdc++ fawkescore pthread

--- a/src/libs/core/tests/Makefile
+++ b/src/libs/core/tests/Makefile
@@ -21,32 +21,33 @@ include $(BASEDIR)/etc/buildsys/catch2.mk
 LIBS_test_circular_buffer += stdc++ fawkescore fawkesutils
 OBJS_test_circular_buffer += test_circular_buffer.o
 
-LIBS_gtest_wait_condition += stdc++ fawkescore pthread
-OBJS_gtest_wait_condition += test_wait_condition.o
+LIBS_test_wait_condition += stdc++ fawkescore pthread
+OBJS_test_wait_condition += test_wait_condition.o
 
-OBJS_all    = $(OBJS_test_circular_buffer) $(OBJS_gtest_wait_condition)
+OBJS_all    = $(OBJS_test_circular_buffer) $(OBJS_test_wait_condition)
 
 ifeq ($(HAVE_CATCH2),1)
   CFLAGS_test_circular_buffer += $(CFLAGS_CATCH2)
   LDFLAGS_test_circular_buffer += $(LDFLAGS_CATCH2)
-  BINS_test += $(BINDIR)/test_circular_buffer
+  BINS_catch2test += $(BINDIR)/test_circular_buffer
 else
   WARN_TARGETS += warning_catch2
 endif
 
 ifeq ($(HAVE_GTEST),1)
-  CFLAGS_gtest_wait_condition += $(CFLAGS_GTEST)
-  LDFLAGS_gtest_wait_condition += $(LDFLAGS_GTEST)
+  CFLAGS_test_wait_condition += $(CFLAGS_GTEST)
+  LDFLAGS_test_wait_condition += $(LDFLAGS_GTEST)
   ifeq ($(CC),clang)
-    CFLAGS_gtest_wait_condition += -Wno-unused-variable
+    CFLAGS_test_wait_condition += -Wno-unused-variable
   else
-    CFLAGS_gtest_wait_condition += -Wno-unused-but-set-variable
+    CFLAGS_test_wait_condition += -Wno-unused-but-set-variable
   endif
-  BINS_test += $(BINDIR)/gtest_wait_condition
+  BINS_gtest += $(BINDIR)/test_wait_condition
 else
   WARN_TARGETS += warning_gtest
 endif
 
+BINS_test = $(BINS_gtest) $(BINS_catch2test)
 BINS_all = $(BINS_test)
 
 ifeq ($(OBJSSUBMAKE),1)

--- a/src/libs/core/tests/Makefile
+++ b/src/libs/core/tests/Makefile
@@ -16,40 +16,47 @@
 BASEDIR = ../../../..
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/etc/buildsys/gtest.mk
+include $(BASEDIR)/etc/buildsys/catch2.mk
 
-LIBS_gtest_circular_buffer += stdc++ fawkescore fawkesutils
-OBJS_gtest_circular_buffer += test_circular_buffer.o
+LIBS_test_circular_buffer += stdc++ fawkescore fawkesutils
+OBJS_test_circular_buffer += test_circular_buffer.o
 
 LIBS_gtest_wait_condition += stdc++ fawkescore pthread
 OBJS_gtest_wait_condition += test_wait_condition.o
 
-OBJS_all    = $(OBJS_gtest_circular_buffer) $(OBJS_gtest_wait_condition)
+OBJS_all    = $(OBJS_test_circular_buffer) $(OBJS_gtest_wait_condition)
+
+ifeq ($(HAVE_CATCH2),1)
+  CFLAGS_test_circular_buffer += $(CFLAGS_CATCH2)
+  LDFLAGS_test_circular_buffer += $(LDFLAGS_CATCH2)
+  BINS_test += $(BINDIR)/test_circular_buffer
+else
+  WARN_TARGETS += warning_catch2
+endif
 
 ifeq ($(HAVE_GTEST),1)
-  CFLAGS += $(CFLAGS_GTEST)
+  CFLAGS_gtest_wait_condition += $(CFLAGS_GTEST)
+  LDFLAGS_gtest_wait_condition += $(LDFLAGS_GTEST)
   ifeq ($(CC),clang)
-    CFLAGS += -Wno-unused-variable
+    CFLAGS_gtest_wait_condition += -Wno-unused-variable
   else
-    CFLAGS += -Wno-unused-but-set-variable
+    CFLAGS_gtest_wait_condition += -Wno-unused-but-set-variable
   endif
-  LDFLAGS += $(LDFLAGS_GTEST)
-  LIBS_test = $(LIBDIR)/test/circular_buffer.so \
-              $(LIBDIR)/test/wait_condition.so
-  BINS_test = $(BINDIR)/gtest_circular_buffer \
-              $(BINDIR)/gtest_wait_condition
-  LIBS_all = $(LIBS_test)
-  BINS_all = $(BINS_test)
+  BINS_test += $(BINDIR)/gtest_wait_condition
 else
   WARN_TARGETS += warning_gtest
 endif
 
+BINS_all = $(BINS_test)
+
 ifeq ($(OBJSSUBMAKE),1)
 test: $(WARN_TARGETS)
 
-.PHONY: warning_gtest
+.PHONY: $(WARN_TARGETS)
 warning_gtest:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting unit tests for CircularBuffer and WaitCondition$(TNORMAL) (gtest not available)"
-
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting unit tests for WaitCondition$(TNORMAL) (gtest not available)"
+warning_catch2:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting unit tests for CircularBuffer$(TNORMAL) (catch2 not available)"
 endif
 
 include $(BUILDSYSDIR)/base.mk

--- a/src/libs/core/tests/test_circular_buffer.cpp
+++ b/src/libs/core/tests/test_circular_buffer.cpp
@@ -19,71 +19,64 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
+#define CATCH_CONFIG_MAIN
 #include <core/utils/circular_buffer.h>
-#include <gtest/gtest.h>
 
+#include <catch2/catch.hpp>
 #include <stdexcept>
 
 using namespace fawkes;
 
-TEST(CircularBufferTest, ElementAccess)
+TEST_CASE("Access elements", "[circular_buffer]")
 {
 	CircularBuffer<int> buffer(1000);
 	for (int i = 0; i < 1000; i++) {
 		buffer.push_back(i);
 	}
 	for (int i = 0; i < 1000; i++) {
-		ASSERT_EQ(i, buffer[i]);
-		ASSERT_EQ(i, buffer.at(i));
+		REQUIRE(buffer[i] == i);
+		REQUIRE(buffer.at(i) == i);
 	}
 }
 
-TEST(CircularBufferTest, ElementDeletion)
+TEST_CASE("Delete elements", "[circular_buffer]")
 {
 	CircularBuffer<int> buffer(1);
 	buffer.push_back(1);
 	buffer.push_back(2);
-	ASSERT_EQ(1, buffer.size());
-	ASSERT_EQ(2, buffer[0]);
+	REQUIRE(buffer.size() == 1);
+	REQUIRE(buffer[0] == 2);
 }
 
-TEST(CircularBufferTest, OutOfMaxRange)
+TEST_CASE("Out of max range", "[circular_buffer]")
 {
 	CircularBuffer<int> buffer(1);
 	int                 i;
-	ASSERT_NO_THROW(i = buffer[1]);
-	ASSERT_THROW(i = buffer.at(1), std::out_of_range);
+	CHECK_NOTHROW(i = buffer[1]);
+	REQUIRE_THROWS_AS(i = buffer.at(1), std::out_of_range);
 }
 
-TEST(CircularBufferTest, OutOfRange)
+TEST_CASE("Out of range", "[circular_buffer]")
 {
 	CircularBuffer<int> buffer(2);
 	buffer.push_back(1);
 	int i;
-	ASSERT_NO_THROW(i = buffer[1]);
-	ASSERT_THROW(i = buffer.at(1), std::out_of_range);
+	REQUIRE_NOTHROW(i = buffer[1]);
+	REQUIRE_THROWS_AS(i = buffer.at(1), std::out_of_range);
 }
 
-TEST(CircularBufferTest, ConstValues)
-{
-	CircularBuffer<int> buffer(5);
-	// buffer[0] = 2; // won't compile
-	CircularBuffer<int>::iterator it = buffer.begin();
-	// *it = 2; // won't compile
-}
-
-TEST(CircularBufferTest, CopyConstructor)
+TEST_CASE("Copy constructor", "[circular_buffer]")
 {
 	CircularBuffer<int> b1(5);
 	b1.push_back(1);
 	b1.push_back(2);
 	CircularBuffer<int> b2(b1);
-	ASSERT_EQ(5, b2.get_max_size());
-	ASSERT_EQ(1, b2[0]);
-	ASSERT_EQ(2, b2[1]);
+	REQUIRE(b2.get_max_size() == 5);
+	REQUIRE(b2[0] == 1);
+	REQUIRE(b2[1] == 2);
 	b2.push_back(3);
-	ASSERT_EQ(3, b2[2]);
-	ASSERT_EQ(1, b1[0]);
-	ASSERT_EQ(2, b1[1]);
-	ASSERT_THROW(b1.at(2), std::out_of_range);
+	REQUIRE(b2[2] == 3);
+	REQUIRE(b1[0] == 1);
+	REQUIRE(b1[1] == 2);
+	REQUIRE_THROWS_AS(b1.at(2), std::out_of_range);
 }

--- a/src/libs/kdl_parser/tests/Makefile
+++ b/src/libs/kdl_parser/tests/Makefile
@@ -28,7 +28,4 @@ ifeq ($(HAVE_GTEST)$(HAVE_KDLPARSER),11)
   BINS_gtest = $(BINDIR)/test_kdlparser
 endif
 
-BINS_test = $(BINS_gtest)
-BINS_all = $(BINDIR)/test_kdlparser
-
 include $(BUILDSYSDIR)/base.mk

--- a/src/libs/kdl_parser/tests/Makefile
+++ b/src/libs/kdl_parser/tests/Makefile
@@ -18,15 +18,17 @@ include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/etc/buildsys/gtest.mk
 include $(BASEDIR)/src/libs/kdl_parser/kdl_parser.mk
 
-LIBS_gtest_kdlparser += stdc++ fawkeskdl_parser
+LIBS_test_kdlparser += stdc++ fawkeskdl_parser
 
-OBJS_gtest_kdlparser += test_kdlparser.o
-OBJS_all = $(OBJS_gtest_kdlparser)
-BINS_all = $(BINDIR)/gtest_kdlparser
-ifeq ($(HAVE_KDLPARSER),1)
+OBJS_test_kdlparser += test_kdlparser.o
+OBJS_all = $(OBJS_test_kdlparser)
+ifeq ($(HAVE_GTEST)$(HAVE_KDLPARSER),11)
   CFLAGS  += $(CFLAGS_KDLPARSER)  $(CFLAGS_GTEST)
   LDFLAGS += $(LDFLAGS_KDLPARSER) $(LDFLAGS_GTEST)
-  BINS_test = $(BINS_all)
+  BINS_gtest = $(BINDIR)/test_kdlparser
 endif
+
+BINS_test = $(BINS_gtest)
+BINS_all = $(BINDIR)/test_kdlparser
 
 include $(BUILDSYSDIR)/base.mk

--- a/src/libs/syncpoint/tests/Makefile
+++ b/src/libs/syncpoint/tests/Makefile
@@ -17,13 +17,11 @@ BASEDIR = ../../../..
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/etc/buildsys/gtest.mk
 
-LIBS_gtest_syncpoint += stdc++ fawkescore fawkesutils fawkessyncpoint pthread \
+LIBS_test_syncpoint += stdc++ fawkescore fawkesutils fawkessyncpoint pthread \
                         fawkeslogging
 
-OBJS_gtest_syncpoint += test_syncpoint.o
-OBJS_all = $(OBJS_gtest_syncpoint)
-LIBS_all = $(LIBDIR)/test/syncpoint.so
-BINS_all = $(BINDIR)/gtest_syncpoint
+OBJS_test_syncpoint += test_syncpoint.o
+OBJS_all = $(OBJS_test_syncpoint)
 
 CFLAGS += -Wno-unused-variable
 ifneq ($(CC),clang)
@@ -33,8 +31,7 @@ endif
 ifeq ($(HAVE_GTEST)$(HAVE_CPP11),11)
   CFLAGS += $(CFLAGS_GTEST) $(CFLAGS_CPP11)
   LDFLAGS += $(LDFLAGS_GTEST)
-  LIBS_test = $(LIBS_all)
-  BINS_test = $(BINS_all)
+  BINS_gtest = $(BINDIR)/test_syncpoint
 else
   ifneq ($(HAVE_GTEST),1)
     WARN_TARGETS += warning_gtest
@@ -43,6 +40,9 @@ else
     WARN_TARGETS += warning_cpp11
   endif
 endif
+
+BINS_test = $(BINS_gtest)
+BINS_all = $(BINS_test)
 
 ifeq ($(OBJSSUBMAKE),1)
 test: $(WARN_TARGETS)

--- a/src/libs/syncpoint/tests/Makefile
+++ b/src/libs/syncpoint/tests/Makefile
@@ -41,9 +41,6 @@ else
   endif
 endif
 
-BINS_test = $(BINS_gtest)
-BINS_all = $(BINS_test)
-
 ifeq ($(OBJSSUBMAKE),1)
 test: $(WARN_TARGETS)
 .PHONY: $(WARN_TARGETS)

--- a/src/tools/Makefile
+++ b/src/tools/Makefile
@@ -17,7 +17,7 @@ BASEDIR = ../..
 
 SUBDIRS = plugin logview config plugin_gui netloggui \
           lasergui skillgui battery_monitor ffinfo vision set_pose \
-          eclipse_debugger plugin_generator pddl_parser laser_calibration
+          eclipse_debugger plugin_generator pddl_parser laser_calibration gtest
 
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(BUILDSYSDIR)/rules.mk

--- a/src/tools/gtest/Makefile
+++ b/src/tools/gtest/Makefile
@@ -19,13 +19,12 @@ include $(BASEDIR)/etc/buildsys/gtest.mk
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/src/libs/netcomm/netcomm.mk
 
-LIBS_gtest_fawkes += stdc++ fawkescore fawkesutils fawkesblackboard fawkesnetcomm \
+LIBS_test_fawkes += stdc++ fawkescore fawkesutils fawkesblackboard fawkesnetcomm \
 	fawkesconfig fawkesplugin fawkesaspects fawkesbaseapp
-OBJS_gtest_fawkes += gtest_fawkes.o
+OBJS_test_fawkes += gtest_fawkes.o
 
-OBJS_all = $(OBJS_gtest_fawkes)
+OBJS_all = $(OBJS_test_fawkes)
 LIBS_all = $(LIBDIR)/test/fawkes.so
-BINS_all = $(BINDIR)/gtest_fawkes
 
 ifeq ($(HAVE_GTEST)$(HAVE_CPP11),11)
   CFLAGS += $(CFLAGS_GTEST)
@@ -33,10 +32,12 @@ ifeq ($(HAVE_GTEST)$(HAVE_CPP11),11)
   CFLAGS += $(CFLAGS_CPP11)
   LDFLAGS += $(LDFLAGS_GTEST)
   LIBS_test = $(LIBS_all)
-  BINS_test = $(BINS_all)
+  BINS_test =  $(BINDIR)/test_fawkes
 else
   WARN_TARGETS += warning_gtest
 endif
+
+BINS_all = $(BINS_test)
 
 ifeq ($(OBJSSUBMAKE),1)
 test: $(WARN_TARGETS)

--- a/src/tools/gtest/Makefile
+++ b/src/tools/gtest/Makefile
@@ -39,8 +39,6 @@ else
   WARN_TARGETS += warning_gtest
 endif
 
-BINS_all = $(BINS_test)
-
 ifeq ($(OBJSSUBMAKE),1)
 test: $(WARN_TARGETS)
 

--- a/src/tools/gtest/Makefile
+++ b/src/tools/gtest/Makefile
@@ -28,7 +28,9 @@ LIBS_all = $(LIBDIR)/test/fawkes.so
 
 ifeq ($(HAVE_GTEST)$(HAVE_CPP11),11)
   CFLAGS += $(CFLAGS_GTEST)
-  CFLAGS += -Wno-unused-but-set-variable
+  ifneq ($(CC),clang)
+    CFLAGS += -Wno-unused-but-set-variable
+  endif
   CFLAGS += $(CFLAGS_CPP11)
   LDFLAGS += $(LDFLAGS_GTEST)
   LIBS_test = $(LIBS_all)

--- a/src/tools/gtest/gtest_fawkes.cpp
+++ b/src/tools/gtest/gtest_fawkes.cpp
@@ -60,13 +60,13 @@ main(int argc, char **argv)
 		//init arguments to start fawkes with
 		char **fawkes_argv;
 		fawkes_argv    = new char *[5];
-		fawkes_argv[0] = new char[6];
+		fawkes_argv[0] = new char[7];
 		strcpy(fawkes_argv[0], "fawkes");
-		fawkes_argv[1] = new char[2];
+		fawkes_argv[1] = new char[3];
 		strcpy(fawkes_argv[1], "-p");
 		fawkes_argv[2] = new char[128];
 		strcpy(fawkes_argv[2], plugins.c_str());
-		fawkes_argv[3] = new char[2];
+		fawkes_argv[3] = new char[3];
 		strcpy(fawkes_argv[3], "-c");
 		fawkes_argv[4] = new char[128];
 		strcpy(fawkes_argv[4], config_path.c_str());


### PR DESCRIPTION
Integrate catch2 into our build system. Also make some restructuring to the test case management: Previously, we assumed all test binaries to have a name `gtest_$testname`. This assumption was implicit and easy to miss. Instead, have separate test sets `BINS_gtest` and `BINS_catch2test` for the test binaries of the respective testing framework.

Adapt all tests to the changes. Also switch the circular buffer tests to catch2, mainly to test how catch2 works.

Note that catch2 produces slightly funny-colored output with our build system. This should be fixed with catchorg/Catch2#1864.