### PR TITLE
blackboard: fix data change handling over network

### DIFF
--- a/src/libs/blackboard/net/interface_listener.h
+++ b/src/libs/blackboard/net/interface_listener.h
@@ -41,6 +41,7 @@ public:
 	virtual ~BlackBoardNetHandlerInterfaceListener();
 
 	virtual void bb_interface_data_refreshed(Interface *interface) throw();
+	virtual void bb_interface_data_changed(Interface *interface) throw();
 	virtual bool bb_interface_message_received(Interface *interface, Message *message) throw();
 	virtual void bb_interface_writer_added(Interface *  interface,
 	                                       unsigned int instance_serial) throw();

--- a/src/libs/blackboard/net/interface_proxy.cpp
+++ b/src/libs/blackboard/net/interface_proxy.cpp
@@ -111,7 +111,7 @@ BlackBoardInterfaceProxy::~BlackBoardInterfaceProxy()
  * @param msg message to process.
  */
 void
-BlackBoardInterfaceProxy::process_data_changed(FawkesNetworkMessage *msg)
+BlackBoardInterfaceProxy::process_data_refreshed(FawkesNetworkMessage *msg)
 {
 	if (msg->msgid() != MSG_BB_DATA_CHANGED && msg->msgid() != MSG_BB_DATA_REFRESHED) {
 		LibLogger::log_error("BlackBoardInterfaceProxy",

--- a/src/libs/blackboard/net/interface_proxy.h
+++ b/src/libs/blackboard/net/interface_proxy.h
@@ -47,7 +47,7 @@ public:
 	                         bool                  readwrite);
 	~BlackBoardInterfaceProxy();
 
-	void process_data_changed(FawkesNetworkMessage *msg);
+	void process_data_refreshed(FawkesNetworkMessage *msg);
 	void process_interface_message(FawkesNetworkMessage *msg);
 	void reader_added(unsigned int event_serial);
 	void reader_removed(unsigned int event_serial);

--- a/src/libs/blackboard/remote.cpp
+++ b/src/libs/blackboard/remote.cpp
@@ -458,10 +458,10 @@ RemoteBlackBoard::inbound_received(FawkesNetworkMessage *m, unsigned int id) thr
 	if (m->cid() == FAWKES_CID_BLACKBOARD) {
 		unsigned int msgid = m->msgid();
 		try {
-			if (msgid == MSG_BB_DATA_CHANGED) {
+			if (msgid == MSG_BB_DATA_CHANGED || msgid == MSG_BB_DATA_REFRESHED) {
 				unsigned int serial = ntohl(((unsigned int *)m->payload())[0]);
 				if (proxies_.find(serial) != proxies_.end()) {
-					proxies_[serial]->process_data_changed(m);
+					proxies_[serial]->process_data_refreshed(m);
 				}
 			} else if (msgid == MSG_BB_INTERFACE_MESSAGE) {
 				unsigned int serial = ntohl(((unsigned int *)m->payload())[0]);

--- a/src/libs/interface/interface.cpp
+++ b/src/libs/interface/interface.cpp
@@ -757,16 +757,27 @@ Interface::set_auto_timestamping(bool enabled)
 	auto_timestamping_ = enabled;
 }
 
-/** Mark data as changed.
- * This m will mark the data as changed for a writing instance. One the
+/** Mark data as refreshed.
+ * This will mark the data as refreshed for a writing instance. On the
  * next write, the data will be written with an updated timestamp (if
- * auto timestamping is enabled), irregardless of whether new data was
+ * auto timestamping is enabled), regardless of whether new data was
  * actually set.
  */
 void
 Interface::mark_data_refreshed()
 {
 	data_refreshed = true;
+}
+
+/** Mark data as changed. There should be no sensible reason for
+ * user code to call this method. It is only used for remote blackboard
+ * synchronization. Will cause change notifications to be dispatched on
+ * write().
+ */
+void
+Interface::mark_data_changed()
+{
+	data_changed = true;
 }
 
 /**

--- a/src/libs/interface/interface.h
+++ b/src/libs/interface/interface.h
@@ -132,6 +132,7 @@ public:
 	void        set_timestamp(const Time *t = NULL);
 	void        set_clock(Clock *clock);
 	void        mark_data_refreshed();
+	void        mark_data_changed();
 
 	std::list<const char *> get_message_types();
 


### PR DESCRIPTION
Some of the remote blackboard code was not correctly adapted to deal with the change vs. refresh functionality introduced by PR #244. This commit should fix the resulting errors, in particular this one:
```
BlackBoardNetworkHandler: Unknown message of type 9 received
```