### PR TITLE
Fix / work around gazebo client initialization issues

### DIFF
--- a/src/plugins/gazebo/gazsim-laser/gazsim_laser_thread.cpp
+++ b/src/plugins/gazebo/gazsim-laser/gazsim_laser_thread.cpp
@@ -63,7 +63,7 @@ LaserSimThread::init()
 	laser_if_ = blackboard->open_for_writing<Laser360Interface>(interface_id_.c_str());
 	laser_if_->set_auto_timestamping(false);
 
-	//subscribing to gazebo publisher
+	logger->log_info(name(), "Subscribing to laser topic '%s'", laser_topic_.c_str());
 	laser_sub_ = gazebonode->Subscribe(laser_topic_, &LaserSimThread::on_laser_data_msg, this);
 
 	//initialize laser data

--- a/src/plugins/gazebo/gazsim-robotino/gazsim_robotino_thread.cpp
+++ b/src/plugins/gazebo/gazsim-robotino/gazsim_robotino_thread.cpp
@@ -91,35 +91,64 @@ RobotinoSimThread::init()
 	imu_if_    = blackboard->open_for_writing<IMUInterface>("IMU Robotino");
 
 	//Create suscribers
-	pos_sub_  = gazebonode->Subscribe(config->get_string("/gazsim/topics/gps"),
-                                   &RobotinoSimThread::on_pos_msg,
-                                   this);
-	gyro_sub_ = gazebonode->Subscribe(config->get_string("/gazsim/topics/gyro"),
-	                                  &RobotinoSimThread::on_gyro_msg,
-	                                  this);
-	infrared_puck_sensor_sub_ =
-	  gazebonode->Subscribe(config->get_string("/gazsim/topics/infrared-puck-sensor"),
-	                        &RobotinoSimThread::on_infrared_puck_sensor_msg,
-	                        this);
-	if (have_gripper_sensors_) {
-		gripper_laser_left_sensor_sub_ =
-		  gazebonode->Subscribe(config->get_string("/gazsim/topics/gripper-laser-left"),
-		                        &RobotinoSimThread::on_gripper_laser_left_sensor_msg,
-		                        this);
-		gripper_laser_right_sensor_sub_ =
-		  gazebonode->Subscribe(config->get_string("/gazsim/topics/gripper-laser-right"),
-		                        &RobotinoSimThread::on_gripper_laser_right_sensor_msg,
+	{
+		const std::string gps_topic = config->get_string("/gazsim/topics/gps");
+		logger->log_info(name(), "Subscribing to GPS topic '%s'", gps_topic.c_str());
+		pos_sub_ = gazebonode->Subscribe(gps_topic, &RobotinoSimThread::on_pos_msg, this);
+	}
+
+	{
+		const std::string gyro_topic = config->get_string("/gazsim/topics/gyro");
+		logger->log_info(name(), "Subscribing to Gyro topic '%s'", gyro_topic.c_str());
+		gyro_sub_ = gazebonode->Subscribe(gyro_topic, &RobotinoSimThread::on_gyro_msg, this);
+	}
+
+	{
+		const std::string puck_sensor_topic = config->get_string("/gazsim/topics/infrared-puck-sensor");
+		logger->log_info(name(), "Subscribing to puck sensor topic '%s'", puck_sensor_topic.c_str());
+		infrared_puck_sensor_sub_ =
+		  gazebonode->Subscribe(puck_sensor_topic,
+		                        &RobotinoSimThread::on_infrared_puck_sensor_msg,
 		                        this);
 	}
 
-	gripper_has_puck_sub_ =
-	  gazebonode->Subscribe(config->get_string("/gazsim/topics/gripper-has-puck"),
-	                        &RobotinoSimThread::on_gripper_has_puck_msg,
-	                        this);
+	if (have_gripper_sensors_) {
+		{
+			const std::string left_gripper_sensor_topic =
+			  config->get_string("/gazsim/topics/gripper-laser-left");
+			logger->log_info(name(),
+			                 "Subscribing to left gripper topic '%s'",
+			                 left_gripper_sensor_topic.c_str());
+			gripper_laser_left_sensor_sub_ =
+			  gazebonode->Subscribe(left_gripper_sensor_topic,
+			                        &RobotinoSimThread::on_gripper_laser_left_sensor_msg,
+			                        this);
+		}
+
+		{
+			const std::string right_gripper_sensor_topic =
+			  config->get_string("/gazsim/topics/gripper-laser-right");
+			logger->log_info(name(),
+			                 "Subscribing to right gripper topic '%s'",
+			                 right_gripper_sensor_topic.c_str());
+			gripper_laser_right_sensor_sub_ =
+			  gazebonode->Subscribe(right_gripper_sensor_topic,
+			                        &RobotinoSimThread::on_gripper_laser_right_sensor_msg,
+			                        this);
+		}
+	}
+
+	{
+		const std::string has_puck_topic = config->get_string("/gazsim/topics/gripper-has-puck");
+		logger->log_info(name(), "Subscribing to has-puck topic '%s'", has_puck_topic.c_str());
+		gripper_has_puck_sub_ =
+		  gazebonode->Subscribe(has_puck_topic, &RobotinoSimThread::on_gripper_has_puck_msg, this);
+	}
 
 	//Create publishers
-	motor_move_pub_ =
-	  gazebonode->Advertise<msgs::Vector3d>(config->get_string("/gazsim/topics/motor-move"));
+	const std::string motor_topic = config->get_string("/gazsim/topics/motor-move");
+	logger->log_info(name(), "Publishing to motor topic '%s'", motor_topic.c_str());
+	motor_move_pub_ = gazebonode->Advertise<msgs::Vector3d>(motor_topic);
 	string_pub_ = gazebonode->Advertise<msgs::Header>(config->get_string("/gazsim/topics/message"));
 
 	//enable motor by default

--- a/src/plugins/gazebo/node_thread.h
+++ b/src/plugins/gazebo/node_thread.h
@@ -69,14 +69,13 @@ private:
 	gazebo::transport::NodePtr gazebonode_;
 	//Node to control the gazebo world (e.g. spawn visual objects)
 	gazebo::transport::NodePtr gazebo_world_node_;
+	// Heartbeat publisher
+	gazebo::transport::PublisherPtr status_publisher_;
 	//Publisher to send Messages:
 	gazebo::transport::PublisherPtr visual_publisher_, model_publisher_, request_publisher_,
 	  light_publisher_;
 
 	fawkes::GazeboAspectIniFin gazebo_aspect_inifin_;
-
-	//channel of a specified robot for the gazebo node communication
-	std::string robot_channel, world_name;
 };
 
 #endif


### PR DESCRIPTION
Fix the gazebo client initialization:
* Call `gazebo::client::setup()`, following the [documentation](http://gazebosim.org/tutorials?tut=topics_subscribed&cat=transport)
* Remove TopicManager and ConnectionManager initializations. These work fine with a single robot, but often crash gazebo when used with multiple robots
* Publish a heartbeat, which somehow works around the issues with not receiving data


Also print topic names when we subscribe to them, for informational purposes.

I've tried debugging the subscription problems for a while, but it seems like some things are messed up either in gazebo-rcll or in gazebo itself. This workaround seems to work well enough for now.