### PR TITLE
CX: avoid double mutex requests

### DIFF
--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -490,7 +490,7 @@
 	=>
 	(bind ?op (sym-cat (bson-get ?obj "operationType")))
 
-	;(printout warn "Trigger: " (bson-tostring ?obj) crlf)
+	(printout debug "Trigger: " (bson-tostring ?obj) crlf)
 	(switch ?op
 		(case insert then (mutex-trigger-update ?obj))
 		(case update then (mutex-trigger-update ?obj))

--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -460,6 +460,13 @@
         (if (and (or (eq ?m:request LOCK) (eq ?m:request RENEW-LOCK)) ?locked)
         then
           (modify ?m (response ACQUIRED))
+        else
+          (if (eq ?m:locked-by (cx-identity))
+           then
+            (printout error "Acquired a mutex without a request,"
+                            " releasing the mutex again!" crlf)
+            (mutex-unlock-async ?id)
+          )
         )
 		  )
 	  )

--- a/src/plugins/clips-executive/clips/wm-robmem-sync.clp
+++ b/src/plugins/clips-executive/clips/wm-robmem-sync.clp
@@ -388,7 +388,7 @@
 	=>
 	(bind ?op (sym-cat (bson-get ?obj "operationType")))
 
-	(printout warn "Trigger: " (bson-tostring ?obj) crlf)
+	(printout debug "Trigger: " (bson-tostring ?obj) crlf)
 	(if (eq ?op delete)
 	 then
 		; We cannot check the source because it is not set for deletions


### PR DESCRIPTION
We should never call mutex-try-lock-async if the mutex is already
locked. Similarly, if there is already a pending request, we should not
send another request. Instead, let the action directly fail.

Also add a safe guard: If we receive an update that we have locked a mutex, but there is no request, unlock the mutex again.

Finally, refactor the trigger processing to make it more understandable.

Fixes carologistics/fawkes-robotino#368.