### PR TITLE
Add a build target for integration tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
       - .buildkite/test
       - .buildkite/annotate
     artifact_paths:
-      - bin/*.log
+      - tests.out.d/**/*
     timeout_in_minutes: 30
     plugins:
       - *merged-pr-plugin

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,7 @@ steps:
       - .buildkite/annotate
     artifact_paths:
       - bin/*.log
+    timeout_in_minutes: 15
     plugins:
       - *merged-pr-plugin
       - docker#v3.3.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,6 +36,8 @@ steps:
       - .buildkite/build
       - .buildkite/test
       - .buildkite/annotate
+    artifact_paths:
+      - bin/*.log
     plugins:
       - *merged-pr-plugin
       - docker#v3.3.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
       - .buildkite/annotate
     artifact_paths:
       - bin/*.log
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     plugins:
       - *merged-pr-plugin
       - docker#v3.3.0:

--- a/.buildkite/test
+++ b/.buildkite/test
@@ -29,3 +29,4 @@ set -euo pipefail
 
 # Run tests
 $MAKE -j$NPROC test
+$MAKE integration-test

--- a/etc/buildsys/root/root.mk
+++ b/etc/buildsys/root/root.mk
@@ -29,6 +29,7 @@ include $(BUILDSYSDIR)/root/parallel.mk
 include $(BUILDSYSDIR)/root/uncolored.mk
 include $(BUILDSYSDIR)/root/stats.mk
 include $(BUILDSYSDIR)/root/git-hooks.mk
+include $(BUILDSYSDIR)/root/test.mk
 
 endif # __buildsys_root_root_mk_
 

--- a/etc/buildsys/root/test.mk
+++ b/etc/buildsys/root/test.mk
@@ -18,7 +18,7 @@ integration-test:
 		for test in $(TOP_BASEDIR)/tests.d/* ; do \
 			if [ -x $$test ] ; then \
 				echo -e $(INDENT_PRINT)"[TEST] Executing test $$test"; \
-				exec $$test | sed s'/^/$(INDENT_PRINT)[TEST] /'; \
+				exec $$test | sed s'/^/$(INDENT_PRINT)[TEST] --> /'; \
 				if [ $${PIPESTATUS[0]}  -ne 0 ] ; then \
 					echo -e $(INDENT_PRINT)"[TEST] $(TBOLDRED)Failed test: $$test$(TNORMAL)"; \
 					exit 1; \

--- a/etc/buildsys/root/test.mk
+++ b/etc/buildsys/root/test.mk
@@ -1,0 +1,29 @@
+#*****************************************************************************
+#                      Makefile Build System for Fawkes
+#                            -------------------
+#   Created on Mon 16 Mar 2020 09:09:58 CET
+#   Copyright (C) 2020 by Till Hofmann <hofmann@kbsg.rwth-aachen.de>
+#
+#*****************************************************************************
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#*****************************************************************************
+
+test: exec_testscripts
+exec_testscripts:
+	$(SILENT) if [ -d $(TOP_BASEDIR)/tests.d/ ] ; then \
+		for test in $$(ls $(TOP_BASEDIR)/tests.d/) ; do \
+			if [ -x $(TOP_BASEDIR)/tests.d/$$test ] ; then \
+				echo -e $(INDENT_PRINT)"[TEST] Executing test $(TOP_BASEDIR)/tests.d/$$test"; \
+				exec $(TOP_BASEDIR)/tests.d/$$test | sed s'/^/$(INDENT_PRINT)[TEST] /'; \
+				if [ $${PIPESTATUS[0]}  -ne 0 ] ; then \
+					echo -e $(INDENT_PRINT)"[TEST] $(TBOLDRED)Failed test: $(TOP_BASEDIR)/tests.d/$$test$(TNORMAL)"; \
+					exit 1; \
+				fi \
+			fi \
+		done \
+	fi

--- a/etc/buildsys/root/test.mk
+++ b/etc/buildsys/root/test.mk
@@ -13,8 +13,7 @@
 #
 #*****************************************************************************
 
-test: exec_testscripts
-exec_testscripts:
+integration-test:
 	$(SILENT) if [ -d $(TOP_BASEDIR)/tests.d/ ] ; then \
 		for test in $$(ls $(TOP_BASEDIR)/tests.d/) ; do \
 			if [ -x $(TOP_BASEDIR)/tests.d/$$test ] ; then \

--- a/etc/buildsys/root/test.mk
+++ b/etc/buildsys/root/test.mk
@@ -15,12 +15,12 @@
 
 integration-test:
 	$(SILENT) if [ -d $(TOP_BASEDIR)/tests.d/ ] ; then \
-		for test in $$(ls $(TOP_BASEDIR)/tests.d/) ; do \
-			if [ -x $(TOP_BASEDIR)/tests.d/$$test ] ; then \
-				echo -e $(INDENT_PRINT)"[TEST] Executing test $(TOP_BASEDIR)/tests.d/$$test"; \
-				exec $(TOP_BASEDIR)/tests.d/$$test | sed s'/^/$(INDENT_PRINT)[TEST] /'; \
+		for test in $(TOP_BASEDIR)/tests.d/* ; do \
+			if [ -x $$test ] ; then \
+				echo -e $(INDENT_PRINT)"[TEST] Executing test $$test"; \
+				exec $$test | sed s'/^/$(INDENT_PRINT)[TEST] /'; \
 				if [ $${PIPESTATUS[0]}  -ne 0 ] ; then \
-					echo -e $(INDENT_PRINT)"[TEST] $(TBOLDRED)Failed test: $(TOP_BASEDIR)/tests.d/$$test$(TNORMAL)"; \
+					echo -e $(INDENT_PRINT)"[TEST] $(TBOLDRED)Failed test: $$test$(TNORMAL)"; \
 					exit 1; \
 				fi \
 			fi \

--- a/src/libs/netcomm/dns-sd/avahi_thread.h
+++ b/src/libs/netcomm/dns-sd/avahi_thread.h
@@ -33,6 +33,7 @@
 #include <netcomm/service_discovery/service_publisher.h>
 #include <netinet/in.h>
 
+#include <chrono>
 #include <string>
 #include <utility>
 
@@ -96,8 +97,8 @@ private:
 	                            AvahiLookupResultFlags flags,
 	                            void *                 instance);
 
-	static void resolve_callback(AvahiServiceResolver *r,
-	                             AVAHI_GCC_UNUSED AvahiIfIndex interface,
+	static void resolve_callback(AvahiServiceResolver *         r,
+	                             AVAHI_GCC_UNUSED AvahiIfIndex  interface,
 	                             AVAHI_GCC_UNUSED AvahiProtocol protocol,
 	                             AvahiResolverEvent             event,
 	                             const char *                   name,
@@ -185,10 +186,11 @@ private:
 	bool do_erase_browsers;
 	bool do_reset_groups;
 
-	AvahiSimplePoll *simple_poll;
-	AvahiClient *    client;
-	AvahiClientState client_state;
-	AvahiProtocol    service_protocol;
+	AvahiSimplePoll *                 simple_poll;
+	AvahiClient *                     client;
+	AvahiClientState                  client_state;
+	AvahiProtocol                     service_protocol;
+	const static std::chrono::seconds wait_on_init_failure;
 
 	WaitCondition *init_wc;
 

--- a/src/plugins/clips/aspect/Makefile
+++ b/src/plugins/clips/aspect/Makefile
@@ -22,7 +22,7 @@ include $(BUILDSYSDIR)/clips.mk
 CFLAGS  += $(CFLAGS_CLIPS)
 LDFLAGS += $(LDFLAGS_CLIPS)
 
-LIBS_libfawkesclipsaspect = stdc++ fawkescore fawkesaspects fawkesutils
+LIBS_libfawkesclipsaspect = stdc++ fawkescore fawkesaspects fawkesutils fawkesbaseapp
 OBJS_libfawkesclipsaspect = $(patsubst %.cpp,%.o,$(patsubst qa/%,,$(subst $(SRCDIR)/,,$(realpath $(wildcard $(SRCDIR)/*.cpp)))))
 
 OBJS_all = $(OBJS_libfawkesclipsaspect)

--- a/src/plugins/clips/aspect/clips_env_manager.cpp
+++ b/src/plugins/clips/aspect/clips_env_manager.cpp
@@ -20,6 +20,7 @@
  *  Read the full text in the LICENSE.GPL_WRE file in the doc directory.
  */
 
+#include <baseapp/run.h>
 #include <logging/logger.h>
 #include <plugins/clips/aspect/clips_env_manager.h>
 #include <plugins/clips/aspect/clips_feature.h>
@@ -396,6 +397,7 @@ CLIPSEnvManager::add_functions(const std::string &env_name, LockPtr<CLIPS::Envir
 	clips->add_function("now-systime",
 	                    sigc::slot<CLIPS::Values>(
 	                      sigc::mem_fun(*this, &CLIPSEnvManager::clips_now_systime)));
+	clips->add_function("quit", sigc::slot<void>(sigc::mem_fun(*this, &CLIPSEnvManager::quit)));
 }
 
 void
@@ -506,6 +508,12 @@ CLIPSEnvManager::guarded_load(const std::string &env_name, const std::string &fi
 			throw Exception("%s: CLIPS code error in %s", env_name.c_str(), filename.c_str());
 		}
 	}
+}
+
+void
+CLIPSEnvManager::quit()
+{
+	fawkes::runtime::quit();
 }
 
 } // end namespace fawkes

--- a/src/plugins/clips/aspect/clips_env_manager.h
+++ b/src/plugins/clips/aspect/clips_env_manager.h
@@ -60,6 +60,7 @@ private:
 	CLIPS::Values clips_now();
 	CLIPS::Values clips_now_systime();
 	void          guarded_load(const std::string &env_name, const std::string &filename);
+	void          quit();
 
 private:
 	Logger *logger_;

--- a/src/plugins/gazebo/gazsim-comm/Makefile
+++ b/src/plugins/gazebo/gazsim-comm/Makefile
@@ -25,8 +25,7 @@ include $(BUILDSYSDIR)/protobuf.mk
 
 CFLAGS += $(CFLAGS_CPP11)
 
-LIBS_gazsim_comm = fawkescore fawkesutils fawkesaspects fawkes_protobuf_comm \
-                   fawkesgazeboaspect gazsim_msgs 
+LIBS_gazsim_comm = fawkescore fawkesaspects fawkes_protobuf_comm
 OBJS_gazsim_comm = gazsim_comm_plugin.o gazsim_comm_thread.o
 
 OBJS_all    = $(OBJS_gazsim_comm)


### PR DESCRIPTION
Provide the capability of running integration tests. In particular:
* Add a build target `integration-test`. The target expects tests to be located in `$(TOP_BASEDIR)/tests.d` and it executes all tests sequentially.
* Prepare buildkite to run integration tests and also upload the results as artifacts.
* Fix #213, which causes high CPU loads in containers
* Provide a CLIPS function `quit` to quit Fawkes from within CLIPS. This allows to have a test controller in CLIPS that quits as soon as all tests have run.
* Do not link `gazsim-comm` against `fawkesgazeboaspect`. This is only a workaround for a linking issue in containers. For some reason, gazebo is not linked correctly in containers, resulting in runtime crashes caused by the dynamic linker which cannot find `libQt5Core`. This is in preparation for some integration tests in fawkes-robotino.

Note that this does not actually include any tests.