### PR TITLE
Adapt Lua macros to changes introduced in GNU Make 4.3

### DIFF
--- a/etc/buildsys/lua.mk
+++ b/etc/buildsys/lua.mk
@@ -29,7 +29,7 @@ ifeq ($(HAVE_LUA),1)
     CLEAN_FILES=*_tolua.{pkg,cpp}
 
 .SECONDEXPANSION:
-%_tolua.cpp: $$(TOLUA_$$(call nametr,$$*))
+%_tolua.cpp: $$(TOLUA_$$(call nametr,$$(*F)))
 	$(SILENT) echo -e "$(INDENT_PRINT)[LUA] $(PARENTDIR)$(TBOLDGRAY)$(@F)$(TNORMAL)"
 	$(SILENT)cat $(addprefix $(SRCDIR)/,$(subst $(SRCDIR)/,,$(filter %.tolua,$^))) > $(patsubst %.cpp,%.pkg,$@)
 	$(SILENT)$(TOLUAPP) -L "$(FAWKES_BASEDIR)/src/lua/fawkes/toluaext.lua" -n $(TOLUA_PKGPREFIX_$(call nametr,$*))$(notdir $*) $(patsubst %.cpp,%.pkg,$@) | \


### PR DESCRIPTION
As per subject - without this change the `%_tolua.cpp` target in `lua.mk` results in an endless loop because [this part](https://github.com/fawkesrobotics/fawkes/blob/2d4b44e3b9818e29f836fde02c2a503fc5485865/etc/buildsys/lua.mk#L34) pipes the output after the appropriate filtering. However as the prerequisites are empty, there is nothing to pipe.