### PR TITLE
webview: use libmicrohttpd build flags

### DIFF
--- a/src/plugins/webview/Makefile
+++ b/src/plugins/webview/Makefile
@@ -46,8 +46,8 @@ PLUGINS_all = $(PLUGINDIR)/webview.so
 ifeq ($(HAVE_BOOST_LIBS)$(HAVE_LIBMICROHTTPD),11)
   PLUGINS_build = $(PLUGINS_all)
 
-  CFLAGS  += $(call boost-libs-cflags,$(REQ_BOOST_LIBS))
-  LDFLAGS += $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))
+  CFLAGS  += $(call boost-libs-cflags,$(REQ_BOOST_LIBS)) $(CFLAGS_LIBMICROHTTPD)
+  LDFLAGS += $(call boost-libs-ldflags,$(REQ_BOOST_LIBS)) $(LDFLAGS_LIBMICROHTTPD)
 
   ifeq ($(HAVE_APR_UTIL),1)
     CFLAGS  += $(CFLAGS_APR_UTIL)


### PR DESCRIPTION
This is a follow-up to #247: the webview plugin did not use the webview build flags, therefore still generating warnings.