### PR TITLE
gazebo: explicitly start topic- and connection manager

### DIFF
--- a/src/plugins/gazebo/node_thread.cpp
+++ b/src/plugins/gazebo/node_thread.cpp
@@ -77,7 +77,18 @@ GazeboNodeThread::init()
 	//initialize node (this node only communicates with nodes that were initialized with the same string)
 	gazebonode_->Init(robot_channel.c_str());
 	gazebo_aspect_inifin_.set_gazebonode(gazebonode_);
-
+	// init Topic Manager, required to subscribe to topics
+	// and to init the connection manager
+	gazebo::transport::TopicManager::Instance();
+	std::string  uri;
+	unsigned int port;
+	bool         master_reached = gazebo::transport::get_master_uri(uri, port);
+	if (!master_reached) {
+		logger->log_error(name(), "Gazebo master uri could not be retrieved");
+	} else {
+		// init connection manager, required to publish topics
+		gazebo::transport::ConnectionManager::Instance()->Init(uri, port);
+	}
 	//and the node for world change messages
 	gazebo_world_node_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
 	gazebo_world_node_->Init(world_name.c_str());


### PR DESCRIPTION
This PR fixes problems when using gazebo 10. The changes introduced should retain backwards compatibility (or at least the same managers and the same functions are present in all the other gazebo API versions i checked; i stopped at gazebo 4...).

I am a bit confused as of why we need to initialize topic and connection manager by hand, as it was not necessary when running an isolated small program subscribing to the same running gazebo server.