### PR TITLE
Fix build on minimal Fedora install

### DIFF
--- a/src/plugins/realsense/Makefile
+++ b/src/plugins/realsense/Makefile
@@ -35,27 +35,31 @@ PLUGINS_all = $(PLUGINDIR)/realsense.$(SOEXT)
 REALSENSE1_INCLUDE_PATHS_ = /usr/include/librealsense1 /usr/local/include/librealsense1
 REALSENSE_INCLUDE_PATHS_ = /usr/include/librealsense /usr/local/include/librealsense
 
-ifneq ($(wildcard $(addsuffix /rs.h,$(REALSENSE1_INCLUDE_PATHS_))),)
-  # The old librealsense has been moved to librealsense1, librealsense is now
-  # librealsense2.  We need the old version because the newer version does not
-  # support our camera.
-  CFLAGS += -DHAVE_REALSENSE1
-  LIBS_realsense += realsense1
-  PLUGINS_build = $(PLUGINS_all)
-else ifneq ($(wildcard $(addsuffix /rs.h,$(REALSENSE_INCLUDE_PATHS_))),)
-  # No librealsense1 but there is a librealsense.
-  # Check its version by checking for RS_API_MAJOR_VERSION in the header.
-  REALSENSE_VERSION=$(shell awk \
-    '/^\#define\s+RS_API_MAJOR_VERSION\s+\S+/{ print $$3; }' \
-    $(firstword $(wildcard $(addsuffix /rs.h,$(REALSENSE_INCLUDE_PATHS_)))))
-  ifeq ($(REALSENSE_VERSION),1)
-    LIBS_realsense += realsense
-    PLUGINS_build = $(PLUGINS_all)
-  else
-    WARN_TARGETS += warning_librealsense_version
-  endif
+ifneq ($(HAVE_PCL),1)
+  WARN_TARGETS += warning_pcl
 else
-  WARN_TARGETS += warning_librealsense
+  ifneq ($(wildcard $(addsuffix /rs.h,$(REALSENSE1_INCLUDE_PATHS_))),)
+    # The old librealsense has been moved to librealsense1, librealsense is now
+    # librealsense2.  We need the old version because the newer version does not
+    # support our camera.
+    CFLAGS += -DHAVE_REALSENSE1
+    LIBS_realsense += realsense1
+    PLUGINS_build = $(PLUGINS_all)
+  else ifneq ($(wildcard $(addsuffix /rs.h,$(REALSENSE_INCLUDE_PATHS_))),)
+    # No librealsense1 but there is a librealsense.
+    # Check its version by checking for RS_API_MAJOR_VERSION in the header.
+    REALSENSE_VERSION=$(shell awk \
+      '/^\#define\s+RS_API_MAJOR_VERSION\s+\S+/{ print $$3; }' \
+      $(firstword $(wildcard $(addsuffix /rs.h,$(REALSENSE_INCLUDE_PATHS_)))))
+    ifeq ($(REALSENSE_VERSION),1)
+      LIBS_realsense += realsense
+      PLUGINS_build = $(PLUGINS_all)
+    else
+      WARN_TARGETS += warning_librealsense_version
+    endif
+  else
+    WARN_TARGETS += warning_librealsense
+  endif
 endif
 
 ifeq ($(OBJSSUBMAKE),1)
@@ -66,6 +70,8 @@ warning_librealsense:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense Plugin$(TNORMAL) (librealsense not found)"
 warning_librealsense_version:
 	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense Plugin$(TNORMAL) (incompatible librealsense version $(REALSENSE_VERSION))"
+warning_pcl:
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting Realsense plugin$(TNORMAL) (PCL not available)"
 endif
 
 include $(BUILDSYSDIR)/base.mk

--- a/src/tools/laser_calibration/Makefile
+++ b/src/tools/laser_calibration/Makefile
@@ -54,11 +54,11 @@ ifeq ($(OBJSSUBMAKE),1)
 all: $(WARN_TARGETS)
 .PHONY: warning_tf warning_pcl warning_pcl_libs
 warning_tf:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting laser calibration tool (TF not available)"
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting laser calibration tool$(TNORMAL) (TF not available)"
 warning_pcl:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting laser calibration tool (PCL not available)"
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting laser calibration tool$(TNORMAL) (PCL not available)"
 warning_pcl_libs:
-	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting laser calibration tool (not all PCL libs available, required: $(REQUIRED_PCL_LIBS))"
+	$(SILENT)echo -e "$(INDENT_PRINT)--> $(TRED)Omitting laser calibration tool$(TNORMAL) (not all PCL libs available, required: $(REQUIRED_PCL_LIBS))"
 endif
 
 include $(BUILDSYSDIR)/base.mk


### PR DESCRIPTION
I tried to build for old times sake after upgrading my laptop to Fedora 33. Due to PCL missing Fawkes would not build. This PR fixes it. Additionally it fixes a small oversight in the laser_calibration Makefile leading to unexpected output coloring.