### PR TITLE
mongodb: add config option to store data and log in a tmp directory

### DIFF
--- a/src/plugins/mongodb/mongodb_instance_config.cpp
+++ b/src/plugins/mongodb/mongodb_instance_config.cpp
@@ -30,6 +30,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/format.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/json.hpp>
 #include <chrono>
@@ -91,8 +92,11 @@ MongoDBInstanceConfig::MongoDBInstanceConfig(Configuration *config,
 		  config->get_bool_or_default((prefix + "clear-data-on-termination").c_str(),
 		                              use_tmp_directory_);
 		if (use_tmp_directory_) {
-			const boost::filesystem::path path = boost::filesystem::unique_path(
-			  boost::filesystem::temp_directory_path() / "mongodb-%%%%-%%%%-%%%%");
+			// Add the port to the filename, escape all literal "%" as "%%".
+			const std::string filename =
+			  boost::str(boost::format("mongodb-%1%-%%%%%%%%-%%%%%%%%-%%%%%%%%") % port_);
+			const boost::filesystem::path path =
+			  boost::filesystem::unique_path(boost::filesystem::temp_directory_path() / filename);
 			data_path_ = path.string();
 			log_path_  = (path / "mongodb.log").string();
 		} else {

--- a/src/plugins/mongodb/mongodb_instance_config.h
+++ b/src/plugins/mongodb/mongodb_instance_config.h
@@ -75,6 +75,7 @@ private:
 	unsigned int termination_grace_period_;
 	float        loop_interval_;
 	bool         clear_data_on_termination_;
+	bool         use_tmp_directory_;
 	std::string  bind_ip_;
 	unsigned int port_;
 	std::string  data_path_;


### PR DESCRIPTION
Using a tmp directory ensures that we always start with an empty
database, as we switch the database directory with every restart.