### PR TITLE
clips-robot-memory: implement bson array creation functions

### DIFF
--- a/src/plugins/clips-robot-memory/clips_robot_memory_thread.h
+++ b/src/plugins/clips-robot-memory/clips_robot_memory_thread.h
@@ -78,8 +78,8 @@ private:
 	void clips_bson_append_regex(void *bson, std::string field_name, CLIPS::Value regex_string);
 	void clips_bson_append_array(void *bson, std::string field_name, CLIPS::Values values);
 	void clips_bson_append_time(void *bson, std::string field_name, CLIPS::Values time);
-	CLIPS::Value  clips_bson_array_start(void *bson, std::string field_name);
-	void          clips_bson_array_finish(void *barr);
+	CLIPS::Value  clips_bson_array_start();
+	void          clips_bson_array_finish(void *bson, std::string field_name, void *array);
 	void          clips_bson_array_append(void *barr, CLIPS::Value value);
 	std::string   clips_bson_tostring(void *bson);
 	CLIPS::Values clips_bson_field_names(void *bson);


### PR DESCRIPTION
The way mongocxx-3 handles arrays has changed, which is why this was
removed when migrating to the new driver. But there is still a way to
create an array, we just need to adapt the function signature.

This is ported from https://github.com/robocup-logistics/rcll-refbox/commit/ba88b1459158d58e62f2182a37d0173008932f7e.