### PR TITLE
Comparing the keys of self.args before and after calling self:init()

### DIFF
--- a/src/lua/skiller/subskill_jumpstate.lua
+++ b/src/lua/skiller/subskill_jumpstate.lua
@@ -246,7 +246,6 @@ function SubSkillJumpState:do_init()
             sname = s[1].name
          end
          self.args[sname] = {}
-         --  exp_sizeof_args = exp_sizeof_args + 1
       end
    end
    -- copy expected arguments table for later comparison

--- a/src/lua/skiller/subskill_jumpstate.lua
+++ b/src/lua/skiller/subskill_jumpstate.lua
@@ -232,8 +232,10 @@ function SubSkillJumpState:do_init()
    self.args = {}
 
    -- store expected size of arguments table to compare after run of init()
-   local exp_sizeof_args = 0
-   local act_sizeof_args = 0
+   -- local exp_sizeof_args = 0
+   -- local act_sizeof_args = 0
+   
+   local exp_args = {}
 
    for _, s in ipairs(self.skills) do
       if s[1] ~= nil then
@@ -244,17 +246,36 @@ function SubSkillJumpState:do_init()
             sname = s[1].name
          end
          self.args[sname] = {}
-         exp_sizeof_args = exp_sizeof_args + 1
+         --  exp_sizeof_args = exp_sizeof_args + 1
       end
    end
+   -- copy expexted arguments table for later comparison
+   exp_args = table.deepcopy(self.args)
+
    self:init()
+   
+   -- copy actual arguments table for comparison
+   act_args = table.deepcopy(self.args)
+
    -- compare size of expected argument table with actual argument table
-   for skillname, skill in pairs(self.args) do
-      act_sizeof_args = act_sizeof_args + 1
+   -- for skillname, skill in pairs(self.args) do
+   --   act_sizeof_args = act_sizeof_args + 1
+   -- end
+   -- if exp_sizeof_args ~= act_sizeof_args then 
+   --   print_warn("Expected size of self.args: " .. tostring(exp_sizeof_args) .. ", actual size of self.args: "
+   --   .. tostring(act_sizeof_args) .. ". Make sure you set the correct key in self.args[key]")
+   -- end
+
+   -- compare keys of copies to determine unexpected key names
+   for act_args_key,act_args_val in pairs(act_args) do
+      for exp_args_key,act_args_val in pairs(exp_args) do 
+         if act_args_key == exp_args_key then
+            act_args[act_args_key] = nil
+         end
+      end
    end
-   if exp_sizeof_args ~= act_sizeof_args then 
-      print_warn("Expected size of self.args: " .. tostring(exp_sizeof_args) .. ", actual size of self.args: "
-      .. tostring(act_sizeof_args) .. ". Make sure you set the correct key in self.args[key]")
+   for unexp_skillname,_ in pairs(act_args) do
+      print_warn("Unexpected skillname: " .. unexp_skillname .. " in self.args")
    end
 
    for _, s in ipairs(self.skills) do

--- a/src/lua/skiller/subskill_jumpstate.lua
+++ b/src/lua/skiller/subskill_jumpstate.lua
@@ -233,9 +233,10 @@ function SubSkillJumpState:do_init()
    
    self.args = {}
 
-   -- store expected size of arguments table to compare after run of init()
+   -- initialize empty tables to compare expected arguments (exp_args) and potential unexpected arguments (unexp_args)
+   -- by the user
    local exp_args = {}
-   local act_args = {}
+   local unexp_args = {}
 
    for _, s in ipairs(self.skills) do
       if s[1] ~= nil then
@@ -253,18 +254,18 @@ function SubSkillJumpState:do_init()
 
    self:init()
    
-   -- copy actual arguments table for comparison
-   act_args = table.deepcopy(self.args)
+   -- copy actual arguments table to single out unexpected arguments
+   unexp_args = table.deepcopy(self.args)
 
    -- compare keys of copies to determine unexpected key names
-   for act_args_key,act_args_val in pairs(act_args) do
+   for act_args_key,act_args_val in pairs(unexp_args) do
       for exp_args_key,act_args_val in pairs(exp_args) do 
          if act_args_key == exp_args_key then
-            act_args[act_args_key] = nil
+            unexp_args[act_args_key] = nil
          end
       end
    end
-   for unexp_skillname,_ in pairs(act_args) do
+   for unexp_skillname,_ in pairs(unexp_args) do
       print_warn("Unexpected skillname: " .. unexp_skillname .. " in self.args")
    end
 

--- a/src/lua/skiller/subskill_jumpstate.lua
+++ b/src/lua/skiller/subskill_jumpstate.lua
@@ -60,6 +60,8 @@ require("fawkes.modinit")
 -- @author Tim Niemueller
 module(..., fawkes.modinit.module_init)
 
+require("fawkes.tableext")
+
 require("fawkes.fsm.jumpstate")
 local skillstati = require("skiller.skillstati")
 
@@ -232,10 +234,8 @@ function SubSkillJumpState:do_init()
    self.args = {}
 
    -- store expected size of arguments table to compare after run of init()
-   -- local exp_sizeof_args = 0
-   -- local act_sizeof_args = 0
-   
    local exp_args = {}
+   local act_args = {}
 
    for _, s in ipairs(self.skills) do
       if s[1] ~= nil then
@@ -249,22 +249,13 @@ function SubSkillJumpState:do_init()
          --  exp_sizeof_args = exp_sizeof_args + 1
       end
    end
-   -- copy expexted arguments table for later comparison
+   -- copy expected arguments table for later comparison
    exp_args = table.deepcopy(self.args)
 
    self:init()
    
    -- copy actual arguments table for comparison
    act_args = table.deepcopy(self.args)
-
-   -- compare size of expected argument table with actual argument table
-   -- for skillname, skill in pairs(self.args) do
-   --   act_sizeof_args = act_sizeof_args + 1
-   -- end
-   -- if exp_sizeof_args ~= act_sizeof_args then 
-   --   print_warn("Expected size of self.args: " .. tostring(exp_sizeof_args) .. ", actual size of self.args: "
-   --   .. tostring(act_sizeof_args) .. ". Make sure you set the correct key in self.args[key]")
-   -- end
 
    -- compare keys of copies to determine unexpected key names
    for act_args_key,act_args_val in pairs(act_args) do

--- a/src/lua/skiller/subskill_jumpstate.lua
+++ b/src/lua/skiller/subskill_jumpstate.lua
@@ -228,8 +228,13 @@ function SubSkillJumpState:do_init()
 
    self:skill_reset()
    self.skill_status = skillstati.S_RUNNING
-
+   
    self.args = {}
+
+   -- store expected size of arguments table to compare after run of init()
+   local exp_sizeof_args = 0
+   local act_sizeof_args = 0
+
    for _, s in ipairs(self.skills) do
       if s[1] ~= nil then
          local sname = ""
@@ -239,9 +244,19 @@ function SubSkillJumpState:do_init()
             sname = s[1].name
          end
          self.args[sname] = {}
+         exp_sizeof_args = exp_sizeof_args + 1
       end
    end
    self:init()
+   -- compare size of expected argument table with actual argument table
+   for skillname, skill in pairs(self.args) do
+      act_sizeof_args = act_sizeof_args + 1
+   end
+   if exp_sizeof_args ~= act_sizeof_args then 
+      print_warn("Expected size of self.args: " .. tostring(exp_sizeof_args) .. ", actual size of self.args: "
+      .. tostring(act_sizeof_args) .. ". Make sure you set the correct key in self.args[key]")
+   end
+
    for _, s in ipairs(self.skills) do
       local set_already = false
       local args = {}

--- a/src/lua/skiller/subskill_jumpstate.lua
+++ b/src/lua/skiller/subskill_jumpstate.lua
@@ -158,21 +158,21 @@ function SubSkillJumpState:set_transition_labels()
    if self.skills and #self.skills > 0 then
       local snames = {}
       for _,s in ipairs(self.skills) do
-	 if s[1] == nil then
-	    error("Skill entry is nil, forgot to add skill to dependencies?")
-	 elseif type(s[1]) == "string" then
-	    table.insert(snames, s[1])
-	 else
-	    table.insert(snames, s[1].name)
-	 end
+         if s[1] == nil then
+          error("Skill entry is nil, forgot to add skill to dependencies?")
+         elseif type(s[1]) == "string" then
+          table.insert(snames, s[1])
+         else
+          table.insert(snames, s[1].name)
+         end
       end
       self.skill_names = table.concat(snames, ", ")
       if self.failure_transition then
-	 self.failure_transition.description =
+         self.failure_transition.description =
             table.concat(snames, " or ") .. " failed"
       end
       if self.final_transition then
-	 self.final_transition.description =
+         self.final_transition.description =
             table.concat(snames, " and ")
          if self.final_fail_trans then
             self.final_transition.description =
@@ -186,10 +186,10 @@ function SubSkillJumpState:set_transition_labels()
    else
       self.skill_names = ""
       if self.failure_transition then
-	 self.failure_transition.description = "Skills failed"
+         self.failure_transition.description = "Skills failed"
       end
       if self.final_transition then
-	 self.final_transition.description   = "Skills succeeded"
+         self.final_transition.description   = "Skills succeeded"
       end
    end
    self.fsm:mark_changed()
@@ -208,7 +208,7 @@ function SubSkillJumpState:jumpcond_skill_failed()
       local error = ""
 
       if error and error ~= "" then
-	 self.fsm:set_error(self.name .. "()/" .. self.skill_names ..
+         self.fsm:set_error(self.name .. "()/" .. self.skill_names ..
                             " failed: " .. error)
       end
       return true
@@ -231,16 +231,16 @@ function SubSkillJumpState:do_init()
 
    self.args = {}
    for _, s in ipairs(self.skills) do
-			if s[1] ~= nil then
-				 local sname = ""
-				 if type(s[1]) == "string" then
-						sname = s[1]
-				 else
-						sname = s[1].name
-				 end
-				 self.args[sname] = {}
-			end
-	 end
+      if s[1] ~= nil then
+         local sname = ""
+         if type(s[1]) == "string" then
+            sname = s[1]
+         else
+            sname = s[1].name
+         end
+         self.args[sname] = {}
+      end
+   end
    self:init()
    for _, s in ipairs(self.skills) do
       local set_already = false
@@ -250,21 +250,21 @@ function SubSkillJumpState:do_init()
          if k ~= 1 then
             set_already = true
             if type(k) == "number" and type(v) == "table" then
-	       -- assuming this is the default args table, passed in define_states
+               -- assuming this is the default args table, passed in define_states
                for k2, v2 in pairs(v) do
                   if type(v2) == "table" then
-		     args[k2] = table.deepcopy(v2)
-		  else
-		     args[k2] = v2
-		  end
+                     args[k2] = table.deepcopy(v2)
+                  else
+                     args[k2] = v2
+                  end
                end
 
             elseif type(k) ~= "string" or (k ~= "status" and k ~= "args") then
-	       print_warn("You have set the subskill "..s[1].name.."'s field '"..tostring(k).."'."
-			  .." Please pass the subskill's arguments in the 'args' field of subskills,"
-			  .." or the 'args' field of the state that envokes the subskill(s).")
+               print_warn("You have set the subskill "..s[1].name.."'s field '"..tostring(k).."'."
+                          .." Please pass the subskill's arguments in the 'args' field of subskills,"
+                          .." or the 'args' field of the state that envokes the subskill(s).")
                args[k] = v
-	    end
+            end
          end
       end
 
@@ -290,7 +290,7 @@ function SubSkillJumpState:do_init()
    if self.skills then
       local t = {}
       for _, skill in ipairs(self.skills) do
-	 table.insert(t, self:skillstring(skill))
+         table.insert(t, self:skillstring(skill))
       end
       print_debug("%s: executing %s", self.name, table.concat(t, "; "))
    --elseif self.skill then
@@ -374,10 +374,10 @@ end
 function SubSkillJumpState:skill_reset()
    if self.skills then
       for _, s in ipairs(self.skills) do
-	 s.args = nil
-	 s.__args = nil
-	 s.status = skillstati.S_RUNNING
-	 s[1].reset()
+         s.args = nil
+         s.__args = nil
+         s.status = skillstati.S_RUNNING
+         s[1].reset()
       end
    end
 end


### PR DESCRIPTION
Currently if you misspell the skillname in `init()` when setting `self.args[skillname]` the skill will be called, but without any arguments.
If you misspell the skillname you add another entry to the `self.args` dictionary, thus changing its size.
This PR adds a hint for those cases, aiming to improve debugging, since before it would warn you about calling the skill without any arguments

1. Checking for spelling mistakes could be done with costly regexes
2. And might result in many false positives if similar skillnames are used

This supersedes #216.