### PR TITLE
Switch to Fedora 31 for buildkite builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ merged-pr-plugin: &merged-pr-plugin
     mode: checkout
 
 docker-plugin-base: &docker-plugin-base
-  image: fawkesrobotics/fawkes-builder:fedora30-melodic
+  image: fawkesrobotics/fawkes-builder:fedora31-melodic
   always-pull: true
   debug: true
   environment: ["BUILDKITE", "BUILDKITE_LABEL"]


### PR DESCRIPTION
Update buildkite to use Fedora 31 instead of Fedora 30.

The main work (the container images) for this was done in https://github.com/fawkesrobotics/docker-robotics.