### PR TITLE
cx: add compound goal to run sub-goals in parallel

### DIFF
--- a/cfg/conf.d/clips-executive.yaml
+++ b/cfg/conf.d/clips-executive.yaml
@@ -92,6 +92,7 @@ clips-executive:
               - goals/run-one.clp
               - goals/run-all.clp
               - goals/try-all.clp
+              - goals/run-parallel.clp
               - goals/retry.clp
               - goals/timeout.clp
               - goals/automatic.clp

--- a/src/plugins/clips-executive/clips/goal-tree.clp
+++ b/src/plugins/clips-executive/clips/goal-tree.clp
@@ -56,18 +56,32 @@
 )
 
 (deffunction goal-tree-assert-run-parallel (?class ?continue-on $?fact-addresses)
+	(bind ?run-parallel-option NONE)
+	(if (member$ ?continue-on (create$ FAILED REJECTED NONE))
+	 then (bind ?run-parallel-option ?continue-on)
+	 else (printout warn "ignoring unrecognized option " ?continue-on
+	                     " for run-parallel goal, expected FAILED|REJECTED|NONE"
+	                     ", using default: NONE" crlf)
+	)
 	(bind ?id (sym-cat PARALLEL- ?class - (gensym*)))
 	(bind ?goal (assert (goal (id ?id) (class ?class) (sub-type RUN-SUBGOALS-IN-PARALLEL)
-	                          (params continue-on ?continue-on))))
+	                          (params continue-on ?run-parallel-option))))
 	(foreach ?f ?fact-addresses
 		(goal-tree-update-child ?f ?id 0))
 	(return ?goal)
 )
 
 (deffunction goal-tree-assert-run-parallel-delayed (?class ?continue-on $?fact-addresses)
+	(bind ?run-parallel-option NONE)
+	(if (member$ ?continue-on (create$ FAILED REJECTED NONE))
+	 then (bind ?run-parallel-option ?continue-on)
+	 else (printout warn "ignoring unrecognized option " ?continue-on
+	                     " for run-parallel goal, expected FAILED|REJECTED|NONE"
+	                     ", using default: NONE" crlf)
+	)
 	(bind ?id (sym-cat PARALLEL- ?class - (gensym*)))
 	(bind ?goal (assert (goal (id ?id) (class ?class) (sub-type RUN-SUBGOALS-IN-PARALLEL)
-	                          (params continue-on ?continue-on))))
+	                          (params continue-on ?run-parallel-option))))
 	(foreach ?f ?fact-addresses
 		(goal-tree-update-child ?f ?id (+ 1 (- (length$ ?fact-addresses) ?f-index))))
 	(return ?goal)

--- a/src/plugins/clips-executive/clips/goal-tree.clp
+++ b/src/plugins/clips-executive/clips/goal-tree.clp
@@ -54,3 +54,21 @@
 	(goal-tree-update-child ?fact-address ?id 0)
 	(return ?goal)
 )
+
+(deffunction goal-tree-assert-run-parallel (?class ?continue-on $?fact-addresses)
+	(bind ?id (sym-cat PARALLEL- ?class - (gensym*)))
+	(bind ?goal (assert (goal (id ?id) (class ?class) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	                          (params continue-on ?continue-on))))
+	(foreach ?f ?fact-addresses
+		(goal-tree-update-child ?f ?id 0))
+	(return ?goal)
+)
+
+(deffunction goal-tree-assert-run-parallel-delayed (?class ?continue-on $?fact-addresses)
+	(bind ?id (sym-cat PARALLEL- ?class - (gensym*)))
+	(bind ?goal (assert (goal (id ?id) (class ?class) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	                          (params continue-on ?continue-on))))
+	(foreach ?f ?fact-addresses
+		(goal-tree-update-child ?f ?id (+ 1 (- (length$ ?fact-addresses) ?f-index))))
+	(return ?goal)
+)

--- a/src/plugins/clips-executive/clips/goal-tree.clp
+++ b/src/plugins/clips-executive/clips/goal-tree.clp
@@ -56,6 +56,17 @@
 )
 
 (deffunction goal-tree-assert-run-parallel (?class ?continue-on $?fact-addresses)
+" Assert a run-parallel goal, where all sub-goals have the same priority.
+  @param ?class: class name of the run-parallel goal
+  @param ?continue-on: If 'REJECTED', then the run-parallel goal continues to
+                       SELECT sub-goals, even if some sub-goal already got
+                       REJECTED.
+                       IF 'FAILED', then it continues to SELECT sub-goals even
+                       if some sub-gaol already got REJECTED or has FAILED.
+                       Else set this to 'NONE'.
+  @param fact-addresses: fact-addresses of the sub-goals
+  @return fact-address of run-parallel goal
+"
 	(bind ?run-parallel-option NONE)
 	(if (member$ ?continue-on (create$ FAILED REJECTED NONE))
 	 then (bind ?run-parallel-option ?continue-on)
@@ -72,6 +83,10 @@
 )
 
 (deffunction goal-tree-assert-run-parallel-delayed (?class ?continue-on $?fact-addresses)
+" See goal-tree-assert-run-parallel, but sub-goals receive descending
+  priorities, causing them to be DISPATCHED in the order of the given
+  fact-addresses.
+"
 	(bind ?run-parallel-option NONE)
 	(if (member$ ?continue-on (create$ FAILED REJECTED NONE))
 	 then (bind ?run-parallel-option ?continue-on)

--- a/src/plugins/clips-executive/clips/goals/run-parallel.clp
+++ b/src/plugins/clips-executive/clips/goals/run-parallel.clp
@@ -15,8 +15,8 @@
 ; Fail:    if at least one sub-goal fails
 ; Reject:  if any sub-goal is rejected but no sub-goal failed
 ;
-; A RUN-PARALLEL parent goal will run all sub-goals in parallel, starting
-; then ordered by their priorities.
+; A RUN-PARALLEL parent goal will run all sub-goals in parallel by
+; continuously SELECTING all sub-goals with the highest priority.
 ; If any goal fails, the parent fails. If any sub-goal is rejected,
 ; the parent is rejected. If all goals have been completed successfully,
 ; the parent goal succeeds.
@@ -34,9 +34,9 @@
 ;   * set RUN-PARALLEL goal mode to EXPANDED
 ; - Automatic: if no sub-goal formulated -> FAIL
 ; - Automatic: if all sub-goals rejected -> REJECT
-; - Automatic: DISPATCH all formulated sub-goals with highest priority by
-;              SELECTING them- SELECT next batch of sub-goals once all
-;              previously SELECTED subgoals are past COMMITTMENT stage.
+; - Automatic: SELECT all formulated sub-goals with highest priority,
+;              SELECT next batch of sub-goals once all
+;              previously SELECTED sub-goals are DISPATCHED|FINISHED|RETRACTED.
 ; - User: handle sub-goal expansion, committing, dispatching, evaluating
 ; - Automatic: when sub-goal is EVALUATED, outcome determines parent goal:
 ;   * REJECTED or FAILED: Reject formulated sub-goals

--- a/src/plugins/clips-executive/clips/goals/run-parallel.clp
+++ b/src/plugins/clips-executive/clips/goals/run-parallel.clp
@@ -1,0 +1,152 @@
+;---------------------------------------------------------------------------
+;  run-parallel.clp - CLIPS executive - goal to run all sub-goals in parallel
+;
+;  Created: Wed Dec 16 2020
+;  Copyright  2020  Tarik Viehmann
+;  Licensed under GPLv2+ license, cf. LICENSE file
+;---------------------------------------------------------------------------
+
+; Sub-type: RUN-SUBGOALS-IN-PARALLEL
+; Perform: all sub-goals in parallel
+; Params: (params continue-on FAILED|REJECTED) to not stop SELECTION of
+;         other goals when a sub-goal FAILED/is REJECTED
+; Succeed: if all sub-goal succeeds
+; Fail:    if at least one sub-goal fails
+; Reject:  if any sub-goal is rejected but no sub-goal failed
+;
+; A RUN-PARALLEL parent goal will run all sub-goals in parallel, starting
+; then ordered by their priorities.
+; If any goal fails, the parent fails. If any sub-goal is rejected,
+; the parent is rejected. If all goals have been completed successfully,
+; the parent goal succeeds.
+; The RUN-PARALLEL goal can be configured to continue execution of other goals
+; upon encountering a FAILED or REJECTED sub-goal by including
+; 'continue-on FAILED' or 'continue-on REJECTED' in the goal params
+; (continue-on FAILED implies continue-on REJECTED).
+
+;
+; Interactions:
+; - User FORMULATES goal
+; - User SELECTS goal
+; - User EXPANDS goal, consisting of:
+;   * create goals with parent ID equal the RUN-PARALLEL goal ID
+;   * set RUN-PARALLEL goal mode to EXPANDED
+; - Automatic: if no sub-goal formulated -> FAIL
+; - Automatic: if all sub-goals rejected -> REJECT
+; - Automatic: DISPATCH all formulated sub-goals with highest priority by
+;              SELECTING them- SELECT next batch of sub-goals once all
+;              previously SELECTED subgoals are past COMMITTMENT stage.
+; - User: handle sub-goal expansion, committing, dispatching, evaluating
+; - Automatic: when sub-goal is EVALUATED, outcome determines parent goal:
+;   * REJECTED or FAILED: Reject formulated sub-goals
+;                         (unless configured otherwise),
+;                         wait for completion of started sub-goals,
+;                         message
+;   * COMPLETED: wait for completion of other sub-goals
+;   -> Sub-goal is RETRACTED
+; - Automatic: once all sub-goals are RETRACTED, finish the parent goal:
+;   * if a sub-goal FAILED: outcome FAILED
+;   * else if a sub-goal was REJECTED: outcome REJECTED
+;   * else (all sub-goals were COMPLETED): outcome COMPLETED
+; - User: EVALUATE goal
+; - User: RETRACT goal
+
+(deffunction run-parallel-stop-execution (?params ?sub-goal-outcome)
+	(return (and (or (eq ?sub-goal-outcome FAILED)
+	                 (eq ?sub-goal-outcome REJECTED))
+	             (not (member$ (create$ continue-on FAILED) ?params))
+	             (not (member$ (create$ continue-on ?sub-goal-outcome) ?params))))
+)
+
+(defrule run-parallel-goal-expand-failed
+	?gf <- (goal (id ?id) (type ACHIEVE) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	             (mode EXPANDED))
+	(not (goal (type ACHIEVE) (parent ?id)))
+	=>
+	(modify ?gf (mode FINISHED) (outcome FAILED)
+	            (error NO-SUB-GOALS)
+	            (message (str-cat "No sub-goal for RUN-PARALLEL goal '" ?id "'")))
+)
+
+(defrule run-parallel-goal-commit
+	?gf <- (goal (id ?id) (type ACHIEVE) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	             (mode EXPANDED))
+	(goal (id ?sub-goal) (parent ?id) (type ACHIEVE) (mode FORMULATED))
+	=>
+	(modify ?gf (mode COMMITTED))
+)
+
+(defrule run-parallel-goal-dispatch
+	?gf <- (goal (id ?id) (type ACHIEVE) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	             (mode COMMITTED)
+	             (required-resources $?req)
+	             (acquired-resources $?acq&:(subsetp ?req ?acq)))
+	=>
+	(modify ?gf (mode DISPATCHED))
+)
+
+(defrule run-parallel-subgoals-select
+	(goal (id ?id) (type ACHIEVE) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	      (mode DISPATCHED) (params $?params))
+	(goal (parent ?id) (id ?sub-id) (type ACHIEVE) (mode FORMULATED)
+	      (priority ?prio))
+	(not (goal (parent ?id) (type ACHIEVE) (mode FORMULATED)
+	           (priority ?o-prio&:(> ?o-prio ?prio))))
+	(not (goal (parent ?id) (type ACHIEVE) (mode SELECTED|EXPANDED|COMMITTED)))
+	(not (goal (parent ?id) (type ACHIEVE)
+	           (outcome ?outcome&:(run-parallel-stop-execution ?params ?outcome))))
+	=>
+	(do-for-all-facts ((?g goal)) (and (eq ?g:parent ?id)
+	                                   (eq ?g:mode FORMULATED)
+	                                   (eq ?g:priority ?prio))
+		(modify ?g (mode SELECTED))
+	)
+)
+
+(defrule run-parallel-subgoal-reject-other-subgoal-rejected
+	(goal (id ?id) (type ACHIEVE) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	      (mode DISPATCHED) (params $?params))
+	?sg <- (goal (parent ?id) (id ?sub-id) (type ACHIEVE) (mode FORMULATED)
+	              (priority ?prio))
+	(not (goal (parent ?id) (type ACHIEVE) (mode FORMULATED)
+	           (priority ?o-prio&:(< ?o-prio ?prio))))
+	(not (goal (parent ?id) (type ACHIEVE) (mode SELECTED|EXPANDED|COMMITTED)))
+	(goal (parent ?id) (type ACHIEVE)
+	      (outcome ?outcome&:(run-parallel-stop-execution ?params ?outcome)))
+	=>
+	(modify ?sg (mode FINISHED) (outcome REJECTED))
+)
+
+(defrule run-parallel-subgoal-evaluated
+	(goal (id ?id) (type ACHIEVE) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	      (mode DISPATCHED))
+	?sg <- (goal (parent ?id) (type ACHIEVE) (mode EVALUATED))
+	=>
+	(modify ?sg (mode RETRACTED))
+)
+
+(defrule run-parallel-goal-finish-all-subgoals-retracted
+	?gf <- (goal (id ?id) (type ACHIEVE) (sub-type RUN-SUBGOALS-IN-PARALLEL)
+	             (mode DISPATCHED))
+	(not (goal (parent ?id) (type ACHIEVE)
+	           (acquired-resources $?acq&:(> (length ?acq) 0))))
+	(not (goal (parent ?id) (type ACHIEVE) (mode ~RETRACTED)))
+	=>
+	(if (not (do-for-fact ((?g goal))
+	                      (and (eq ?g:parent ?id) (eq ?g:outcome FAILED))
+		(modify ?gf (mode FINISHED) (outcome ?g:outcome)
+		          (error SUB-GOAL-FAILED ?g:id)
+		          (message (str-cat "Sub-goal '" ?g:id "' of RUN-PARALLEL goal '"
+		                            ?id "' has failed")))))
+	 then
+		(if (not (do-for-fact ((?g goal))
+		                    (and (eq ?g:parent ?id) (eq ?g:outcome REJECTED))
+			(modify ?gf (mode FINISHED) (outcome ?g:outcome)
+			          (error SUB-GOAL-REJECTED ?g:id)
+			          (message (str-cat "Sub-goal '" ?g:id "' of RUN-PARALLEL goal '"
+			                            ?id "' was rejected")))))
+		 then
+			(modify ?gf (mode FINISHED) (outcome COMPLETED))
+		)
+	)
+)

--- a/src/plugins/clips-executive/clips/goals/run-parallel.clp
+++ b/src/plugins/clips-executive/clips/goals/run-parallel.clp
@@ -10,6 +10,7 @@
 ; Perform: all sub-goals in parallel
 ; Params: (params continue-on FAILED|REJECTED) to not stop SELECTION of
 ;         other goals when a sub-goal FAILED/is REJECTED
+;         other values will be ignored
 ; Succeed: if all sub-goal succeeds
 ; Fail:    if at least one sub-goal fails
 ; Reject:  if any sub-goal is rejected but no sub-goal failed

--- a/src/plugins/clips-executive/clips/test-scenario/domain.pddl
+++ b/src/plugins/clips-executive/clips/test-scenario/domain.pddl
@@ -22,6 +22,10 @@
 (define (domain hello-world)
   (:requirements :strips :typing)
   (:types name text howoften)
+  (:constants
+    hello goodbye - text
+    once - howoften
+  )
   (:predicates
 	 (said ?n - name ?t - text)
 	 (spoken ?h - howoften)

--- a/src/plugins/clips-executive/clips/test-scenario/goal-reasoner.clp
+++ b/src/plugins/clips-executive/clips/test-scenario/goal-reasoner.clp
@@ -17,16 +17,30 @@
 	; 				;(goal (id (sym-cat TEST-PARENT- (gensym*))) (parent ?goal-id) (class TESTGOAL)))
 
 	(goal-tree-assert-run-one TESTGOAL-PARENT
-	 (assert (goal (class ALWAYS-REJECT)))
+	 (assert (goal (id (gensym*)) (class ALWAYS-REJECT)))
 	 (goal-tree-assert-run-all AUTOMATIC-SUBGOAL
-		(goal-tree-assert-retry AUTOMATIC-SUBGOAL 3
-		 (assert (goal (class SUCCEED-SECOND-TRY))))
+		(goal-tree-assert-run-parallel AUTOMATIC-SUBGOAL NONE
+		 (assert (goal (id (gensym*)) (class TALK)))
+		 (goal-tree-assert-retry AUTOMATIC-SUBGOAL 3
+		  (assert (goal (id (gensym*)) (class SUCCEED-SECOND-TRY))))
+		)
 		(goal-tree-assert-try-all AUTOMATIC-SUBGOAL
 		 (goal-tree-assert-timeout AUTOMATIC-SUBGOAL 5.0
-			(assert (goal (class HANG-NOOP)))
+			(assert (goal (id (gensym*)) (class HANG-NOOP)))
 		 )
-		 (assert (goal (class ALWAYS-FAIL)))
-		 (assert (goal (class TALK)))
+		 (goal-tree-assert-run-parallel-delayed AUTOMATIC-SUBGOAL FAILED
+			(assert (goal (id (gensym*)) (class ALWAYS-REJECT)))
+			(goal-tree-assert-run-parallel AUTOMATIC-SUBGOAL NONE
+			 (assert (goal (id (sym-cat PARALLEL-PRINT- (gensym*))) (class PRINT)))
+			 (assert (goal (id (sym-cat PARALLEL-PRINT- (gensym*))) (class PRINT)))
+			)
+		 )
+		 (goal-tree-assert-run-parallel-delayed AUTOMATIC-SUBGOAL REJECTED
+			(assert (goal (id (gensym*)) (class ALWAYS-FAIL)))
+			(assert (goal (id (sym-cat NEVER-EXPANDED- (gensym*))) (class PRINT)))
+		 )
+		 (assert (goal (id (gensym*)) (class ALWAYS-FAIL)))
+		 (assert (goal (id (sym-cat FINALLY-SUCCEED- (gensym*))) (class PRINT)))
 		)
 	 )
 	)

--- a/src/plugins/clips-executive/clips/test-scenario/goal-reasoner.clp
+++ b/src/plugins/clips-executive/clips/test-scenario/goal-reasoner.clp
@@ -67,7 +67,7 @@
 )
 
 (defrule goal-reasoner-expanded
-	?g <- (goal (id ?goal-id) (class TALK) (mode SELECTED))
+	?g <- (goal (id ?goal-id) (class TALK|PRINT) (mode SELECTED))
 	(plan (goal-id ?goal-id))
 	=>
   (modify ?g (mode EXPANDED))

--- a/src/plugins/clips-executive/clips/test-scenario/goal-reasoner.clp
+++ b/src/plugins/clips-executive/clips/test-scenario/goal-reasoner.clp
@@ -5,6 +5,7 @@
 	(not (goal))
 	(not (test-performed))
   (domain-facts-loaded)
+  (skiller-control (acquired TRUE))
 	=>
 	; (bind ?goal-id (sym-cat TEST-PARENT- (gensym*)))
 	; (assert (goal (id ?goal-id) (class TESTGOAL-PARENT)

--- a/src/plugins/clips-executive/clips/test-scenario/goals/talk.clp
+++ b/src/plugins/clips-executive/clips/test-scenario/goals/talk.clp
@@ -25,8 +25,9 @@
 )
 
 (defrule talk-goal-evaluate-failed
-	?g <- (goal (id ?goal-id) (class TALK|PRINT) (mode FINISHED) (outcome FAILED|REJECTED))
+	?g <- (goal (id ?goal-id) (class TALK|PRINT) (mode FINISHED)
+	            (outcome ?outcome&FAILED|REJECTED))
 	=>
-	(printout t "Goal '" ?goal-id "' has failed, evaluating" crlf)
+	(printout t "Goal '" ?goal-id "' has failed (" ?outcome "), evaluating" crlf)
 	(modify ?g (mode EVALUATED))
 )

--- a/src/plugins/clips-executive/clips/test-scenario/goals/talk.clp
+++ b/src/plugins/clips-executive/clips/test-scenario/goals/talk.clp
@@ -1,7 +1,7 @@
 
 ; #  Commit to goal (we "intend" it)
 (defrule talk-goal-commit
-	?g <- (goal (id ?goal-id) (parent ?id) (class TALK) (mode EXPANDED))
+	?g <- (goal (id ?goal-id) (parent ?id) (class TALK|PRINT) (mode EXPANDED))
 	(plan (id ?plan-id) (goal-id ?goal-id))
 	=>
 	(modify ?g (mode COMMITTED) (committed-to ?plan-id))
@@ -9,7 +9,7 @@
 
 ; #  Dispatch goal (action selection and execution now kick in)
 (defrule talk-goal-dispatch
-	?g <- (goal (class TALK) (mode COMMITTED)
+	?g <- (goal (class TALK|PRINT) (mode COMMITTED)
 							(required-resources $?req)
 							(acquired-resources $?acq&:(subsetp ?req ?acq)))
 	=>
@@ -18,14 +18,14 @@
 
 ; #  Goal Monitoring
 (defrule talk-goal-evaluate-completed
-	?g <- (goal (id ?goal-id) (class TALK) (mode FINISHED) (outcome COMPLETED))
+	?g <- (goal (id ?goal-id) (class TALK|PRINT) (mode FINISHED) (outcome COMPLETED))
 	=>
 	(printout t "Goal '" ?goal-id "' has been completed, evaluating" crlf)
 	(modify ?g (mode EVALUATED))
 )
 
 (defrule talk-goal-evaluate-failed
-	?g <- (goal (id ?goal-id) (class TALK) (mode FINISHED) (outcome FAILED|REJECTED))
+	?g <- (goal (id ?goal-id) (class TALK|PRINT) (mode FINISHED) (outcome FAILED|REJECTED))
 	=>
 	(printout t "Goal '" ?goal-id "' has failed, evaluating" crlf)
 	(modify ?g (mode EVALUATED))

--- a/src/plugins/clips-executive/clips/test-scenario/plans/talk-plan.clp
+++ b/src/plugins/clips-executive/clips/test-scenario/plans/talk-plan.clp
@@ -42,3 +42,22 @@
 		             (action-name say-cleanup))
 	)
 )
+
+(defrule plan-print-expand
+	?g <- (goal (mode SELECTED) (id ?goal-id) (class PRINT))
+	=>
+	(bind ?plan-id (sym-cat ?goal-id -PLAN))
+	(assert
+		(plan (id ?plan-id) (goal-id ?goal-id) (type SEQUENTIAL))
+		(plan-action (id 10) (goal-id ?goal-id) (plan-id ?plan-id)
+		             (duration 4.0)
+		             (action-name print)
+								 (param-names severity text)
+		             (param-values warn (str-cat ?goal-id " prints something")))
+		(plan-action (id 20) (goal-id ?goal-id) (plan-id ?plan-id)
+		             (duration 4.0)
+		             (action-name print)
+								 (param-names severity text)
+		             (param-values warn (str-cat ?goal-id " prints something else")))
+	)
+)

--- a/src/plugins/clips-executive/clips/test-scenario/print-action.clp
+++ b/src/plugins/clips-executive/clips/test-scenario/print-action.clp
@@ -8,5 +8,12 @@
 	(bind ?severity (plan-action-arg severity ?param-names ?param-values info))
 	(bind ?text     (plan-action-arg text ?param-names ?param-values ""))
 	(printout ?severity ?text crlf)
+	(modify ?pa (state RUNNING))
+)
+
+(defrule print-action-end
+	(declare (salience ?*SALIENCE-LOW*))
+	?pa <- (plan-action (state RUNNING) (action-name print))
+	=>
 	(modify ?pa (state EXECUTION-SUCCEEDED))
 )


### PR DESCRIPTION
This PR introduces a `RUN-PARALLEL` compound goal:

The `RUN-PARALLEL` goal executes all its sub-goals in parallel, starting
by selecting the ones with highest priority. Once those are `DISPATCHED`,
the next batch is selected.
So priorities can be used to give a head start to certain goals, e.g., to
acquire resources before other goals start or to serialize expensive expansion
tasks.
A run-parallel stops `SELECTING` goals once a sub-goal is `REJECTED` or
`FAILED`, unless it is configured to continue regardless (which is done
by specifying the goal parameter `continue-on`).