### PR TITLE
Use podman instead of docker for buildkite builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
       - .buildkite/annotate
     artifact_paths:
       - tests.out.d/**/*
-    timeout_in_minutes: 30
+    timeout_in_minutes: 45
     plugins:
       - *merged-pr-plugin
       - kennasecurity/podman#master:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ merged-pr-plugin: &merged-pr-plugin
   seek-oss/github-merged-pr#v1.1.2:
     mode: checkout
 
-docker-plugin-base: &docker-plugin-base
+podman-plugin-base: &podman-plugin-base
   image: fawkesrobotics/fawkes-builder:fedora33-noetic
   always-pull: true
   debug: true
@@ -16,8 +16,8 @@ steps:
     command: .buildkite/lint
     plugins:
       - *merged-pr-plugin
-      - docker#v3.3.0:
-          <<: *docker-plugin-base
+      - kennasecurity/podman#master:
+          <<: *podman-plugin-base
           environment:
             - BUILDKITE
             - BUILDKITE_REPO
@@ -41,8 +41,8 @@ steps:
     timeout_in_minutes: 30
     plugins:
       - *merged-pr-plugin
-      - docker#v3.3.0:
-          <<: *docker-plugin-base
+      - kennasecurity/podman#master:
+          <<: *podman-plugin-base
           volumes:
             - /var/lib/buildkite-agent/ccache_fedora:/var/cache/ccache
 
@@ -53,8 +53,8 @@ steps:
       - .buildkite/annotate
     plugins:
       - *merged-pr-plugin
-      - docker#v3.3.0:
-          <<: *docker-plugin-base
+      - kennasecurity/podman#master:
+          <<: *podman-plugin-base
           image: fawkesrobotics/fawkes-builder:ubuntu1804-melodic
           volumes:
             - /var/lib/buildkite-agent/ccache_ubuntu:/var/cache/ccache


### PR DESCRIPTION
We have switched our build servers to CentOS 8, which works better with podman than docker.