### PR TITLE
gologpp: include facored-out header file

### DIFF
--- a/src/plugins/gologpp/exog_manager.cpp
+++ b/src/plugins/gologpp/exog_manager.cpp
@@ -24,6 +24,7 @@
 #include "utils.h"
 
 #include <core/exception.h>
+#include <golog++/model/grounding.h>
 #include <libs/interface/field_iterator.h>
 
 using namespace fawkes;


### PR DESCRIPTION
Minor compatibility fix for the most recent `golog++` version which factors the `Grounding<T>` template into a separate header