### PR TITLE
Switch to Fedora 32

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ merged-pr-plugin: &merged-pr-plugin
     mode: checkout
 
 docker-plugin-base: &docker-plugin-base
-  image: fawkesrobotics/fawkes-builder:fedora31-melodic
+  image: fawkesrobotics/fawkes-builder:fedora32-noetic
   always-pull: true
   debug: true
   environment: ["BUILDKITE", "BUILDKITE_LABEL"]

--- a/etc/buildsys/cgal.mk
+++ b/etc/buildsys/cgal.mk
@@ -38,7 +38,7 @@ ifeq ($(CGAL_HAVE_BOOST_LIBS),1)
         # Disable this runtime check since it fails when using valgrind
         CFLAGS_CGAL += -DCGAL_DISABLE_ROUNDING_MATH_CHECK
 
-        LDFLAGS_CGAL:=-lCGAL -lCGAL_Core -lgmp -lmpfr -lm \
+        LDFLAGS_CGAL:=-lgmp -lmpfr -lm \
 		      $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))
 
         ifeq ($(CC),clang)

--- a/etc/buildsys/cgal.mk
+++ b/etc/buildsys/cgal.mk
@@ -42,7 +42,7 @@ ifeq ($(CGAL_HAVE_BOOST_LIBS),1)
         else
           CGAL_VERSION_HEADER=$(SYSROOT)/usr/include/CGAL/version.h
         endif
-        CGAL_VERSION=$(shell grep -oP "CGAL_VERSION\s+\K.*" $(CGAL_VERSION_HEADER))
+        CGAL_VERSION=$(shell sed -n -e 's/.*CGAL_VERSION[[:space:]]\(.*\)/\1/p' $(CGAL_VERSION_HEADER))
         CGAL_VERSION_SPLITTED=$(call split,.,$(CGAL_VERSION))
         CGAL_VERSION_MAJOR=$(word 1,$(CGAL_VERSION_SPLITTED))
         CGAL_VERSION_MINOR=$(word 2,$(CGAL_VERSION_SPLITTED))

--- a/etc/buildsys/fvconf.mk
+++ b/etc/buildsys/fvconf.mk
@@ -117,6 +117,10 @@ ifeq ($(HAVE_OPENCV),1)
   VERSION_SPLITTED_OPENCV = $(call split,.,$(VERSION_OPENCV))
   VERSION_MAJOR_OPENCV    = $(word 1,$(VERSION_SPLITTED_OPENCV))
   VERSION_MINOR_OPENCV    = $(word 2,$(VERSION_SPLITTED_OPENCV))
+  ifeq ($(VERSION_MAJOR_OPENCV),4)
+    # We do not support opencv4 yet.
+    HAVE_OPENCV=0
+  endif
   CFLAGS_OPENCV      = -DHAVE_OPENCV -Wno-deprecated-declarations \
 		       $(shell $(PKGCONFIG) --cflags 'opencv$(OPENCV_VERSION_SUFFIX)') \
 		       $(CFLAG_W_NO_UNUSED_LOCAL_TYPEDEFS)

--- a/src/libs/aspect/blocked_timing.cpp
+++ b/src/libs/aspect/blocked_timing.cpp
@@ -25,6 +25,8 @@
 #include <core/exception.h>
 #include <core/threading/thread.h>
 
+#include <stdexcept>
+
 namespace fawkes {
 
 /** @class BlockedTimingAspect <aspect/blocked_timing.h>

--- a/src/libs/blackboard/blackboard.h
+++ b/src/libs/blackboard/blackboard.h
@@ -258,8 +258,8 @@ operator|(const BlackBoard::ListenerRegisterFlag &a, const BlackBoard::ListenerR
  * @param b flags to test for
  * @return resulting flags
  */
-inline BlackBoard::ListenerRegisterFlag operator&(const BlackBoard::ListenerRegisterFlag &a,
-                                                  const BlackBoard::ListenerRegisterFlag &b)
+inline BlackBoard::ListenerRegisterFlag
+operator&(const BlackBoard::ListenerRegisterFlag &a, const BlackBoard::ListenerRegisterFlag &b)
 {
 	return (BlackBoard::ListenerRegisterFlag)((int)a & (int)b);
 }

--- a/src/libs/blackboard/internal/memory_manager.cpp
+++ b/src/libs/blackboard/internal/memory_manager.cpp
@@ -1015,7 +1015,8 @@ BlackBoardMemoryManager::ChunkIterator::operator!=(const ChunkIterator &c) const
  * points to.
  * @return pointer to memory
  */
-void *BlackBoardMemoryManager::ChunkIterator::operator*() const
+void *
+BlackBoardMemoryManager::ChunkIterator::operator*() const
 {
 	if (cur_ == NULL)
 		return NULL;

--- a/src/libs/config/yaml_node.h
+++ b/src/libs/config/yaml_node.h
@@ -424,7 +424,8 @@ public:
 		return this->name_ < n.name_;
 	}
 
-	std::shared_ptr<YamlConfigurationNode> operator[](const std::string &p)
+	std::shared_ptr<YamlConfigurationNode>
+	operator[](const std::string &p)
 	{
 		std::map<std::string, std::shared_ptr<YamlConfigurationNode>>::iterator i;
 		if ((i = children_.find(p)) != children_.end()) {

--- a/src/libs/core/exception.cpp
+++ b/src/libs/core/exception.cpp
@@ -770,7 +770,8 @@ Exception::iterator::operator!=(const iterator &i) const
  * Get message at current position. Returns NULL for the invalid ieterator.
  * @return message or NULL if iterator is invalid
  */
-const char *Exception::iterator::operator*() const
+const char *
+Exception::iterator::operator*() const
 {
 	if (mlist != NULL) {
 		return mlist->msg;

--- a/src/libs/core/macros.h
+++ b/src/libs/core/macros.h
@@ -22,64 +22,64 @@
  */
 
 #ifndef _CORE_MACROS_H_
-#	define _CORE_MACROS_H_
+#define _CORE_MACROS_H_
 
 // from http://blog.rlove.org/2005_10_01_archive.html
 // Note that __GNUC__ is also set appropriately by the Intel compiler
-#	if __GNUC__ >= 3
-#		ifndef __inline
-#			define __inline inline __attribute__((__always_inline__))
-#		endif
-#		ifndef __pure
-#			define __pure __attribute__((__pure__))
-#		endif
-#		define __const_ __attribute__((__const__))
-#		define __noreturn __attribute__((__noreturn__))
-#		define __malloc __attribute__((__malloc__))
-#		define __must_check __attribute__((__warn_unused_result__))
-#		ifndef __deprecated
-#			define __deprecated __attribute__((__deprecated__))
-#		endif
-#		ifndef __used
-#			define __used __attribute__((__used__))
-#		endif
-#		ifndef __unused
-#			define __unused __attribute__((__unused__))
-#		endif
-#		ifndef __packed
-#			define __packed __attribute__((__packed__))
-#		endif
-#		ifndef __aligned
-#			define __aligned(x) __attribute__((__aligned__(x)))
-#		endif
-#		define likely(x) __builtin_expect(!!(x), 1)
-#		define unlikely(x) __builtin_expect(!!(x), 0)
-#	else
-#		ifndef __inline
-#			define __inline /* no inline */
-#		endif
-#		ifndef __pure
-#			define __pure /* no pure */
-#		endif
-#		define __const_     /* no const */
-#		define __noreturn   /* no noreturn */
-#		define __malloc     /* no malloc */
-#		define __must_check /* no warn_unused_result */
-#		define __deprecated /* no deprecated */
-#		ifndef __used
-#			define __used /* no used */
-#		endif
-#		ifndef __unused
-#			define __unused /* no unused */
-#		endif
-#		ifndef __packed
-#			define __packed /* no packed */
-#		endif
-#		ifndef __aligned
-#			define __aligned(x) /* no align */
-#		endif
-#		define likely(x) (x)
-#		define unlikely(x) (x)
+#if __GNUC__ >= 3
+#	ifndef __inline
+#		define __inline inline __attribute__((__always_inline__))
 #	endif
+#	ifndef __pure
+#		define __pure __attribute__((__pure__))
+#	endif
+#	define __const_ __attribute__((__const__))
+#	define __noreturn __attribute__((__noreturn__))
+#	define __malloc __attribute__((__malloc__))
+#	define __must_check __attribute__((__warn_unused_result__))
+#	ifndef __deprecated
+#		define __deprecated __attribute__((__deprecated__))
+#	endif
+#	ifndef __used
+#		define __used __attribute__((__used__))
+#	endif
+#	ifndef __unused
+#		define __unused __attribute__((__unused__))
+#	endif
+#	ifndef __packed
+#		define __packed __attribute__((__packed__))
+#	endif
+#	ifndef __aligned
+#		define __aligned(x) __attribute__((__aligned__(x)))
+#	endif
+#	define likely(x) __builtin_expect(!!(x), 1)
+#	define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+#	ifndef __inline
+#		define __inline /* no inline */
+#	endif
+#	ifndef __pure
+#		define __pure /* no pure */
+#	endif
+#	define __const_     /* no const */
+#	define __noreturn   /* no noreturn */
+#	define __malloc     /* no malloc */
+#	define __must_check /* no warn_unused_result */
+#	define __deprecated /* no deprecated */
+#	ifndef __used
+#		define __used /* no used */
+#	endif
+#	ifndef __unused
+#		define __unused /* no unused */
+#	endif
+#	ifndef __packed
+#		define __packed /* no packed */
+#	endif
+#	ifndef __aligned
+#		define __aligned(x) /* no align */
+#	endif
+#	define likely(x) (x)
+#	define unlikely(x) (x)
+#endif
 
 #endif

--- a/src/libs/core/utils/circular_buffer.h
+++ b/src/libs/core/utils/circular_buffer.h
@@ -124,7 +124,8 @@ public:
    * @param n position of the element
    * @return reference to the n-th element
    */
-	const Type &operator[](size_type n) const
+	const Type &
+	operator[](size_type n) const
 	{
 		return deque_[n];
 	}

--- a/src/libs/core/utils/lock_hashmap.h
+++ b/src/libs/core/utils/lock_hashmap.h
@@ -157,8 +157,8 @@ LockHashMap<KeyType, ValueType, HashFunction, EqualKey>::mutex() const
  */
 template <typename KeyType, typename ValueType, class HashFunction, typename EqualKey>
 LockHashMap<KeyType, ValueType, HashFunction, EqualKey> &
-LockHashMap<KeyType, ValueType, HashFunction, EqualKey>::
-operator=(const LockHashMap<KeyType, ValueType, HashFunction, EqualKey> &ll)
+LockHashMap<KeyType, ValueType, HashFunction, EqualKey>::operator=(
+  const LockHashMap<KeyType, ValueType, HashFunction, EqualKey> &ll)
 {
 	mutex_->lock();
 	ll.lock();

--- a/src/libs/core/utils/lock_hashset.h
+++ b/src/libs/core/utils/lock_hashset.h
@@ -169,8 +169,8 @@ LockHashSet<KeyType, HashFunction, EqualKey>::mutex() const
  */
 template <typename KeyType, class HashFunction, class EqualKey>
 LockHashSet<KeyType, HashFunction, EqualKey> &
-LockHashSet<KeyType, HashFunction, EqualKey>::
-operator=(const LockHashSet<KeyType, HashFunction, EqualKey> &ll)
+LockHashSet<KeyType, HashFunction, EqualKey>::operator=(
+  const LockHashSet<KeyType, HashFunction, EqualKey> &ll)
 {
 	mutex_->lock();
 	ll.lock();

--- a/src/libs/core/utils/lock_multimap.h
+++ b/src/libs/core/utils/lock_multimap.h
@@ -146,8 +146,8 @@ LockMultiMap<KeyType, ValueType, LessKey>::mutex() const
  */
 template <typename KeyType, typename ValueType, typename LessKey>
 LockMultiMap<KeyType, ValueType, LessKey> &
-LockMultiMap<KeyType, ValueType, LessKey>::
-operator=(const LockMultiMap<KeyType, ValueType, LessKey> &ll)
+LockMultiMap<KeyType, ValueType, LessKey>::operator=(
+  const LockMultiMap<KeyType, ValueType, LessKey> &ll)
 {
 	mutex_->lock();
 	ll.lock();

--- a/src/libs/core/utils/lockptr.h
+++ b/src/libs/core/utils/lockptr.h
@@ -297,13 +297,15 @@ private:
 // If it would come after them it wouldn't be inlined.
 
 template <class T_CppObject>
-inline T_CppObject *LockPtr<T_CppObject>::operator->() const
+inline T_CppObject *
+LockPtr<T_CppObject>::operator->() const
 {
 	return cpp_object_;
 }
 
 template <class T_CppObject>
-inline T_CppObject *LockPtr<T_CppObject>::operator*() const
+inline T_CppObject *
+LockPtr<T_CppObject>::operator*() const
 {
 	return cpp_object_;
 }

--- a/src/libs/core/utils/refptr.h
+++ b/src/libs/core/utils/refptr.h
@@ -257,13 +257,15 @@ private:
 // If it would come after them it wouldn't be inlined.
 
 template <class T_CppObject>
-inline T_CppObject *RefPtr<T_CppObject>::operator->() const
+inline T_CppObject *
+RefPtr<T_CppObject>::operator->() const
 {
 	return cpp_object_;
 }
 
 template <class T_CppObject>
-inline T_CppObject *RefPtr<T_CppObject>::operator*() const
+inline T_CppObject *
+RefPtr<T_CppObject>::operator*() const
 {
 	return cpp_object_;
 }

--- a/src/libs/fvcams/control/sony_evid100p.cpp
+++ b/src/libs/fvcams/control/sony_evid100p.cpp
@@ -137,7 +137,6 @@ SonyEviD100PControl::~SonyEviD100PControl()
 }
 
 /** Open visca device.
- * @return true on success
  */
 void
 SonyEviD100PControl::open()

--- a/src/libs/fvmodels/scanlines/beams.cpp
+++ b/src/libs/fvmodels/scanlines/beams.cpp
@@ -92,12 +92,14 @@ ScanlineBeams::ScanlineBeams(unsigned int image_width,
 	reset();
 }
 
-upoint_t ScanlineBeams::operator*()
+upoint_t
+ScanlineBeams::operator*()
 {
 	return coord;
 }
 
-upoint_t *ScanlineBeams::operator->()
+upoint_t *
+ScanlineBeams::operator->()
 {
 	return &coord;
 }

--- a/src/libs/fvmodels/scanlines/cornerhorizon.cpp
+++ b/src/libs/fvmodels/scanlines/cornerhorizon.cpp
@@ -105,12 +105,14 @@ CornerHorizon::~CornerHorizon()
 	delete model;
 }
 
-upoint_t CornerHorizon::operator*()
+upoint_t
+CornerHorizon::operator*()
 {
 	return coord;
 }
 
-upoint_t *CornerHorizon::operator->()
+upoint_t *
+CornerHorizon::operator->()
 {
 	return &coord;
 }

--- a/src/libs/fvmodels/scanlines/grid.cpp
+++ b/src/libs/fvmodels/scanlines/grid.cpp
@@ -64,12 +64,14 @@ ScanlineGrid::~ScanlineGrid()
 	delete this->roi;
 }
 
-upoint_t ScanlineGrid::operator*()
+upoint_t
+ScanlineGrid::operator*()
 {
 	return coord;
 }
 
-upoint_t *ScanlineGrid::operator->()
+upoint_t *
+ScanlineGrid::operator->()
 {
 	return &coord;
 }

--- a/src/libs/fvmodels/scanlines/line_grid.cpp
+++ b/src/libs/fvmodels/scanlines/line_grid.cpp
@@ -73,12 +73,14 @@ ScanlineLineGrid::~ScanlineLineGrid()
 	delete roi_;
 }
 
-upoint_t ScanlineLineGrid::operator*()
+upoint_t
+ScanlineLineGrid::operator*()
 {
 	return *cur_;
 }
 
-upoint_t *ScanlineLineGrid::operator->()
+upoint_t *
+ScanlineLineGrid::operator->()
 {
 	return &*cur_;
 }

--- a/src/libs/fvmodels/scanlines/radial.cpp
+++ b/src/libs/fvmodels/scanlines/radial.cpp
@@ -74,12 +74,14 @@ ScanlineRadial::ScanlineRadial(unsigned int width,
 	reset();
 }
 
-upoint_t ScanlineRadial::operator*()
+upoint_t
+ScanlineRadial::operator*()
 {
 	return coord;
 }
 
-upoint_t *ScanlineRadial::operator->()
+upoint_t *
+ScanlineRadial::operator->()
 {
 	return &coord;
 }

--- a/src/libs/fvmodels/scanlines/star.cpp
+++ b/src/libs/fvmodels/scanlines/star.cpp
@@ -101,12 +101,14 @@ ScanlineStar::~ScanlineStar()
 	}
 }
 
-upoint_t ScanlineStar::operator*()
+upoint_t
+ScanlineStar::operator*()
 {
 	return m_current_point;
 }
 
-upoint_t *ScanlineStar::operator->()
+upoint_t *
+ScanlineStar::operator->()
 {
 	return &m_current_point;
 }

--- a/src/libs/interface/field_iterator.cpp
+++ b/src/libs/interface/field_iterator.cpp
@@ -162,7 +162,8 @@ InterfaceFieldIterator::operator!=(const InterfaceFieldIterator &fi) const
 /** Get FieldHeader.
  * @return shared memory header
  */
-const void *InterfaceFieldIterator::operator*() const
+const void *
+InterfaceFieldIterator::operator*() const
 {
 	if (infol_ == NULL) {
 		throw NullPointerException("Cannot get value of end element");

--- a/src/libs/interface/message_queue.cpp
+++ b/src/libs/interface/message_queue.cpp
@@ -121,7 +121,6 @@ MessageQueue::append(Message *msg)
 /** Enqueue message after given iterator.
  * @param it Iterator
  * @param msg Message to enqueue
- * @return message queue id of the appended message.
  * @exception NullPointerException thrown if iterator is end iterator.
  * @exception NotLockedException thrown if message queue is not locked during this operation.
  * @exception MessageAlreadyQueuedException thrown if the message has already been

--- a/src/libs/interface/message_queue.cpp
+++ b/src/libs/interface/message_queue.cpp
@@ -462,7 +462,8 @@ MessageQueue::MessageIterator::operator!=(const MessageIterator &c) const
  * points to.
  * @return pointer to memory
  */
-Message *MessageQueue::MessageIterator::operator*() const
+Message *
+MessageQueue::MessageIterator::operator*() const
 {
 	return (cur != NULL) ? cur->msg : NULL;
 }
@@ -471,7 +472,8 @@ Message *MessageQueue::MessageIterator::operator*() const
  * Node that you have to make sure that this is not called on the end node!
  * @return current message
  */
-Message *MessageQueue::MessageIterator::operator->() const
+Message *
+MessageQueue::MessageIterator::operator->() const
 {
 	return cur->msg;
 }

--- a/src/libs/pcl_utils/storage_adapter.h
+++ b/src/libs/pcl_utils/storage_adapter.h
@@ -102,50 +102,94 @@ public:
 		return pcl_utils::cloudptr_from_refptr(cloud);
 	}
 
+	/** Clone this storage adapter.
+   * @return A pointer to a copy of this storage adapter.
+   */
 	virtual StorageAdapter *clone() const;
 
+	/** Transform the point cloud.
+   * @param target_frame frame to transform to
+   * @param transformer transformer to get transform from
+   */
 	virtual void transform(const std::string &target_frame, const tf::Transformer &transformer);
 
+	/** Transform point cloud.
+   *  @param target_frame frame to transform to
+   *  @param target_time time for which to transform
+   *  @param fixed_frame frame fixed over time
+   *  @param transformer transformer to get transform from
+   */
 	virtual void transform(const std::string &    target_frame,
 	                       const Time &           target_time,
 	                       const std::string &    fixed_frame,
 	                       const tf::Transformer &transformer);
 
+	/** Get typename of storage adapter.
+  * @return type name
+  */
 	virtual const char *
 	get_typename()
 	{
 		return typeid(this).name();
 	}
+
+	/** Get size of a point.
+   * @return size in bytes of a single point
+   */
 	virtual size_t
 	point_size() const
 	{
 		return sizeof(PointT);
 	}
+
+	/** Get width of point cloud.
+   * @return width of point cloud
+   */
 	virtual unsigned int
 	width() const
 	{
 		return cloud->width;
 	}
+
+	/** Get height of point cloud.
+   * @return height of point cloud
+   */
 	virtual unsigned int
 	height() const
 	{
 		return cloud->height;
 	}
+
+	/** Get numer of points in point cloud.
+   * @return number of points
+   */
 	virtual size_t
 	num_points() const
 	{
 		return cloud->points.size();
 	}
+
+	/** Get pointer on data.
+  * @return pointer on data
+  */
 	virtual void *
 	data_ptr() const
 	{
 		return &cloud->points[0];
 	}
+
+	/** Get frame ID of point cloud.
+   * @return Frame ID of point cloud.
+   */
 	virtual std::string
 	frame_id() const
 	{
 		return cloud->header.frame_id;
 	}
+
+	/** Get last capture time.
+   * @param time upon return contains last capture time
+   */
 	virtual void get_time(fawkes::Time &time) const;
 };
 

--- a/src/libs/protoboard/blackboard_manager.h
+++ b/src/libs/protoboard/blackboard_manager.h
@@ -122,7 +122,7 @@ public:
 
 	/** Go through all interface managers, empty all blackboard message queues and send out
 	 * ProtoBuf messages accordingly.
-	 * @return whether anything was sent */
+   */
 	virtual void process_sending_interfaces() = 0;
 
 	/// Deferred initialization, coincides with the main thread.
@@ -147,7 +147,7 @@ protected:
 		 * @tparam IfaceT the interface type handled by the interface manager
 		 * @tparam MessageT the current
 		 * @param iface_mgr a bb_iface_manager for a specific message type
-		 * @return Whether any ProtoBuf message was sent */
+     */
 		template <class IfaceT, class MessageT>
 		void operator()(const bb_iface_manager<IfaceT, type_list<MessageT>> &iface_mgr) const;
 
@@ -157,7 +157,7 @@ protected:
 		 * @tparam MessageT1 First message type in the list
 		 * @tparam MessageTs Remaining message types
 		 * @param iface_mgr a bb_iface_manager with a list of message type to go through
-		 * @return Whether any ProtoBuf message was sent */
+		 */
 		template <class IfaceT, class MessageT1, class... MessageTs>
 		void
 		operator()(const bb_iface_manager<IfaceT, type_list<MessageT1, MessageTs...>> &iface_mgr) const;

--- a/src/libs/protoboard/blackboard_manager.h
+++ b/src/libs/protoboard/blackboard_manager.h
@@ -293,16 +293,16 @@ ProtobufSender<IfaceManagerTs...>::finalize()
 
 template <class IfaceT, class MessageT>
 void
-AbstractProtobufSender::handle_messages::
-operator()(const bb_iface_manager<IfaceT, type_list<MessageT>> &pair) const
+AbstractProtobufSender::handle_messages::operator()(
+  const bb_iface_manager<IfaceT, type_list<MessageT>> &pair) const
 {
 	manager->handle_message_type<MessageT>(pair.interface());
 }
 
 template <class IfaceT, class MessageT1, class... MessageTs>
 void
-AbstractProtobufSender::handle_messages::
-operator()(const bb_iface_manager<IfaceT, type_list<MessageT1, MessageTs...>> &iface_mgr) const
+AbstractProtobufSender::handle_messages::operator()(
+  const bb_iface_manager<IfaceT, type_list<MessageT1, MessageTs...>> &iface_mgr) const
 {
 	BlackboardManager::on_interface<IfaceT>{iface_mgr.interface(), manager}
 	  .template handle_msg_types<MessageTs...>();

--- a/src/libs/protobuf_comm/message_register.h
+++ b/src/libs/protobuf_comm/message_register.h
@@ -77,8 +77,10 @@ public:
    * @param component_id ID of component this message type belongs to
    * @param msg_type message type
    */
-	template <class MT>
-	typename std::enable_if<std::is_base_of<google::protobuf::Message, MT>::value, void>::type
+	template <
+	  class MT,
+	  typename = typename std::enable_if<std::is_base_of<google::protobuf::Message, MT>::value>::type>
+	void
 	add_message_type(uint16_t component_id, uint16_t msg_type)
 	{
 		KeyType key(component_id, msg_type);
@@ -101,8 +103,11 @@ public:
    * The template parameter must be a sub-class of google::protobuf::Message.
    * An instance is spawned and kept internally to spawn more on incoming messages.
    */
-	template <class MT>
-	typename std::enable_if<std::is_base_of<google::protobuf::Message, MT>::value, void>::type
+	template <
+	  class MT,
+	  typename =
+	    typename std::enable_if<std::is_base_of<google::protobuf::Message, MT>::value, void>::type>
+	void
 	add_message_type()
 	{
 		MT                                  m;

--- a/src/libs/utils/ipc/shm.cpp
+++ b/src/libs/utils/ipc/shm.cpp
@@ -244,7 +244,7 @@ SharedMemory::SharedMemory(const char *magic_token,
 {
 	_magic_token = new char[MagicTokenSize];
 	memset(_magic_token, 0, MagicTokenSize);
-	strncpy(_magic_token, magic_token, MagicTokenSize);
+	strncpy(_magic_token, magic_token, MagicTokenSize - 1);
 
 	_is_read_only      = is_read_only;
 	_destroy_on_delete = destroy_on_delete;
@@ -280,7 +280,7 @@ SharedMemory::SharedMemory(const SharedMemory &s)
 {
 	_magic_token = new char[MagicTokenSize];
 	memset(_magic_token, 0, MagicTokenSize);
-	strncpy(_magic_token, s._magic_token, MagicTokenSize);
+	strncpy(_magic_token, s._magic_token, MagicTokenSize - 1);
 
 	_is_read_only      = s._is_read_only;
 	_destroy_on_delete = s._destroy_on_delete;
@@ -354,7 +354,7 @@ SharedMemory::SharedMemory(const char *        magic_token,
 {
 	_magic_token = new char[MagicTokenSize];
 	memset(_magic_token, 0, MagicTokenSize);
-	strncpy(_magic_token, magic_token, MagicTokenSize);
+	strncpy(_magic_token, magic_token, MagicTokenSize - 1);
 
 	_header            = header;
 	_is_read_only      = is_read_only;
@@ -437,7 +437,7 @@ SharedMemory::operator=(const SharedMemory &s)
 
 	_magic_token = new char[MagicTokenSize];
 	memset(_magic_token, 0, MagicTokenSize);
-	strncpy(_magic_token, s._magic_token, MagicTokenSize);
+	strncpy(_magic_token, s._magic_token, MagicTokenSize - 1);
 
 	_is_read_only      = s._is_read_only;
 	_destroy_on_delete = s._destroy_on_delete;
@@ -596,7 +596,7 @@ SharedMemory::attach()
 					_shm_offset             = 0;
 					shared_mem_upper_bound_ = _shm_upper_bound;
 
-					strncpy(_shm_magic_token, _magic_token, MagicTokenSize);
+					strncpy(_shm_magic_token, _magic_token, MagicTokenSize - 1);
 
 					_header->initialize((char *)shared_mem_ + MagicTokenSize + sizeof(SharedMemory_header_t));
 				} else {
@@ -1532,7 +1532,8 @@ SharedMemory::SharedMemoryIterator::operator!=(const SharedMemoryIterator &s) co
 /** Get SharedMemoryHeader.
  * @return shared memory header
  */
-const SharedMemoryHeader *SharedMemory::SharedMemoryIterator::operator*() const
+const SharedMemoryHeader *
+SharedMemory::SharedMemoryIterator::operator*() const
 {
 	return header_;
 }

--- a/src/libs/utils/misc/autofree.cpp
+++ b/src/libs/utils/misc/autofree.cpp
@@ -83,7 +83,8 @@ MemAutoFree::reset(void *new_ptr)
 /** Access memory pointer.
  * @return pointer to memory, maybe NULL
  */
-void *MemAutoFree::operator*() const
+void *
+MemAutoFree::operator*() const
 {
 	return ptr_;
 }

--- a/src/libs/utils/system/argparser.cpp
+++ b/src/libs/utils/system/argparser.cpp
@@ -245,7 +245,6 @@ ArgumentParser::parse_hostport(const char *argn, char **host, unsigned short int
  * @param host Upon successful return contains a pointer to a newly alloated string
  * with the hostname part. Free it after you are finished.
  * @param port upon successful return contains the port part
- * @return true, if the argument was supplied, false otherwise
  * @exception Exception thrown on parsing error
  */
 void
@@ -336,7 +335,6 @@ ArgumentParser::parse_hostport(const char *argn, std::string &host, unsigned sho
  * @param s string to parse
  * @param host Upon successful return contains the hostname part
  * @param port upon successful return contains the port part (unchanged if not supplied)
- * @return true, if the argument was supplied, false otherwise
  * @exception OutOfBoundsException thrown if port is not in the range [0..65535]
  */
 void

--- a/src/libs/utils/system/dynamic_module/module.cpp
+++ b/src/libs/utils/system/dynamic_module/module.cpp
@@ -79,7 +79,6 @@ Module::~Module()
 }
 
 /** Open the module
- * @return true if the module could be opened, false otherwise
  * @exception ModuleOpenException thrown if there was any problem
  * while loading the module
  */

--- a/src/libs/utils/time/time.cpp
+++ b/src/libs/utils/time/time.cpp
@@ -180,7 +180,7 @@ Time::Time(const Time &t)
 	clock_        = t.clock_;
 	if (t.timestr_) {
 		timestr_ = (char *)malloc(TIMESTR_SIZE);
-		strncpy(timestr_, t.timestr_, TIMESTR_SIZE);
+		strncpy(timestr_, t.timestr_, TIMESTR_SIZE - 1);
 	} else {
 		timestr_ = NULL;
 	}
@@ -196,7 +196,7 @@ Time::Time(const Time *t)
 	clock_        = t->clock_;
 	if (t->timestr_) {
 		timestr_ = (char *)malloc(TIMESTR_SIZE);
-		strncpy(timestr_, t->timestr_, TIMESTR_SIZE);
+		strncpy(timestr_, t->timestr_, TIMESTR_SIZE - 1);
 	} else {
 		timestr_ = NULL;
 	}

--- a/src/plugins/asp/aspect/clingo_control_manager.h
+++ b/src/plugins/asp/aspect/clingo_control_manager.h
@@ -25,6 +25,7 @@
 
 #include <core/utils/lockptr.h>
 
+#include <string>
 #include <unordered_map>
 
 namespace fawkes {

--- a/src/plugins/gazebo/gazebo.mk
+++ b/src/plugins/gazebo/gazebo.mk
@@ -32,7 +32,7 @@ ifeq ($(HAVE_GAZEBO),1)
   # Gazebo 8 declared several symbols as deprecated but still uses them.
   # Disable the deprecated declarations warning until this is fixed.
   CFLAGS_GAZEBO  = -DHAVE_GAZEBO $(shell $(PKGCONFIG) --cflags 'gazebo') \
-                   -Wno-deprecated-declarations
+                   -Wno-deprecated-declarations -DTBB_SUPPRESS_DEPRECATED_MESSAGES
   LDFLAGS_GAZEBO = $(shell $(PKGCONFIG) --libs 'gazebo') -ldl
 
   ifeq ($(HAVE_GAZEBO_96)$(boost-have-lib system),11)

--- a/src/plugins/gazebo/gazebo.mk
+++ b/src/plugins/gazebo/gazebo.mk
@@ -26,13 +26,18 @@ __buildsys_gazebo_mk_ := 1
 ifneq ($(PKGCONFIG),)
   HAVE_GAZEBO   = $(if $(shell $(PKGCONFIG) --atleast-version=1.0.1 'gazebo'; echo $${?/1/}),1,0)
   HAVE_GAZEBO_96 = $(if $(shell $(PKGCONFIG) --atleast-version=9.6.0 'gazebo'; echo $${?/1/}),1,0)
+  HAVE_GAZEBO_10 = $(if $(shell $(PKGCONFIG) --atleast-version=10 'gazebo'; echo $${?/1/}),1,0)
 endif
 
 ifeq ($(HAVE_GAZEBO),1)
-  # Gazebo 8 declared several symbols as deprecated but still uses them.
-  # Disable the deprecated declarations warning until this is fixed.
   CFLAGS_GAZEBO  = -DHAVE_GAZEBO $(shell $(PKGCONFIG) --cflags 'gazebo') \
-                   -Wno-deprecated-declarations -DTBB_SUPPRESS_DEPRECATED_MESSAGES
+                   -DTBB_SUPPRESS_DEPRECATED_MESSAGES
+  ifneq ($(HAVE_GAZEBO_101),1)
+    # Gazebo 8 declared several symbols as deprecated but still uses them.
+		# Those were fixed in Gazebo 10.
+    # Disable the deprecated declarations warning with older gazebo versions.
+    CFLAGS += -Wno-deprecated-declarations
+  endif
   LDFLAGS_GAZEBO = $(shell $(PKGCONFIG) --libs 'gazebo') -ldl
 
   ifeq ($(HAVE_GAZEBO_96)$(boost-have-lib system),11)

--- a/src/plugins/laser-filter/filters/deadspots.cpp
+++ b/src/plugins/laser-filter/filters/deadspots.cpp
@@ -81,7 +81,7 @@ LaserDeadSpotsDataFilter::LaserDeadSpotsDataFilter(const std::string &    filter
 	while (vit->next()) {
 		const char *path = vit->path();
 		if (regexec(&pathre, path, 2, matches, 0) == 0) {
-			unsigned int match1_length = matches[1].rm_eo - matches[1].rm_so;
+			size_t match1_length = matches[1].rm_eo - matches[1].rm_so;
 
 			char entry[match1_length + 1];
 			entry[match1_length] = 0;

--- a/src/plugins/openni/handtracker_thread.cpp
+++ b/src/plugins/openni/handtracker_thread.cpp
@@ -53,51 +53,51 @@ OpenNiHandTrackerThread::~OpenNiHandTrackerThread()
 }
 
 static void XN_CALLBACK_TYPE
-            cb_hand_create(xn::HandsGenerator &generator,
-                           XnUserID            user,
-                           const XnPoint3D *   position,
-                           XnFloat             time,
-                           void *              cookie)
+cb_hand_create(xn::HandsGenerator &generator,
+               XnUserID            user,
+               const XnPoint3D *   position,
+               XnFloat             time,
+               void *              cookie)
 {
 	OpenNiHandTrackerThread *t = static_cast<OpenNiHandTrackerThread *>(cookie);
 	t->hand_create(user, position, time);
 }
 
 static void XN_CALLBACK_TYPE
-            cb_hand_destroy(xn::HandsGenerator &generator, XnUserID user, XnFloat time, void *cookie)
+cb_hand_destroy(xn::HandsGenerator &generator, XnUserID user, XnFloat time, void *cookie)
 {
 	OpenNiHandTrackerThread *t = static_cast<OpenNiHandTrackerThread *>(cookie);
 	t->hand_destroy(user, time);
 }
 
 static void XN_CALLBACK_TYPE
-            cb_hand_update(xn::HandsGenerator &generator,
-                           XnUserID            user,
-                           const XnPoint3D *   position,
-                           XnFloat             time,
-                           void *              cookie)
+cb_hand_update(xn::HandsGenerator &generator,
+               XnUserID            user,
+               const XnPoint3D *   position,
+               XnFloat             time,
+               void *              cookie)
 {
 	OpenNiHandTrackerThread *t = static_cast<OpenNiHandTrackerThread *>(cookie);
 	t->hand_update(user, position, time);
 }
 
 static void XN_CALLBACK_TYPE
-            cb_gesture_recognized(xn::GestureGenerator &generator,
-                                  const XnChar *        gesture_name,
-                                  const XnPoint3D *     position,
-                                  const XnPoint3D *     end_position,
-                                  void *                cookie)
+cb_gesture_recognized(xn::GestureGenerator &generator,
+                      const XnChar *        gesture_name,
+                      const XnPoint3D *     position,
+                      const XnPoint3D *     end_position,
+                      void *                cookie)
 {
 	OpenNiHandTrackerThread *t = static_cast<OpenNiHandTrackerThread *>(cookie);
 	t->gesture_recognized(gesture_name, position, end_position);
 }
 
 static void XN_CALLBACK_TYPE
-            cb_gesture_progress(xn::GestureGenerator &generator,
-                                const XnChar *        gesture_name,
-                                const XnPoint3D *     position,
-                                XnFloat               progress,
-                                void *                cookie)
+cb_gesture_progress(xn::GestureGenerator &generator,
+                    const XnChar *        gesture_name,
+                    const XnPoint3D *     position,
+                    XnFloat               progress,
+                    void *                cookie)
 {
 	OpenNiHandTrackerThread *t = static_cast<OpenNiHandTrackerThread *>(cookie);
 	t->gesture_progress(gesture_name, position, progress);

--- a/src/plugins/openni/usertracker_thread.cpp
+++ b/src/plugins/openni/usertracker_thread.cpp
@@ -55,41 +55,41 @@ OpenNiUserTrackerThread::~OpenNiUserTrackerThread()
 }
 
 static void XN_CALLBACK_TYPE
-            cb_new_user(xn::UserGenerator &generator, XnUserID id, void *cookie)
+cb_new_user(xn::UserGenerator &generator, XnUserID id, void *cookie)
 {
 	OpenNiUserTrackerThread *t = static_cast<OpenNiUserTrackerThread *>(cookie);
 	t->new_user(id);
 }
 
 static void XN_CALLBACK_TYPE
-            cb_lost_user(xn::UserGenerator &generator, XnUserID id, void *cookie)
+cb_lost_user(xn::UserGenerator &generator, XnUserID id, void *cookie)
 {
 	OpenNiUserTrackerThread *t = static_cast<OpenNiUserTrackerThread *>(cookie);
 	t->lost_user(id);
 }
 
 static void XN_CALLBACK_TYPE
-            cb_pose_start(xn::PoseDetectionCapability &capability,
-                          const XnChar *               pose_name,
-                          XnUserID                     id,
-                          void *                       cookie)
+cb_pose_start(xn::PoseDetectionCapability &capability,
+              const XnChar *               pose_name,
+              XnUserID                     id,
+              void *                       cookie)
 {
 	OpenNiUserTrackerThread *t = static_cast<OpenNiUserTrackerThread *>(cookie);
 	t->pose_start(id, pose_name);
 }
 
 static void XN_CALLBACK_TYPE
-            cb_pose_end(xn::PoseDetectionCapability &capability,
-                        const XnChar *               pose_name,
-                        XnUserID                     id,
-                        void *                       cookie)
+cb_pose_end(xn::PoseDetectionCapability &capability,
+            const XnChar *               pose_name,
+            XnUserID                     id,
+            void *                       cookie)
 {
 	OpenNiUserTrackerThread *t = static_cast<OpenNiUserTrackerThread *>(cookie);
 	t->pose_end(id, pose_name);
 }
 
 static void XN_CALLBACK_TYPE
-            cb_calibration_start(xn::SkeletonCapability &capability, XnUserID id, void *cookie)
+cb_calibration_start(xn::SkeletonCapability &capability, XnUserID id, void *cookie)
 {
 	OpenNiUserTrackerThread *t = static_cast<OpenNiUserTrackerThread *>(cookie);
 	t->calibration_start(id);
@@ -97,17 +97,17 @@ static void XN_CALLBACK_TYPE
 
 #if XN_VERSION_GE(1, 3, 2, 0)
 static void XN_CALLBACK_TYPE
-            cb_calibration_complete(xn::SkeletonCapability &capability,
-                                    XnUserID                id,
-                                    XnCalibrationStatus     status,
-                                    void *                  cookie)
+cb_calibration_complete(xn::SkeletonCapability &capability,
+                        XnUserID                id,
+                        XnCalibrationStatus     status,
+                        void *                  cookie)
 {
 	OpenNiUserTrackerThread *t = static_cast<OpenNiUserTrackerThread *>(cookie);
 	t->calibration_end(id, status == XN_CALIBRATION_STATUS_OK);
 }
 #else
 static void XN_CALLBACK_TYPE
-            cb_calibration_end(xn::SkeletonCapability &capability, XnUserID id, XnBool success, void *cookie)
+cb_calibration_end(xn::SkeletonCapability &capability, XnUserID id, XnBool success, void *cookie)
 {
 	OpenNiUserTrackerThread *t = static_cast<OpenNiUserTrackerThread *>(cookie);
 	t->calibration_end(id, success);

--- a/src/plugins/openprs/mod_utils.h
+++ b/src/plugins/openprs/mod_utils.h
@@ -58,10 +58,10 @@ Symbol              wait_sym;
 typedef enum { LOGICAL_VARIABLE, PROGRAM_VARIABLE } Variable_Type;
 
 struct envar
-{                      /* Un envar */
-	Symbol        name;  /* son name */
-	Term *        value; /* le term sur lequel elle pointe */
-	Type *        unif_type;
+{                           /* Un envar */
+	Symbol             name;  /* son name */
+	Term *             value; /* le term sur lequel elle pointe */
+	Type *             unif_type;
 	Variable_Type type BITFIELDS( : 8); /* Le type de la variable */
 };
 

--- a/src/plugins/openrave/environment.cpp
+++ b/src/plugins/openrave/environment.cpp
@@ -199,7 +199,6 @@ OpenRaveEnvironment::disable_debug()
 
 /** Add a robot into the scene.
  * @param robot RobotBasePtr of robot to add
- * @return 1 if succeeded, 0 if not able to add robot
  */
 void
 OpenRaveEnvironment::add_robot(OpenRAVE::RobotBasePtr robot)
@@ -220,7 +219,6 @@ OpenRaveEnvironment::add_robot(OpenRAVE::RobotBasePtr robot)
 
 /** Add a robot into the scene.
  * @param filename path to robot's xml file
- * @return 1 if succeeded, 0 if not able to load file
  */
 void
 OpenRaveEnvironment::add_robot(const std::string &filename)
@@ -245,7 +243,6 @@ OpenRaveEnvironment::add_robot(const std::string &filename)
 
 /** Add a robot into the scene.
  * @param robot pointer to OpenRaveRobot object of robot to add
- * @return 1 if succeeded, 0 if not able to add robot
  */
 void
 OpenRaveEnvironment::add_robot(OpenRaveRobotPtr &robot)


### PR DESCRIPTION
Switch to Fedora 32 for the buildkite CI builds and apply the necessary changes for Fedora 32, in particular:
* Fix a number of documentation issues
* Use CGAL as header-only library if CGAL has version >= 5
* Reformat with the latest clang-format
* Disable opencv support if the opencv version is >= 4 (related to #191)
* Change the gazebo compile flags to avoid warnings about deprecated TBB functions, re-enable other warnings that have been fixed in gazebo