### PR TITLE
fix potentially inconsistent protobuf client ids

### DIFF
--- a/src/libs/protobuf_clips/communicator.cpp
+++ b/src/libs/protobuf_clips/communicator.cpp
@@ -977,7 +977,7 @@ ClipsProtobufCommunicator::clips_assert_message(std::pair<std::string, unsigned 
                                                 uint16_t                                msg_type,
                                                 std::shared_ptr<google::protobuf::Message> &msg,
                                                 ClipsProtobufCommunicator::ClientType       ct,
-                                                unsigned int client_id)
+                                                long int client_id)
 {
 	CLIPS::Template::pointer temp = clips_->get_template("protobuf-msg");
 	if (temp) {

--- a/src/libs/protobuf_clips/communicator.h
+++ b/src/libs/protobuf_clips/communicator.h
@@ -166,7 +166,7 @@ private:
 	                          uint16_t                                    msg_type,
 	                          std::shared_ptr<google::protobuf::Message> &msg,
 	                          ClientType                                  ct,
-	                          unsigned int                                client_id = 0);
+	                          long int                                    client_id = 0);
 	void handle_server_client_connected(protobuf_comm::ProtobufStreamServer::ClientID client,
 	                                    boost::asio::ip::tcp::endpoint &              endpoint);
 	void handle_server_client_disconnected(protobuf_comm::ProtobufStreamServer::ClientID client,


### PR DESCRIPTION
Ported from https://github.com/robocup-logistics/rcll-refbox/pull/94.

Edit: In fawkes the `next_client_id_` member is already initialized in the constructors.