### PR TITLE
Print syncpoint wait times

### DIFF
--- a/src/libs/core/tests/Makefile
+++ b/src/libs/core/tests/Makefile
@@ -19,7 +19,7 @@ include $(BASEDIR)/etc/buildsys/gtest.mk
 include $(BASEDIR)/etc/buildsys/catch2.mk
 
 LIBS_test_circular_buffer += stdc++ fawkescore m
-OBJS_test_circular_buffer += test_circular_buffer.o
+OBJS_test_circular_buffer += test_circular_buffer.o catch2_main.o
 
 LIBS_test_wait_condition += stdc++ fawkescore pthread
 OBJS_test_wait_condition += test_wait_condition.o

--- a/src/libs/core/tests/catch2_main.cpp
+++ b/src/libs/core/tests/catch2_main.cpp
@@ -1,0 +1,24 @@
+/***************************************************************************
+ *  catch2_main.cpp - CircularBuffer Unit Test
+ *
+ *  Created: Tue Nov 24 14:45:42 2020
+ *  Copyright  2020  Till Hofmann
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>

--- a/src/libs/core/tests/test_circular_buffer.cpp
+++ b/src/libs/core/tests/test_circular_buffer.cpp
@@ -19,7 +19,6 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#define CATCH_CONFIG_MAIN
 #include <core/utils/circular_buffer.h>
 
 #include <catch2/catch.hpp>
@@ -79,4 +78,28 @@ TEST_CASE("Copy constructor", "[circular_buffer]")
 	REQUIRE(b1[0] == 1);
 	REQUIRE(b1[1] == 2);
 	REQUIRE_THROWS_AS(b1.at(2), std::out_of_range);
+}
+
+TEST_CASE("Iterator", "[circular_buffer]")
+{
+	CircularBuffer<int> buffer(5);
+	for (int i = 0; i < 10; i++) {
+		buffer.push_back(i);
+	}
+	int i = 5;
+	for (auto it = buffer.begin(); it != buffer.end(); it++) {
+		REQUIRE(*it == i++);
+	}
+}
+
+TEST_CASE("Reverse Iterator", "[circular_buffer]")
+{
+	CircularBuffer<int> buffer(5);
+	for (int i = 0; i < 10; i++) {
+		buffer.push_back(i);
+	}
+	int i = 9;
+	for (auto it = buffer.rbegin(); it != buffer.rend(); it++) {
+		REQUIRE(*it == i--);
+	}
 }

--- a/src/libs/core/utils/circular_buffer.h
+++ b/src/libs/core/utils/circular_buffer.h
@@ -48,6 +48,8 @@ public:
 	typedef size_t size_type;
 	/** The CircularBuffer's iterator is a std::deque iterator */
 	typedef typename std::deque<Type>::const_iterator const_iterator;
+	/** The CircularBuffer's reverse iterator is a std::deque reverse iterator */
+	typedef typename std::deque<Type>::const_reverse_iterator const_reverse_iterator;
 	/** iterator is also const, we don't want to manipulate any elements */
 	typedef const_iterator iterator;
 
@@ -174,6 +176,24 @@ public:
 	end() const
 	{
 		return deque_.end();
+	}
+
+	/** Get reverse iterator to the beginning
+   * @return iterator
+   */
+	const_reverse_iterator
+	rbegin() const
+	{
+		return deque_.rbegin();
+	}
+
+	/** Get reverse iterator to the end
+   * @return iterator
+   */
+	const_reverse_iterator
+	rend() const
+	{
+		return deque_.rend();
 	}
 
 	/** Get actual size of the buffer

--- a/src/libs/syncpoint/syncpoint.cpp
+++ b/src/libs/syncpoint/syncpoint.cpp
@@ -602,20 +602,19 @@ SyncPoint::handle_default(string component, WakeupType type)
 	                  max_waittime_sec_ + static_cast<float>(max_waittime_nsec_) / 1000000000.f);
 	bad_components_.insert(pending_emitters_.begin(), pending_emitters_.end());
 	if (!bad_components_.empty()) {
-		stringstream bad_components_string;
+		stringstream message;
 		for (set<string>::const_iterator it = bad_components_.begin(); it != bad_components_.end();
 		     it++) {
-			bad_components_string << " " << *it;
+			message << " " << *it;
 			const auto &last_call =
 			  std::find_if(emit_calls_.rbegin(), emit_calls_.rend(), [&](const SyncPointCall &call) {
 				  return call.get_caller() == *it;
 			  });
 			if (last_call != emit_calls_.rend()) {
-				bad_components_string << " (" << Time().in_sec() - last_call->get_call_time().in_sec()
-				                      << "s)";
+				message << " (" << Time().in_sec() - last_call->get_call_time().in_sec() << "s)";
 			}
 		}
-		logger_->log_warn(component.c_str(), "bad components:%s", bad_components_string.str().c_str());
+		logger_->log_warn(component.c_str(), "bad components:%s", message.str().c_str());
 	} else if (type == SyncPoint::WAIT_FOR_ALL) {
 		throw Exception("SyncPoints: component %s defaulted, "
 		                "but there is no pending emitter. This is probably a bug.",


### PR DESCRIPTION
If a pending emitter fails to emit, we may also be interested in when
the component emitted the last time. Print the time difference between
now and the last emit call.

This is especially helpful to understand whether a component is just a bit too slow (e.g., we waited for 0.4s) or its loop is stuck (with a wait time of several seconds).