### PR TITLE
buildkite: fix loop over emails in build creator check

### DIFF
--- a/.buildkite/lint
+++ b/.buildkite/lint
@@ -114,7 +114,7 @@ check_build_creator () {
 			IFS=","
 			declare -a EMAILS=(${AUTHOR_EMAILS[$i]})
 			IFS=$OIFS
-			for E in $EMAILS; do
+			for E in "${EMAILS[@]}"; do
 				if [[ "$E" == "$ce" || "$E" == "$g@users.noreply.github.com" ]]; then
 					AUTHOR_INDEX=$i
 				fi


### PR DESCRIPTION
The variable `EMAILS` is an array and may contain more than one value.
Properly expand the array before iterating over it.