### PR TITLE
Adapt to boost 1.73 (Fedora 33)

### DIFF
--- a/etc/buildsys/ros.mk
+++ b/etc/buildsys/ros.mk
@@ -66,7 +66,7 @@ else
 endif
 
 ifeq ($(HAVE_ROS),1)
-  CFLAGS_ROS  = -DHAVE_ROS $(call ros-pkg-cflags,roscpp)
+  CFLAGS_ROS  = -DHAVE_ROS $(call ros-pkg-cflags,roscpp) -DBOOST_BIND_GLOBAL_PLACEHOLDERS
   LDFLAGS_ROS = $(call ros-pkg-lflags,roscpp)
 endif
 

--- a/src/libs/logging/fd_redirect.cpp
+++ b/src/libs/logging/fd_redirect.cpp
@@ -23,7 +23,7 @@
 #include <logging/fd_redirect.h>
 #include <logging/logger.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace fawkes {
 

--- a/src/libs/webview/webview.mk
+++ b/src/libs/webview/webview.mk
@@ -20,6 +20,8 @@ endif
 
 ifeq ($(HAVE_LIBMICROHTTPD),1)
   CFLAGS_LIBMICROHTTPD  = -DHAVE_LIBMICROHTTPD $(shell $(PKGCONFIG) --cflags 'libmicrohttpd')
+  # boost's property_tree uses deprecated global placeholders
+  CFLAGS_LIBMICROHTTPD += -DBOOST_BIND_GLOBAL_PLACEHOLDERS
   LDFLAGS_LIBMICROHTTPD = $(shell $(PKGCONFIG) --libs 'libmicrohttpd')
   HAVE_WEBVIEW = 1
 else
@@ -31,8 +33,12 @@ else
   endif
 endif
 
+
 # RapidJSON is optional, but may be convenient
 ifeq ($(HAVE_RAPIDJSON),1)
   CFLAGS_RAPIDJSON  = -DHAVE_RAPIDJSON $(shell $(PKGCONFIG) --cflags 'RapidJSON')
   LDFLAGS_RAPIDJSON = $(shell $(PKGCONFIG) --libs 'RapidJSON')
 endif
+
+CFLAGS_WEBVIEW = $(CFLAGS_LIBMICROHTTPD) $(CFLAGS_RAPIDJSON)
+LDFLAGS_WEBVIEW = $(LDFLAGS_LIBMICROHTTPD) $(LDFLAGS_RAPIDJSON)

--- a/src/plugins/gazebo/gazebo.mk
+++ b/src/plugins/gazebo/gazebo.mk
@@ -27,6 +27,7 @@ ifneq ($(PKGCONFIG),)
   HAVE_GAZEBO   = $(if $(shell $(PKGCONFIG) --atleast-version=1.0.1 'gazebo'; echo $${?/1/}),1,0)
   HAVE_GAZEBO_96 = $(if $(shell $(PKGCONFIG) --atleast-version=9.6.0 'gazebo'; echo $${?/1/}),1,0)
   HAVE_GAZEBO_10 = $(if $(shell $(PKGCONFIG) --atleast-version=10 'gazebo'; echo $${?/1/}),1,0)
+  HAVE_GAZEBO_11 = $(if $(shell $(PKGCONFIG) --atleast-version=11 'gazebo'; echo $${?/1/}),1,0)
 endif
 
 ifeq ($(HAVE_GAZEBO),1)
@@ -42,6 +43,10 @@ ifeq ($(HAVE_GAZEBO),1)
 
   ifeq ($(HAVE_GAZEBO_96)$(boost-have-lib system),11)
     LDFLAGS_GAZEBO += $(boost-lib-ldflags system)
+  endif
+	# Assume that this is no longer necessary in Gazebo 11.
+  ifneq ($(HAVE_GAZEBO_11),1)
+    CFLAGS_GAZEBO += -DBOOST_BIND_GLOBAL_PLACEHOLDERS
   endif
 
   # if ffmpeg is installed, gazebo may have been compiled with support for it

--- a/src/plugins/gazebo/gazsim-localization/gazebo-plugin/gps.h
+++ b/src/plugins/gazebo/gazsim-localization/gazebo-plugin/gps.h
@@ -18,7 +18,7 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>

--- a/src/plugins/gazebo/gazsim-robotino/gazebo-plugin-gyro/gyro.h
+++ b/src/plugins/gazebo/gazsim-robotino/gazebo-plugin-gyro/gyro.h
@@ -18,7 +18,7 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>

--- a/src/plugins/gazebo/gazsim-robotino/gazebo-plugin-motor/motor.h
+++ b/src/plugins/gazebo/gazsim-robotino/gazebo-plugin-motor/motor.h
@@ -18,7 +18,7 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>

--- a/src/plugins/laser/sick_tim55x_ethernet_aqt.cpp
+++ b/src/plugins/laser/sick_tim55x_ethernet_aqt.cpp
@@ -31,7 +31,7 @@
 #include <boost/lambda/lambda.hpp>
 #include <boost/lexical_cast.hpp>
 #if BOOST_VERSION < 104800
-#	include <boost/bind.hpp>
+#	include <boost/bind/bind.hpp>
 #endif
 #include <cstdio>
 #include <cstdlib>

--- a/src/plugins/nao/button_thread.cpp
+++ b/src/plugins/nao/button_thread.cpp
@@ -33,7 +33,7 @@
 #include <interfaces/SwitchInterface.h>
 #include <sys/stat.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <cerrno>
 #include <cstring>
 

--- a/src/plugins/nao/dcm_thread.cpp
+++ b/src/plugins/nao/dcm_thread.cpp
@@ -33,7 +33,7 @@
 #include <interfaces/NaoJointStiffnessInterface.h>
 #include <interfaces/NaoSensorInterface.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 using namespace fawkes;
 

--- a/src/plugins/openprs/openprs_thread.cpp
+++ b/src/plugins/openprs/openprs_thread.cpp
@@ -29,7 +29,7 @@
 #include <netcomm/fawkes/network_manager.h>
 #include <utils/sub_process/proc.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/lambda/bind.hpp>
 #include <boost/lambda/lambda.hpp>

--- a/src/plugins/openprs/utils/openprs_mp_proxy.cpp
+++ b/src/plugins/openprs/utils/openprs_mp_proxy.cpp
@@ -25,7 +25,7 @@
 #include <core/exception.h>
 #include <logging/logger.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lexical_cast.hpp>
 
 using namespace boost::asio;

--- a/src/plugins/openprs/utils/openprs_server_proxy.cpp
+++ b/src/plugins/openprs/utils/openprs_server_proxy.cpp
@@ -27,7 +27,7 @@
 #include <core/threading/mutex_locker.h>
 #include <logging/logger.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lexical_cast.hpp>
 
 using namespace boost::asio;

--- a/src/plugins/openrave/environment.cpp
+++ b/src/plugins/openrave/environment.cpp
@@ -31,7 +31,7 @@
 #include <openrave/planningutils.h>
 
 #include <Python.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/thread.hpp>
 #include <cstdio>
 #include <openrave-core.h>

--- a/src/plugins/plexil/protobuf_adapter.cpp
+++ b/src/plugins/plexil/protobuf_adapter.cpp
@@ -37,6 +37,7 @@
 using namespace fawkes;
 using namespace protobuf_comm;
 using namespace google::protobuf;
+using namespace boost::placeholders;
 
 /** @class ProtobufCommPlexilAdapter "protobuf_adapter.h"
  * Plexil adapter to provide access to protobuf_comm.

--- a/src/plugins/robot-memory/event_trigger_manager.cpp
+++ b/src/plugins/robot-memory/event_trigger_manager.cpp
@@ -27,7 +27,7 @@
 #include <plugins/mongodb/utils.h>
 #include <utils/time/tracker_macros.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <bsoncxx/json.hpp>
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/exception/query_exception.hpp>

--- a/src/plugins/robotino/direct_com_thread.cpp
+++ b/src/plugins/robotino/direct_com_thread.cpp
@@ -33,7 +33,7 @@
 #include <utils/math/angle.h>
 #include <utils/time/wait.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/lambda/bind.hpp>
 #include <boost/lambda/lambda.hpp>


### PR DESCRIPTION
boost 1.73 deprecates global placeholders. Adapt by
* avoiding the use of global placeholders (use `boost/bind/bind.hpp` instead of `boost/bind.hpp`)
* using the placeholders namespace where necessary
* disabling the deprecation warning where we include external headers which trigger the warning