### PR TITLE
fawkesinterface: Always auto-timestamp on write()

### DIFF
--- a/src/libs/interface/interface.cpp
+++ b/src/libs/interface/interface.cpp
@@ -501,16 +501,16 @@ Interface::write()
 	data_mutex_->lock();
 	bool do_notify = false;
 	if (valid_) {
-		if (data_changed) {
-			if (auto_timestamping_)
-				timestamp_->stamp();
-			long sec = 0, usec = 0;
-			timestamp_->get_timestamp(sec, usec);
-			data_ts->timestamp_sec  = sec;
-			data_ts->timestamp_usec = usec;
-			data_changed            = false;
-			do_notify               = true;
-		}
+		if (auto_timestamping_)
+			timestamp_->stamp();
+		long sec = 0, usec = 0;
+		timestamp_->get_timestamp(sec, usec);
+		data_ts->timestamp_sec  = sec;
+		data_ts->timestamp_usec = usec;
+
+		do_notify    = data_changed;
+		data_changed = false;
+
 		memcpy(mem_data_ptr_, data_ptr, data_size);
 	} else {
 		data_mutex_->unlock();


### PR DESCRIPTION
If auto-timestamping is enabled on an interface, `write()` should always update the timestamp, even if the data haven't changed. Thus, a `write()` is interpreted as the writer saying "The data in the interface (changed or not) are valid at the time of writing".

This should be more in line with the previous semantics where simply calling any interface field
setter would set the `data_changed` flag and therefore a timestamp update, even if the new data were identical to the old data.