### PR TITLE
buildsys: use ldoc instead of luadoc

### DIFF
--- a/etc/buildsys/config.mk
+++ b/etc/buildsys/config.mk
@@ -141,7 +141,7 @@ PKGCONFIG = $(shell which pkg-config)
 NM=nm
 ASCIIDOC=asciidoc
 ASCIIDOC_A2X=a2x
-LUADOC=luadoc
+LUADOC=ldoc
 ifneq ($(wildcard /bin/bash),)
   SHELL = /bin/bash
 else


### PR DESCRIPTION
ldoc is a replacement for luadoc to generate documentation for lua.
luadoc does not work with lua 5.3 and is broken on recent Fedora
releases.

This fixes #220.