### PR TITLE
CX: finish compound goals based on retracted sub-goals

### DIFF
--- a/src/plugins/clips-executive/clips/goals/run-all.clp
+++ b/src/plugins/clips-executive/clips/goals/run-all.clp
@@ -94,7 +94,7 @@
 	?gf <- (goal (id ?id) (type ACHIEVE) (sub-type RUN-ALL-OF-SUBGOALS) (mode DISPATCHED)
 	             (committed-to ?sub-goal))
 	?sg <- (goal (id ?sub-goal) (parent ?id) (acquired-resources)
-	             (type ACHIEVE) (mode EVALUATED) (outcome FAILED))
+	             (type ACHIEVE) (mode RETRACTED) (outcome FAILED))
 	=>
 	(modify ?gf (mode FINISHED) (outcome FAILED) (committed-to nil)
 					(error SUB-GOAL-FAILED ?sub-goal)

--- a/src/plugins/clips-executive/clips/goals/try-all.clp
+++ b/src/plugins/clips-executive/clips/goals/try-all.clp
@@ -60,7 +60,7 @@
 (defrule try-all-goal-reject
 	?gf <- (goal (id ?id) (type ACHIEVE) (sub-type TRY-ALL-OF-SUBGOALS) (mode EXPANDED))
 	(forall (goal (id ?sub-goal) (parent ?id) (type ACHIEVE))
-		(goal (id ?sub-goal) (mode EVALUATED) (outcome REJECTED)))
+		(goal (id ?sub-goal) (acquired-resources) (mode RETRACTED) (outcome REJECTED)))
 	=>
 	(modify ?gf (mode FINISHED) (outcome REJECTED) (committed-to nil)
 	        (error SUB-GOALS-REJECTED))
@@ -69,8 +69,8 @@
 (defrule try-all-goal-failed
 	?gf <- (goal (id ?id) (type ACHIEVE) (sub-type TRY-ALL-OF-SUBGOALS) (mode EXPANDED))
 	(forall (goal (id ?sub-goal) (parent ?id) (type ACHIEVE))
-		(goal (id ?sub-goal) (mode EVALUATED) (outcome FAILED|REJECTED)))
-	(goal (id ?some-subgoal) (mode EVALUATED) (outcome FAILED))
+		(goal (id ?sub-goal) (acquired-resources) (mode RETRACTED) (outcome FAILED|REJECTED)))
+	(goal (id ?some-subgoal) (mode RETRACTED) (outcome FAILED))
 	=>
 	(modify ?gf (mode FINISHED) (outcome FAILED) (committed-to nil)
 	        (error SUB-GOALS-FAILED))


### PR DESCRIPTION
This PR addresses an issue, where some compound goals (`run-all` and `try-all`) with finish conditions based on the outcome of sub-goals are getting stuck.
The problem is caused by a race between progressing the progression of the sub-goal from `EVALUATED` to `RETRACTED` and progressing the parent goal from `DISPATCHED` to `FINISHED`. The intended way to avoid this issue is to react on `RETRACTED` sub-goals instead of `EVALUATED` ones. For `run-all` and `try-all` goals this was not the case yet.

While fixing the issue i also noted, that the `try-all` goal does not wait for the release of the resources of its sub-goals either, which is now fixed as well to make it consistent with the behaviour of other compound goals.