### PR TITLE
gazebo-robotino: react on gripper has puck msg

### DIFF
--- a/src/plugins/gazebo/gazsim-robotino/gazsim_robotino_thread.cpp
+++ b/src/plugins/gazebo/gazsim-robotino/gazsim_robotino_thread.cpp
@@ -112,6 +112,11 @@ RobotinoSimThread::init()
 		                        this);
 	}
 
+	gripper_has_puck_sub_ =
+	  gazebonode->Subscribe(config->get_string("/gazsim/topics/gripper-has-puck"),
+	                        &RobotinoSimThread::on_gripper_has_puck_msg,
+	                        this);
+
 	//Create publishers
 	motor_move_pub_ =
 	  gazebonode->Advertise<msgs::Vector3d>(config->get_string("/gazsim/topics/motor-move"));
@@ -120,6 +125,11 @@ RobotinoSimThread::init()
 	//enable motor by default
 	switch_if_->set_enabled(true);
 	switch_if_->write();
+
+	// puck sensor connected to first 2 inputs of RobotinoInterface
+	sens_if_->set_digital_in(0, false);
+	sens_if_->set_digital_in(1, false);
+	sens_if_->write();
 
 	imu_if_->set_frame(cfg_frame_imu_.c_str());
 	imu_if_->set_linear_acceleration(0, -1.);
@@ -408,4 +418,12 @@ RobotinoSimThread::on_gripper_laser_left_sensor_msg(ConstFloatPtr &msg)
 		analog_in_left_ = gripper_laser_value_far_;
 	}
 	new_data_ = true;
+}
+
+void
+RobotinoSimThread::on_gripper_has_puck_msg(ConstIntPtr &msg)
+{
+	// 1 means the gripper has a puck 0 not
+	sens_if_->set_digital_in(1, msg->data() > 0);
+	sens_if_->write();
 }

--- a/src/plugins/gazebo/gazsim-robotino/gazsim_robotino_thread.h
+++ b/src/plugins/gazebo/gazsim-robotino/gazsim_robotino_thread.h
@@ -77,6 +77,7 @@ private:
 	gazebo::transport::SubscriberPtr infrared_puck_sensor_sub_;
 	gazebo::transport::SubscriberPtr gripper_laser_left_sensor_sub_;
 	gazebo::transport::SubscriberPtr gripper_laser_right_sensor_sub_;
+	gazebo::transport::SubscriberPtr gripper_has_puck_sub_;
 	gazebo::transport::SubscriberPtr pos_sub_;
 
 	//Handler functions for incoming messages
@@ -84,6 +85,7 @@ private:
 	void on_infrared_puck_sensor_msg(ConstLaserScanStampedPtr &msg);
 	void on_gripper_laser_left_sensor_msg(ConstFloatPtr &msg);
 	void on_gripper_laser_right_sensor_msg(ConstFloatPtr &msg);
+	void on_gripper_has_puck_msg(ConstIntPtr &msg);
 	void on_pos_msg(ConstPosePtr &msg);
 
 	//provided interfaces


### PR DESCRIPTION

 Writing to RobotinoInterface to gazsim-robotino plugin (moved from fawkes-robotino)
- Adapting to the new gripper hardwar, the puck sensor is now connected to the robotino input  -- white cable on    DI1 and black on DI2

