### PR TITLE
Adapt webview to updated libmicrohttpd

### DIFF
--- a/src/libs/webview/microhttpd_compat.h
+++ b/src/libs/webview/microhttpd_compat.h
@@ -2,7 +2,19 @@
  * microhttpd_compat.h
  * Copyright (C) 2020 Tarik Viehmann <viehmann@kbsg.rwth-aachen.de>
  *
- * Distributed under terms of the MIT license.
+ */
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
 #ifndef MICROHTTPD_COMPAT_H

--- a/src/libs/webview/microhttpd_compat.h
+++ b/src/libs/webview/microhttpd_compat.h
@@ -1,0 +1,17 @@
+/*
+ * microhttpd_compat.h
+ * Copyright (C) 2020 Tarik Viehmann <viehmann@kbsg.rwth-aachen.de>
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#ifndef MICROHTTPD_COMPAT_H
+#define MICROHTTPD_COMPAT_H
+#include <microhttpd.h>
+#if MHD_VERSION >= 0x00097002
+#	define MHD_RESULT MHD_Result
+#else
+#	define MHD_RESULT int
+#endif
+
+#endif /* !MICROHTTPD_COMPAT_H */

--- a/src/libs/webview/request.cpp
+++ b/src/libs/webview/request.cpp
@@ -19,6 +19,8 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
+#include "microhttpd_compat.h"
+
 #include <core/exception.h>
 #include <netinet/in.h>
 #include <sys/select.h>
@@ -26,14 +28,13 @@
 #include <webview/request.h>
 
 #include <cstring>
-#include <microhttpd.h>
 #include <stdint.h>
 #include <unistd.h>
 
 namespace fawkes {
 
 /// @cond INTERNAL
-static int
+static MHD_RESULT
 cookie_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
 {
 	WebRequest *request = static_cast<WebRequest *>(cls);
@@ -41,7 +42,7 @@ cookie_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const char 
 	return MHD_YES;
 }
 
-static int
+static MHD_RESULT
 get_argument_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
 {
 	WebRequest *request = static_cast<WebRequest *>(cls);
@@ -52,7 +53,7 @@ get_argument_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const
 	return MHD_YES;
 }
 
-static int
+static MHD_RESULT
 header_iterator(void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
 {
 	WebRequest *request = static_cast<WebRequest *>(cls);

--- a/src/libs/webview/request_dispatcher.cpp
+++ b/src/libs/webview/request_dispatcher.cpp
@@ -170,7 +170,7 @@ WebRequestDispatcher::process_request_cb(void *                 callback_data,
                                          const char *           method,
                                          const char *           version,
                                          const char *           upload_data,
-                                         long unsigned int *    upload_data_size,
+                                         size_t *               upload_data_size,
                                          void **                session_data)
 {
 	WebRequestDispatcher *rd = static_cast<WebRequestDispatcher *>(callback_data);

--- a/src/libs/webview/request_dispatcher.cpp
+++ b/src/libs/webview/request_dispatcher.cpp
@@ -19,6 +19,8 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
+#include "microhttpd_compat.h"
+
 #include <core/exception.h>
 #include <core/threading/mutex.h>
 #include <core/threading/mutex_locker.h>
@@ -36,7 +38,6 @@
 #include <cstdarg>
 #include <cstdlib>
 #include <cstring>
-#include <microhttpd.h>
 
 #define UNAUTHORIZED_REPLY                                         \
 	"<html>\n"                                                       \
@@ -162,14 +163,14 @@ WebRequestDispatcher::uri_log_cb(void *cls, const char *uri)
  * @param session_data session data pointer
  * @return appropriate return code for libmicrohttpd
  */
-int
+MHD_RESULT
 WebRequestDispatcher::process_request_cb(void *                 callback_data,
                                          struct MHD_Connection *connection,
                                          const char *           url,
                                          const char *           method,
                                          const char *           version,
                                          const char *           upload_data,
-                                         size_t *               upload_data_size,
+                                         long unsigned int *    upload_data_size,
                                          void **                session_data)
 {
 	WebRequestDispatcher *rd = static_cast<WebRequestDispatcher *>(callback_data);
@@ -267,7 +268,7 @@ WebRequestDispatcher::prepare_static_response(StaticWebReply *sreply)
  * @param sreply static reply
  * @return response struct ready to be enqueued
  */
-int
+MHD_RESULT
 WebRequestDispatcher::queue_dynamic_reply(struct MHD_Connection *connection,
                                           WebRequest *           request,
                                           DynamicWebReply *      dreply)
@@ -286,7 +287,7 @@ WebRequestDispatcher::queue_dynamic_reply(struct MHD_Connection *connection,
 		MHD_add_response_header(response, i->first.c_str(), i->second.c_str());
 	}
 
-	int ret = MHD_queue_response(connection, dreply->code(), response);
+	MHD_RESULT ret = MHD_queue_response(connection, dreply->code(), response);
 	MHD_destroy_response(response);
 
 	return ret;
@@ -298,7 +299,7 @@ WebRequestDispatcher::queue_dynamic_reply(struct MHD_Connection *connection,
  * @param sreply static web reply to queue
  * @return suitable libmicrohttpd return code
  */
-int
+MHD_RESULT
 WebRequestDispatcher::queue_static_reply(struct MHD_Connection *connection,
                                          WebRequest *           request,
                                          StaticWebReply *       sreply)
@@ -307,7 +308,7 @@ WebRequestDispatcher::queue_static_reply(struct MHD_Connection *connection,
 
 	struct MHD_Response *response = prepare_static_response(sreply);
 
-	int rv = MHD_queue_response(connection, sreply->code(), response);
+	MHD_RESULT rv = MHD_queue_response(connection, sreply->code(), response);
 	MHD_destroy_response(response);
 	return rv;
 }
@@ -316,7 +317,7 @@ WebRequestDispatcher::queue_static_reply(struct MHD_Connection *connection,
  * @param connection libmicrohttpd connection to queue response to
  * @return suitable libmicrohttpd return code
  */
-int
+MHD_RESULT
 WebRequestDispatcher::queue_basic_auth_fail(struct MHD_Connection *connection, WebRequest *request)
 {
 	StaticWebReply sreply(WebReply::HTTP_UNAUTHORIZED, UNAUTHORIZED_REPLY);
@@ -326,13 +327,14 @@ WebRequestDispatcher::queue_basic_auth_fail(struct MHD_Connection *connection, W
 	sreply.pack();
 	struct MHD_Response *response = prepare_static_response(&sreply);
 
-	int rv = MHD_queue_basic_auth_fail_response(connection, realm_, response);
+	MHD_RESULT rv =
+	  static_cast<MHD_RESULT>(MHD_queue_basic_auth_fail_response(connection, realm_, response));
 	MHD_destroy_response(response);
 #else
 	sreply.add_header(MHD_HTTP_HEADER_WWW_AUTHENTICATE,
 	                  (std::string("Basic realm=") + realm_).c_str());
 
-	int rv = queue_static_reply(connection, request, &sreply);
+	MHD_RESULT rv = queue_static_reply(connection, request, &sreply);
 #endif
 	return rv;
 }
@@ -356,7 +358,7 @@ WebRequestDispatcher::queue_basic_auth_fail(struct MHD_Connection *connection, W
  * @return MHD_YES to continue iterating,
  *         MHD_NO to abort the iteration
  */
-static int
+static MHD_RESULT
 post_iterator(void *             cls,
               enum MHD_ValueKind kind,
               const char *       key,
@@ -398,7 +400,7 @@ WebRequestDispatcher::log_uri(const char *uri)
  * @param session_data session data pointer
  * @return appropriate return code for libmicrohttpd
  */
-int
+MHD_RESULT
 WebRequestDispatcher::process_request(struct MHD_Connection *connection,
                                       const char *           url,
                                       const char *           method,
@@ -498,8 +500,8 @@ WebRequestDispatcher::process_request(struct MHD_Connection *connection,
 	}
 
 	try {
-		WebReply *reply = url_manager_->process_request(request);
-		int       ret;
+		WebReply * reply = url_manager_->process_request(request);
+		MHD_RESULT ret;
 
 		if (reply) {
 			if (cors_allow_all_) {

--- a/src/libs/webview/request_dispatcher.h
+++ b/src/libs/webview/request_dispatcher.h
@@ -22,6 +22,8 @@
 #ifndef _LIBS_WEBVIEW_REQUEST_DISPATCHER_H_
 #define _LIBS_WEBVIEW_REQUEST_DISPATCHER_H_
 
+#include "microhttpd_compat.h"
+
 #include <utils/time/time.h>
 
 #include <map>
@@ -51,14 +53,14 @@ public:
 	                     WebPageFooterGenerator *footergen = 0);
 	~WebRequestDispatcher();
 
-	static int process_request_cb(void *                 callback_data,
-	                              struct MHD_Connection *connection,
-	                              const char *           url,
-	                              const char *           method,
-	                              const char *           version,
-	                              const char *           upload_data,
-	                              size_t *               upload_data_size,
-	                              void **                session_data);
+	static MHD_RESULT process_request_cb(void *                 callback_data,
+	                                     struct MHD_Connection *connection,
+	                                     const char *           url,
+	                                     const char *           method,
+	                                     const char *           version,
+	                                     const char *           upload_data,
+	                                     long unsigned int *    upload_data_size,
+	                                     void **                session_data);
 
 	static void request_completed_cb(void *                          cls,
 	                                 struct MHD_Connection *         connection,
@@ -76,21 +78,21 @@ public:
 
 private:
 	struct MHD_Response *prepare_static_response(StaticWebReply *sreply);
-	int                  queue_static_reply(struct MHD_Connection *connection,
+	MHD_RESULT           queue_static_reply(struct MHD_Connection *connection,
 	                                        WebRequest *           request,
 	                                        StaticWebReply *       sreply);
-	int                  queue_dynamic_reply(struct MHD_Connection *connection,
+	MHD_RESULT           queue_dynamic_reply(struct MHD_Connection *connection,
 	                                         WebRequest *           request,
 	                                         DynamicWebReply *      sreply);
-	int   queue_basic_auth_fail(struct MHD_Connection *connection, WebRequest *request);
-	int   process_request(struct MHD_Connection *connection,
-	                      const char *           url,
-	                      const char *           method,
-	                      const char *           version,
-	                      const char *           upload_data,
-	                      size_t *               upload_data_size,
-	                      void **                session_data);
-	void *log_uri(const char *uri);
+	MHD_RESULT queue_basic_auth_fail(struct MHD_Connection *connection, WebRequest *request);
+	MHD_RESULT process_request(struct MHD_Connection *connection,
+	                           const char *           url,
+	                           const char *           method,
+	                           const char *           version,
+	                           const char *           upload_data,
+	                           size_t *               upload_data_size,
+	                           void **                session_data);
+	void *     log_uri(const char *uri);
 
 	void request_completed(WebRequest *request, MHD_RequestTerminationCode term_code);
 

--- a/src/libs/webview/request_dispatcher.h
+++ b/src/libs/webview/request_dispatcher.h
@@ -59,7 +59,7 @@ public:
 	                                     const char *           method,
 	                                     const char *           version,
 	                                     const char *           upload_data,
-	                                     long unsigned int *    upload_data_size,
+	                                     size_t *               upload_data_size,
 	                                     void **                session_data);
 
 	static void request_completed_cb(void *                          cls,

--- a/src/libs/webview/server.cpp
+++ b/src/libs/webview/server.cpp
@@ -19,6 +19,8 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
+#include "microhttpd_compat.h"
+
 #include <core/exception.h>
 #include <core/exceptions/system.h>
 #include <core/threading/thread.h>
@@ -33,7 +35,6 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
-#include <microhttpd.h>
 
 namespace fawkes {
 

--- a/src/plugins/Makefile
+++ b/src/plugins/Makefile
@@ -32,7 +32,7 @@ SUBDIRS	= bbsync bblogger webview ttmainloop rrd \
 	  openrave-robot-memory openni refboxcomm ros player xmlrpc gossip \
 	  robot_state_publisher gazebo dynamixel navgraph-interactive \
 	  pddl-planner stn-generator clips-executive \
-	  asp plexil cedar gologpp hardware-models execution-time-estimator
+	  asp plexil cedar hardware-models execution-time-estimator
 
 include $(BUILDSYSDIR)/rules.mk
 


### PR DESCRIPTION
This is adapted from robocup-logistics/rcll-refbox#83 (done by @TarikViehmann).

Needed to fix [recent build failures on an updated Fedora 32](https://buildkite.com/fawkesrobotics/fawkes-build/builds/1317#cdfe9924-39ca-4d0b-b0d4-76e67877e6a2).