### PR TITLE
explicitly link pthread with boost::asio

### DIFF
--- a/src/libs/protobuf_comm/Makefile
+++ b/src/libs/protobuf_comm/Makefile
@@ -34,7 +34,7 @@ ifeq ($(HAVE_LIBCRYPTO),1)
   LDFLAGS_LIBCRYPTO += $(shell $(PKGCONFIG) --libs $(LIBCRYPTO_PKG))
 endif
 
-LIBS_libfawkes_protobuf_comm = stdc++ m
+LIBS_libfawkes_protobuf_comm = stdc++ m pthread
 OBJS_libfawkes_protobuf_comm = $(patsubst %.cpp,%.o,$(patsubst qa/%,,$(subst $(SRCDIR)/,,$(realpath $(wildcard $(SRCDIR)/*.cpp $(SRCDIR)/*/*.cpp $(SRCDIR)/*/*/*.cpp)))))
 HDRS_libfawkes_protobuf_comm = $(subst $(SRCDIR)/,,$(wildcard $(SRCDIR)/*.h $(SRCDIR)/*/*.h $(SRCDIR)/*/*/*.h))
 

--- a/src/plugins/gossip/aspect/Makefile
+++ b/src/plugins/gossip/aspect/Makefile
@@ -24,7 +24,7 @@ CFLAGS += $(CFLAGS_CPP11)
 REQ_BOOST_LIBS = asio system
 HAVE_BOOST_LIBS = $(call boost-have-libs,$(REQ_BOOST_LIBS))
 
-LIBS_libfawkesgossipaspect = stdc++ fawkescore fawkesaspects fawkesutils fawkesgossip
+LIBS_libfawkesgossipaspect = stdc++ pthread fawkescore fawkesaspects fawkesutils fawkesgossip
 OBJS_libfawkesgossipaspect = gossip.o gossip_inifin.o
 
 OBJS_all = $(OBJS_libfawkesgossipaspect)

--- a/src/plugins/gossip/gossip/Makefile
+++ b/src/plugins/gossip/gossip/Makefile
@@ -21,6 +21,7 @@ include $(BUILDSYSDIR)/boost.mk
 CFLAGS += $(CFLAGS_CPP11)
 
 LIBS_libfawkesgossip = \
+	pthread \
 	fawkescore fawkesutils fawkesnetcomm fawkes_protobuf_comm
 OBJS_libfawkesgossip = gossip_group.o gossip_group_manager.o
 


### PR DESCRIPTION
I've been merging this locally since around boost-1.70, but apparently no one else is seeing the issue?

So the issue is that on these libs/plugins, `-lpthread` was implicitly added before (through `boost::asio` I suspect), which it is not any more. So although no one else is experiencing this problem currently, it doesn't hurt to put it in and it should increase portability.