### PR TITLE
skiller-simulator: adapt tests to changes in the build system

### DIFF
--- a/src/plugins/skiller-simulator/tests/Makefile
+++ b/src/plugins/skiller-simulator/tests/Makefile
@@ -17,16 +17,15 @@ BASEDIR = ../../../..
 include $(BASEDIR)/etc/buildsys/config.mk
 include $(BASEDIR)/etc/buildsys/gtest.mk
 
-LIBS_gtest_skiller_simulator_skill_parser = m fawkes_skiller_time_estimator
-OBJS_gtest_skiller_simulator_skill_parser = test_skill_parser.o
+LIBS_test_skiller_simulator_skill_parser = m fawkes_skiller_time_estimator
+OBJS_test_skiller_simulator_skill_parser = test_skill_parser.o
 OBJS_all = $(OBJS_gtest_skiller_simulator_skill_parser)
-BINS_all = $(BINDIR)/gtest_skiller_simulator_skill_parser
 
 ifeq ($(HAVE_CPP17),1)
   ifeq ($(HAVE_GTEST),1)
     CFLAGS += $(CFLAGS_GTEST)
     LDFLAGS += $(LDFLAGS_GTEST)
-    BINS_test = $(BINS_all)
+    BINS_gtest = $(BINDIR)/test_skiller_simulator_skill_parser
   else
     WARN_TARGETS += warn_gtest
   endif


### PR DESCRIPTION
The recent changes from #204 and #197 were incompatible, resulting in the tests from the skiller simulator (#197) not being built. This PR fixes the tests.