### PR TITLE
Split navgraph visualization markers into groups

### DIFF
--- a/src/plugins/navgraph/visualization_thread.cpp
+++ b/src/plugins/navgraph/visualization_thread.cpp
@@ -334,10 +334,15 @@ NavGraphVisualizationThread::regenerate()
 		//bool is_next    = (plan_.size() >= 2) && (plan_[1].name() == nodes[i].name());
 		bool is_active = (plan_to_ == nodes[i].name());
 
+		std::string ns = "navgraph";
+		if (nodes[i].has_property("group")) {
+			ns += "-" + nodes[i].property("group");
+		}
+
 		visualization_msgs::Marker sphere;
 		sphere.header.frame_id    = cfg_global_frame_;
 		sphere.header.stamp       = ros::Time::now();
-		sphere.ns                 = "navgraph";
+		sphere.ns                 = ns;
 		sphere.id                 = id_num++;
 		sphere.type               = visualization_msgs::Marker::SPHERE;
 		sphere.action             = visualization_msgs::Marker::ADD;
@@ -456,7 +461,7 @@ NavGraphVisualizationThread::regenerate()
 			visualization_msgs::Marker arrow;
 			arrow.header.frame_id    = cfg_global_frame_;
 			arrow.header.stamp       = ros::Time::now();
-			arrow.ns                 = "navgraph";
+			arrow.ns                 = ns;
 			arrow.id                 = id_num++;
 			arrow.type               = visualization_msgs::Marker::ARROW;
 			arrow.action             = visualization_msgs::Marker::ADD;
@@ -490,7 +495,7 @@ NavGraphVisualizationThread::regenerate()
 		visualization_msgs::Marker text;
 		text.header.frame_id    = cfg_global_frame_;
 		text.header.stamp       = ros::Time::now();
-		text.ns                 = "navgraph";
+		text.ns                 = ns;
 		text.id                 = id_num++;
 		text.type               = visualization_msgs::Marker::TEXT_VIEW_FACING;
 		text.action             = visualization_msgs::Marker::ADD;

--- a/src/plugins/navgraph/visualization_thread.cpp
+++ b/src/plugins/navgraph/visualization_thread.cpp
@@ -46,7 +46,6 @@ NavGraphVisualizationThread::NavGraphVisualizationThread()
 : fawkes::Thread("NavGraphVisualizationThread", Thread::OPMODE_WAITFORWAKEUP),
   fawkes::BlockedTimingAspect(fawkes::BlockedTimingAspect::WAKEUP_HOOK_WORLDSTATE)
 {
-	set_coalesce_wakeups(true);
 	graph_ = NULL;
 	crepo_ = NULL;
 }
@@ -120,7 +119,7 @@ NavGraphVisualizationThread::set_graph(fawkes::LockPtr<NavGraph> &graph)
 	graph_ = graph;
 	traversal_.invalidate();
 	plan_to_ = plan_from_ = "";
-	wakeup();
+	regenerate();
 }
 
 /** Set the constraint repo.
@@ -140,7 +139,7 @@ NavGraphVisualizationThread::set_traversal(NavGraphPath::Traversal &traversal)
 {
 	traversal_ = traversal;
 	plan_to_ = plan_from_ = "";
-	wakeup();
+	regenerate();
 }
 
 /** Reset the current plan. */
@@ -149,7 +148,7 @@ NavGraphVisualizationThread::reset_plan()
 {
 	traversal_.invalidate();
 	plan_to_ = plan_from_ = "";
-	wakeup();
+	regenerate();
 }
 
 /** Set the currently executed edge of the plan.

--- a/src/plugins/navgraph/visualization_thread.h
+++ b/src/plugins/navgraph/visualization_thread.h
@@ -22,6 +22,8 @@
 #ifndef _PLUGINS_VISPATHPLAN_VISPATHPLAN_THREAD_H_
 #define _PLUGINS_VISPATHPLAN_VISPATHPLAN_THREAD_H_
 
+#include "aspect/blocked_timing.h"
+
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 #include <core/threading/mutex.h>
@@ -34,6 +36,7 @@
 #include <visualization_msgs/MarkerArray.h>
 
 class NavGraphVisualizationThread : public fawkes::Thread,
+                                    public fawkes::BlockedTimingAspect,
                                     public fawkes::ConfigurableAspect,
                                     public fawkes::LoggingAspect,
                                     public fawkes::ROSAspect,
@@ -57,6 +60,7 @@ public:
 
 private:
 	void  publish();
+	void  regenerate();
 	void  add_circle_markers(visualization_msgs::MarkerArray &m,
 	                         size_t &                         id_num,
 	                         float                            center_x,
@@ -88,6 +92,8 @@ private:
 	fawkes::LockPtr<fawkes::NavGraphConstraintRepo> crepo_;
 
 	std::string cfg_global_frame_;
+
+	visualization_msgs::MarkerArray markers_;
 };
 
 #endif


### PR DESCRIPTION
Split navgraph visualization markers into groups and republish the marker in every iteration. This allows filtering the markers by selecting/unselecting namespaces in rviz. It also fixes an issue that the navgraph nodes cannot be displayed if rviz does not get the initial visualization marker message.