### PR TITLE
fixes for boost 1.73 and PCL 1.11

### DIFF
--- a/src/libs/pcl_utils/comparisons.h
+++ b/src/libs/pcl_utils/comparisons.h
@@ -22,6 +22,8 @@
 #ifndef _LIBS_PCL_UTILS_COMPARISONS_H_
 #define _LIBS_PCL_UTILS_COMPARISONS_H_
 
+#include "compatibility.h"
+
 #include <pcl/ModelCoefficients.h>
 #include <pcl/filters/conditional_removal.h>
 #include <pcl/point_cloud.h>

--- a/src/libs/pcl_utils/comparisons.h
+++ b/src/libs/pcl_utils/comparisons.h
@@ -45,9 +45,9 @@ class PolygonComparison : public pcl::ComparisonBase<PointT>
 
 public:
 	/// Shared pointer.
-	typedef boost::shared_ptr<PolygonComparison<PointT>> Ptr;
+	typedef pcl::shared_ptr<PolygonComparison<PointT>> Ptr;
 	/// Constant shared pointer.
-	typedef boost::shared_ptr<const PolygonComparison<PointT>> ConstPtr;
+	typedef pcl::shared_ptr<const PolygonComparison<PointT>> ConstPtr;
 
 	/** Constructor.
    * @param polygon polygon to compare against, it must have at least three points
@@ -101,9 +101,9 @@ class PlaneDistanceComparison : public pcl::ComparisonBase<PointT>
 
 public:
 	/// Shared pointer.
-	typedef boost::shared_ptr<PlaneDistanceComparison<PointT>> Ptr;
+	typedef pcl::shared_ptr<PlaneDistanceComparison<PointT>> Ptr;
 	/// Constant shared pointer.
-	typedef boost::shared_ptr<const PlaneDistanceComparison<PointT>> ConstPtr;
+	typedef pcl::shared_ptr<const PlaneDistanceComparison<PointT>> ConstPtr;
 
 	/** Constructor.
    * @param coeff planar model coefficients

--- a/src/libs/pcl_utils/compatibility.h
+++ b/src/libs/pcl_utils/compatibility.h
@@ -1,0 +1,38 @@
+
+/***************************************************************************
+ *  compatibility.h - Helper definitions for PCL's boost -> std transition
+ *
+ *  Copyright  2020  Victor Mataré
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#pragma once
+
+#include <pcl/pcl_config.h>
+
+#if PCL_VERSION_COMPARE(<, 1, 11, 0)
+
+#	include <boost/smart_ptr/shared_ptr.hpp>
+
+namespace pcl {
+template <class T>
+using shared_ptr = boost::shared_ptr<T>;
+}
+
+#else
+
+#	include <pcl/memory.h>
+
+#endif

--- a/src/libs/pcl_utils/utils.h
+++ b/src/libs/pcl_utils/utils.h
@@ -112,11 +112,11 @@ set_time(fawkes::RefPtr<pcl::PointCloud<PointT>> &cloud, const fawkes::Time &tim
  * @param cloud cloud of which to set the time
  * @param time time to use
  */
-template <typename PointT>
+template <typename CloudPtrT>
 inline void
-set_time(boost::shared_ptr<pcl::PointCloud<PointT>> &cloud, const fawkes::Time &time)
+set_time(CloudPtrT &cloud, const fawkes::Time &time)
 {
-	set_time<PointT>(*cloud, time);
+	set_time<typename CloudPtrT::element_type::PointType>(*cloud, time);
 }
 
 /** Get time of a point cloud as a fawkes::Time instance.
@@ -125,32 +125,9 @@ set_time(boost::shared_ptr<pcl::PointCloud<PointT>> &cloud, const fawkes::Time &
  * @param cloud cloud of which to get the time
  * @param time upon return contains the timestamp of the cloud
  */
-template <typename PointT>
+template <typename CloudPtrT>
 inline void
-get_time(const fawkes::RefPtr<const pcl::PointCloud<PointT>> &cloud, fawkes::Time &time)
-{
-#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
-	time.set_time(cloud->header.stamp / 1000000U, cloud->header.stamp % 1000000);
-#else
-#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
-	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
-#	else
-	PointCloudTimestamp pclts;
-	pclts.timestamp = cloud->header.stamp;
-	time.set_time(pclts.time.sec, pclts.time.usec);
-#	endif
-#endif
-}
-
-/** Get time of a point cloud as a fawkes::Time instance.
- * This uses the PointCloudTimestamp struct to set the time in the PCL
- * timestamp field (if non-ROS PCL is used).
- * @param cloud cloud of which to get the time
- * @param time upon return contains the timestamp of the cloud
- */
-template <typename PointT>
-inline void
-get_time(const fawkes::RefPtr<pcl::PointCloud<PointT>> &cloud, fawkes::Time &time)
+get_time(const CloudPtrT &cloud, fawkes::Time &time)
 {
 #if PCL_VERSION_COMPARE(>=, 1, 7, 0)
 	time.set_time(cloud->header.stamp / 1000000U, cloud->header.stamp % 1000000);
@@ -188,83 +165,13 @@ get_time(const pcl::PointCloud<PointT> &cloud, fawkes::Time &time)
 #endif
 }
 
-/** Get time of a point cloud as a fawkes::Time instance.
- * This uses the PointCloudTimestamp struct to set the time in the PCL
- * timestamp field (if non-ROS PCL is used).
- * @param cloud cloud of which to get the time
- * @param time upon return contains the timestamp of the cloud
- */
-template <typename PointT>
-inline void
-get_time(const boost::shared_ptr<pcl::PointCloud<PointT>> &cloud, fawkes::Time &time)
-{
-#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
-	time.set_time(cloud->header.stamp / 1000000U, cloud->header.stamp % 1000000);
-#else
-#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
-	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
-#	else
-	PointCloudTimestamp pclts;
-	pclts.timestamp = cloud->header.stamp;
-	time.set_time(pclts.time.sec, pclts.time.usec);
-#	endif
-#endif
-}
-
-/** Get time of a point cloud as a fawkes::Time instance.
- * This uses the PointCloudTimestamp struct to set the time in the PCL
- * timestamp field (if non-ROS PCL is used).
- * @param cloud cloud of which to get the time
- * @param time upon return contains the timestamp of the cloud
- */
-template <typename PointT>
-inline void
-get_time(const boost::shared_ptr<const pcl::PointCloud<PointT>> &cloud, fawkes::Time &time)
-{
-#if PCL_VERSION_COMPARE(>=, 1, 7, 0)
-	time.set_time(cloud->header.stamp / 1000000U, cloud->header.stamp % 1000000);
-#else
-#	if defined(HAVE_ROS_PCL) || defined(ROSCPP_TYPES_H)
-	time.set_time(cloud->header.stamp.sec, cloud->header.stamp.nsec / 1000);
-#	else
-	PointCloudTimestamp pclts;
-	pclts.timestamp = cloud->header.stamp;
-	time.set_time(pclts.time.sec, pclts.time.usec);
-#	endif
-#endif
-}
-
 /** Copy time from one point cloud to another.
  * @param from point cloud to copy time from
  * @param to point cloud to copy time to
  */
-template <typename PointT1, typename PointT2>
+template <typename CloudPtrT, typename PointT2>
 inline void
-copy_time(fawkes::RefPtr<const pcl::PointCloud<PointT1>> &from,
-          fawkes::RefPtr<pcl::PointCloud<PointT2>> &      to)
-{
-	to->header.stamp = from->header.stamp;
-}
-
-/** Copy time from one point cloud to another.
- * @param from point cloud to copy time from
- * @param to point cloud to copy time to
- */
-template <typename PointT1, typename PointT2>
-inline void
-copy_time(boost::shared_ptr<const pcl::PointCloud<PointT1>> &from,
-          fawkes::RefPtr<pcl::PointCloud<PointT2>> &         to)
-{
-	to->header.stamp = from->header.stamp;
-}
-
-/** Copy time from one point cloud to another.
- * @param from point cloud to copy time from
- * @param to point cloud to copy time to
- */
-template <typename PointT1, typename PointT2>
-inline void
-copy_time(const pcl::PointCloud<PointT1> &from, pcl::PointCloud<PointT2> &to)
+copy_time(const CloudPtrT &from, fawkes::RefPtr<pcl::PointCloud<PointT2>> &to)
 {
 	to->header.stamp = from->header.stamp;
 }
@@ -279,11 +186,10 @@ copy_time(const pcl::PointCloud<PointT1> &from, pcl::PointCloud<PointT2> &to)
 struct PointCloudNonDeleter
 {
 	/** Delete operator that does nothing.
-   * @param t object to destroy
    */
 	template <typename T>
 	void
-	operator()(T *t)
+	operator()(T *)
 	{
 	}
 };
@@ -292,14 +198,14 @@ template <typename PointT>
 typename pcl::PointCloud<PointT>::Ptr
 cloudptr_from_refptr(const fawkes::RefPtr<pcl::PointCloud<PointT>> &in)
 {
-	return boost::shared_ptr<pcl::PointCloud<PointT>>(*in, PointCloudNonDeleter());
+	return typename pcl::PointCloud<PointT>::Ptr(*in, PointCloudNonDeleter());
 }
 
 template <typename PointT>
 typename pcl::PointCloud<PointT>::ConstPtr
 cloudptr_from_refptr(const fawkes::RefPtr<const pcl::PointCloud<PointT>> &in)
 {
-	return boost::shared_ptr<const pcl::PointCloud<PointT>>(*in, PointCloudNonDeleter());
+	return typename pcl::PointCloud<PointT>::ConstPtr(*in, PointCloudNonDeleter());
 }
 
 } // namespace pcl_utils

--- a/src/libs/pcl_utils/utils.h
+++ b/src/libs/pcl_utils/utils.h
@@ -22,6 +22,8 @@
 #ifndef _LIBS_PCL_UTILS_UTILS_H_
 #define _LIBS_PCL_UTILS_UTILS_H_
 
+#include "compatibility.h"
+
 #include <config/config.h>
 #include <core/utils/refptr.h>
 #include <pcl/console/print.h>

--- a/src/libs/protoboard/protobuf_thread.cpp
+++ b/src/libs/protoboard/protobuf_thread.cpp
@@ -31,6 +31,7 @@
 
 using namespace google::protobuf;
 using namespace protobuf_comm;
+using namespace boost::placeholders;
 
 namespace protoboard {
 

--- a/src/libs/protobuf_clips/communicator.cpp
+++ b/src/libs/protobuf_clips/communicator.cpp
@@ -46,6 +46,7 @@
 
 using namespace google::protobuf;
 using namespace protobuf_comm;
+using namespace boost::placeholders;
 
 namespace protobuf_clips {
 

--- a/src/libs/protobuf_comm/peer.cpp
+++ b/src/libs/protobuf_comm/peer.cpp
@@ -41,6 +41,7 @@
 
 using namespace boost::asio;
 using namespace boost::system;
+using namespace boost::placeholders;
 
 namespace protobuf_comm {
 

--- a/src/libs/utils/sub_process/proc.cpp
+++ b/src/libs/utils/sub_process/proc.cpp
@@ -23,7 +23,7 @@
 
 #include <core/exception.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #ifdef HAVE_LIBDAEMON
 #	include <libdaemon/dfork.h>

--- a/src/plugins/gazebo/gazsim-comm/gazsim_comm_thread.cpp
+++ b/src/plugins/gazebo/gazsim-comm/gazsim_comm_thread.cpp
@@ -33,6 +33,7 @@
 
 using namespace fawkes;
 using namespace protobuf_comm;
+using namespace boost::placeholders;
 
 /** @class GazsimCommThread "clips_thread.h"
  * Plugin simulates and manages communication for Simulation in Gazebo

--- a/src/plugins/imu/imu_cruizcore_xg1010.cpp
+++ b/src/plugins/imu/imu_cruizcore_xg1010.cpp
@@ -30,7 +30,7 @@
 #endif
 #include <utils/time/tracker_macros.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/plugins/perception/pcl-db/pcl_db_merge_pipeline.h
+++ b/src/plugins/perception/pcl-db/pcl_db_merge_pipeline.h
@@ -485,7 +485,7 @@ private: // methods
 		//pcl::console::VERBOSITY_LEVEL old_level = pcl::console::getVerbosityLevel();
 		//pcl::console::setVerbosityLevel(pcl::console::L_DEBUG);
 		pcl::IterativeClosestPoint<PointType, PointType> icp;
-		icp.setInputCloud(source);
+		icp.setInputSource(source);
 		icp.setInputTarget(target);
 
 		icp.setRANSACIterations(cfg_icp_ransac_iterations_);

--- a/src/plugins/robot-memory/computables/computables_manager.h
+++ b/src/plugins/robot-memory/computables/computables_manager.h
@@ -28,7 +28,7 @@
 #include <aspect/configurable.h>
 #include <aspect/logging.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <map>
 #include <mongocxx/client.hpp>
 #include <tuple>
@@ -42,6 +42,8 @@ namespace fawkes {
 class TimeTracker;
 #endif
 } // namespace fawkes
+
+using namespace boost::placeholders;
 
 class ComputablesManager
 {

--- a/src/plugins/robot-memory/event_trigger_manager.h
+++ b/src/plugins/robot-memory/event_trigger_manager.h
@@ -32,7 +32,7 @@
 #include <plugins/mongodb/aspect/mongodb_conncreator.h>
 #include <plugins/mongodb/utils.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <list>
 
@@ -41,6 +41,8 @@ namespace fawkes {
 class TimeTracker;
 #endif
 } // namespace fawkes
+
+using namespace boost::placeholders;
 
 class EventTriggerManager
 {

--- a/src/tools/laser_calibration/laser_calibration.cpp
+++ b/src/tools/laser_calibration/laser_calibration.cpp
@@ -212,7 +212,7 @@ LaserCalibration::get_matching_cost(PointCloudPtr cloud1, PointCloudPtr cloud2, 
 		throw InsufficientDataException(error.str().c_str());
 	}
 	pcl::IterativeClosestPoint<Point, Point> icp;
-	icp.setInputCloud(cloud2);
+	icp.setInputSource(cloud2);
 	icp.setInputTarget(cloud1);
 	PointCloud final;
 	icp.align(final);


### PR DESCRIPTION
main thing is that with boost 1.73, the `boost::bind` placeholders `_1`, `_2` etc. aren't declared in the global namespace any more. One has to be `using namespace boost::placeholders` to make them available. PCL 1.11 fixes some related issues (1.9 doesn't compile against boost 1.73), but also brings some other API changes, mainly eliminating `boost::shared_ptr` completely from the PCL API. They've had a `pcl::shared_ptr` typedef for a while, so using that should maximize compatibility.