### PR TITLE
clips executive: process wm-sync triggers from old to new

### DIFF
--- a/src/plugins/clips-executive/clips/wm-robmem-sync.clp
+++ b/src/plugins/clips-executive/clips/wm-robmem-sync.clp
@@ -382,7 +382,9 @@
 
 (defrule wm-robmem-sync-fact-trigger-event
 	(wm-fact (key cx identity) (value ?identity))
-	?rt <- (robmem-trigger (name "wm-robmem-sync-trigger") (ptr ?obj))
+	?rt <- (robmem-trigger (name "wm-robmem-sync-trigger") (ptr ?obj) (rcvd-at $?recv-time))
+	(not (robmem-trigger (name "wm-robmem-sync-trigger")
+                       (rcvd-at $?comp-time&:(time> ?recv-time ?comp-time))))
 	=>
 	(bind ?op (sym-cat (bson-get ?obj "operationType")))
 


### PR DESCRIPTION
This PR ensures that wm-sync triggers from robot memory are processed in the same order that they are received. This aligns with the behaviour for coordination mutexes: https://github.com/fawkesrobotics/fawkes/blob/6a006f7b19f468b35e6e01c74b55bfcb6c2e6c0d/src/plugins/clips-executive/clips/coordination-mutex.clp#L478-L482
