### PR TITLE
Robot memory dump/restore improvements

### DIFF
--- a/src/plugins/robot-memory/Makefile
+++ b/src/plugins/robot-memory/Makefile
@@ -32,8 +32,8 @@ PLUGINS_all = $(PLUGINDIR)/robot-memory.so
 # Enable this flag for time tracking
 #CFLAGS += -DUSE_TIMETRACKER
 
-ifeq ($(HAVE_ROBOT_MEMORY)$(HAVE_CPP11),11)
-  CFLAGS += $(CFLAGS_ROBOT_MEMORY) $(CFLAGS_CPP11)
+ifeq ($(HAVE_ROBOT_MEMORY)$(HAVE_CPP17),11)
+  CFLAGS += $(CFLAGS_ROBOT_MEMORY) $(CFLAGS_CPP17)
   LDFLAGS += $(LDFLAGS_ROBOT_MEMORY)
 
   PLUGINS_build = $(PLUGINS_all)
@@ -41,8 +41,8 @@ else
   ifneq ($(HAVE_MONGODB),1)
     WARN_TARGETS += warning_mongodb
   endif
-  ifneq ($(HAVE_CPP11),1)
-    WARN_TARGETS += warning_cpp11
+  ifneq ($(HAVE_CPP17),1)
+    WARN_TARGETS += warning_cpp17
   endif
   ifneq ($(HAVE_TF),1)
     WARN_TARGETS += warning_tf
@@ -59,8 +59,8 @@ endif
 ifeq ($(OBJSSUBMAKE),1)
 all: $(WARN_TARGETS)
 
-.PHONY: warning_cpp11 warning_mongodb warning_tf warning_ubuntu
-warning_cpp11:
+.PHONY: warning_cpp17 warning_mongodb warning_tf warning_ubuntu
+warning_cpp17:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting RobotMemory Plugin$(TNORMAL) (C++11 required)"
 warning_mongodb:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting RobotMemory Plugin$(TNORMAL) (mongodb[-devel] not installed)"

--- a/src/plugins/robot-memory/robot_memory.cpp
+++ b/src/plugins/robot-memory/robot_memory.cpp
@@ -590,7 +590,7 @@ RobotMemory::restore_collection(const std::string &collection,
                                 const std::string &target_collection)
 {
 	std::string target_coll;
-	if (target_collection == "noop") {
+	if (target_collection == "") {
 		target_coll = std::move(collection);
 	} else {
 		target_coll = std::move(target_collection);

--- a/src/plugins/robot-memory/robot_memory.h
+++ b/src/plugins/robot-memory/robot_memory.h
@@ -208,6 +208,7 @@ private:
 	             const std::string &            level = "info");
 
 	bool                 is_distributed_database(const std::string &dbcollection);
+	std::string          get_hostport(const std::string &dbcollection);
 	mongocxx::client *   get_mongodb_client(const std::string &collection);
 	mongocxx::collection get_collection(const std::string &dbcollection);
 

--- a/src/plugins/robot-memory/robot_memory.h
+++ b/src/plugins/robot-memory/robot_memory.h
@@ -90,7 +90,7 @@ public:
 	int              restore_collection(const std::string &dbcollection,
 	                                    const std::string &directory = "@CONFDIR@/robot-memory",
 	                                    std::string        target_dbcollection = "");
-	int              dump_collection(const std::string &collection,
+	int              dump_collection(const std::string &dbcollection,
 	                                 const std::string &directory = "@CONFDIR@/robot-memory");
 	int              create_index(bsoncxx::document::view keys,
 	                              const std::string &     collection = "",

--- a/src/plugins/robot-memory/robot_memory.h
+++ b/src/plugins/robot-memory/robot_memory.h
@@ -89,7 +89,7 @@ public:
 	int              clear_memory();
 	int              restore_collection(const std::string &collection,
 	                                    const std::string &directory = "@CONFDIR@/robot-memory",
-	                                    const std::string &target_collection = "noop");
+	                                    const std::string &target_collection = "");
 	int              dump_collection(const std::string &collection,
 	                                 const std::string &directory = "@CONFDIR@/robot-memory");
 	int              create_index(bsoncxx::document::view keys,

--- a/src/plugins/robot-memory/robot_memory.h
+++ b/src/plugins/robot-memory/robot_memory.h
@@ -87,9 +87,9 @@ public:
 	mongocxx::cursor aggregate(bsoncxx::document::view pipeline, const std::string &collection = "");
 	int              drop_collection(const std::string &collection);
 	int              clear_memory();
-	int              restore_collection(const std::string &collection,
+	int              restore_collection(const std::string &dbcollection,
 	                                    const std::string &directory = "@CONFDIR@/robot-memory",
-	                                    const std::string &target_collection = "");
+	                                    std::string        target_dbcollection = "");
 	int              dump_collection(const std::string &collection,
 	                                 const std::string &directory = "@CONFDIR@/robot-memory");
 	int              create_index(bsoncxx::document::view keys,


### PR DESCRIPTION
This PR contains some minor improvements as follow-up to #192:
* Always use `split_db_collection_string` instead of parsing the db/collection string manually (fix #202)
* Get rid of "noop" as a special collection name for using the input collection as target collection. Use the empty string instead (which is always an invalid collection name) (fix #201)
* Do not hardcode host/port in dump and restore (fix #199)