### PR TITLE
Fix compiler errors on Fedora 34

### DIFF
--- a/src/libs/aspect/inifins/mainloop.cpp
+++ b/src/libs/aspect/inifins/mainloop.cpp
@@ -97,7 +97,7 @@ MainLoopAspectIniFin::finalize(Thread *thread)
 }
 
 bool
-MainLoopAspectIniFin::thread_started(Thread *thread) throw()
+MainLoopAspectIniFin::thread_started(Thread *thread) noexcept
 {
 	MainLoopAspect *mainloop_thread;
 	if ((mainloop_thread = dynamic_cast<MainLoopAspect *>(thread)) != NULL) {
@@ -113,7 +113,7 @@ MainLoopAspectIniFin::thread_started(Thread *thread) throw()
 }
 
 bool
-MainLoopAspectIniFin::thread_init_failed(Thread *thread) throw()
+MainLoopAspectIniFin::thread_init_failed(Thread *thread) noexcept
 {
 	MainLoopAspect *mainloop_thread;
 	if ((mainloop_thread = dynamic_cast<MainLoopAspect *>(thread)) != NULL) {

--- a/src/libs/aspect/inifins/mainloop.h
+++ b/src/libs/aspect/inifins/mainloop.h
@@ -42,8 +42,8 @@ public:
 	virtual void init(Thread *thread);
 	virtual void finalize(Thread *thread);
 
-	virtual bool thread_started(Thread *thread) throw();
-	virtual bool thread_init_failed(Thread *thread) throw();
+	virtual bool thread_started(Thread *thread) noexcept;
+	virtual bool thread_init_failed(Thread *thread) noexcept;
 
 private:
 	MainLoopEmployer *                   employer_;

--- a/src/libs/blackboard/blackboard.cpp
+++ b/src/libs/blackboard/blackboard.cpp
@@ -115,11 +115,11 @@ namespace fawkes {
  * @param interface interface to close
  *
  *
- * @fn bool BlackBoard::is_alive() const throw() = 0
+ * @fn bool BlackBoard::is_alive() const noexcept = 0
  * Check if the BlackBoard is still alive.
  * @return true, if the BlackBoard is still alive and may be used, false otherwise.
  *
- * @fn bool BlackBoard::try_aliveness_restore() throw()
+ * @fn bool BlackBoard::try_aliveness_restore() noexcept
  * Try to restore the aliveness of the BlackBoard instance.
  * Note that even though the aliveness of the BlackBoard is restored single
  * interfaces may still be invalid. That can for instance happen if a remote

--- a/src/libs/blackboard/blackboard.h
+++ b/src/libs/blackboard/blackboard.h
@@ -60,8 +60,8 @@ public:
 
 	virtual InterfaceInfoList *list_all()                                             = 0;
 	virtual InterfaceInfoList *list(const char *type_pattern, const char *id_pattern) = 0;
-	virtual bool               is_alive() const throw()                               = 0;
-	virtual bool               try_aliveness_restore() throw()                        = 0;
+	virtual bool               is_alive() const noexcept                              = 0;
+	virtual bool               try_aliveness_restore() noexcept                       = 0;
 
 	virtual std::list<Interface *> open_multiple_for_reading(const char *type_pattern,
 	                                                         const char *id_pattern = "*",

--- a/src/libs/blackboard/interface_list_maintainer.cpp
+++ b/src/libs/blackboard/interface_list_maintainer.cpp
@@ -111,7 +111,7 @@ BlackBoardInterfaceListMaintainer::~BlackBoardInterfaceListMaintainer()
  * @param id    the name of the interface
  */
 void
-BlackBoardInterfaceListMaintainer::bb_interface_created(const char *type, const char *id) throw()
+BlackBoardInterfaceListMaintainer::bb_interface_created(const char *type, const char *id) noexcept
 {
 	Interface *pif;
 	try {
@@ -149,8 +149,9 @@ BlackBoardInterfaceListMaintainer::bb_interface_created(const char *type, const 
  * @param instance_serial defiend by the callback, not used here
  */
 void
-BlackBoardInterfaceListMaintainer::bb_interface_writer_removed(fawkes::Interface *interface,
-                                                               fawkes::Uuid instance_serial) throw()
+BlackBoardInterfaceListMaintainer::bb_interface_writer_removed(
+  fawkes::Interface *interface,
+  fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
@@ -161,8 +162,9 @@ BlackBoardInterfaceListMaintainer::bb_interface_writer_removed(fawkes::Interface
  * @param instance_serial defiend by the callback, not used here
  */
 void
-BlackBoardInterfaceListMaintainer::bb_interface_reader_removed(fawkes::Interface *interface,
-                                                               fawkes::Uuid instance_serial) throw()
+BlackBoardInterfaceListMaintainer::bb_interface_reader_removed(
+  fawkes::Interface *interface,
+  fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
@@ -173,7 +175,7 @@ BlackBoardInterfaceListMaintainer::bb_interface_reader_removed(fawkes::Interface
  * @param pif interface to close
  */
 void
-BlackBoardInterfaceListMaintainer::conditional_close(Interface *pif) throw()
+BlackBoardInterfaceListMaintainer::conditional_close(Interface *pif) noexcept
 {
 	bool        close = false;
 	MutexLocker lock(ifs_.mutex());

--- a/src/libs/blackboard/interface_list_maintainer.h
+++ b/src/libs/blackboard/interface_list_maintainer.h
@@ -60,15 +60,15 @@ public:
 
 private:
 	// for BlackBoardInterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	// for BlackBoardInterfaceListener
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 
-	void conditional_close(fawkes::Interface *interface) throw();
+	void conditional_close(fawkes::Interface *interface) noexcept;
 
 private:
 	BlackBoard *                          blackboard_;

--- a/src/libs/blackboard/interface_listener.cpp
+++ b/src/libs/blackboard/interface_listener.cpp
@@ -122,7 +122,7 @@ BlackBoardInterfaceListener::bbil_name() const
  * @see bb_interface_data_changed
  */
 void
-BlackBoardInterfaceListener::bb_interface_data_refreshed(Interface *interface) throw()
+BlackBoardInterfaceListener::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 }
 
@@ -136,7 +136,7 @@ BlackBoardInterfaceListener::bb_interface_data_refreshed(Interface *interface) t
  * @see bb_interface_data_refreshed
  */
 void
-BlackBoardInterfaceListener::bb_interface_data_changed(Interface *interface) throw()
+BlackBoardInterfaceListener::bb_interface_data_changed(Interface *interface) noexcept
 {
 }
 
@@ -159,7 +159,7 @@ BlackBoardInterfaceListener::bb_interface_data_changed(Interface *interface) thr
  */
 bool
 BlackBoardInterfaceListener::bb_interface_message_received(Interface *interface,
-                                                           Message *  message) throw()
+                                                           Message *  message) noexcept
 {
 	return true;
 }
@@ -173,7 +173,7 @@ BlackBoardInterfaceListener::bb_interface_message_received(Interface *interface,
  */
 void
 BlackBoardInterfaceListener::bb_interface_reader_added(Interface *interface,
-                                                       Uuid       instance_serial) throw()
+                                                       Uuid       instance_serial) noexcept
 {
 }
 
@@ -186,7 +186,7 @@ BlackBoardInterfaceListener::bb_interface_reader_added(Interface *interface,
  */
 void
 BlackBoardInterfaceListener::bb_interface_reader_removed(Interface *interface,
-                                                         Uuid       instance_serial) throw()
+                                                         Uuid       instance_serial) noexcept
 {
 }
 
@@ -199,7 +199,7 @@ BlackBoardInterfaceListener::bb_interface_reader_removed(Interface *interface,
  */
 void
 BlackBoardInterfaceListener::bb_interface_writer_added(Interface *interface,
-                                                       Uuid       instance_serial) throw()
+                                                       Uuid       instance_serial) noexcept
 {
 }
 
@@ -212,7 +212,7 @@ BlackBoardInterfaceListener::bb_interface_writer_added(Interface *interface,
  */
 void
 BlackBoardInterfaceListener::bb_interface_writer_removed(Interface *interface,
-                                                         Uuid       instance_serial) throw()
+                                                         Uuid       instance_serial) noexcept
 {
 }
 
@@ -333,14 +333,14 @@ BlackBoardInterfaceListener::bbil_remove_writer_interface(Interface *interface)
 }
 
 const BlackBoardInterfaceListener::InterfaceQueue &
-BlackBoardInterfaceListener::bbil_acquire_queue() throw()
+BlackBoardInterfaceListener::bbil_acquire_queue() noexcept
 {
 	bbil_queue_mutex_->lock();
 	return bbil_queue_;
 }
 
 void
-BlackBoardInterfaceListener::bbil_release_queue(BlackBoard::ListenerRegisterFlag flag) throw()
+BlackBoardInterfaceListener::bbil_release_queue(BlackBoard::ListenerRegisterFlag flag) noexcept
 {
 	bbil_maps_mutex_->lock();
 
@@ -426,14 +426,14 @@ BlackBoardInterfaceListener::bbil_release_queue(BlackBoard::ListenerRegisterFlag
 }
 
 const BlackBoardInterfaceListener::InterfaceMaps &
-BlackBoardInterfaceListener::bbil_acquire_maps() throw()
+BlackBoardInterfaceListener::bbil_acquire_maps() noexcept
 {
 	bbil_maps_mutex_->lock();
 	return bbil_maps_;
 }
 
 void
-BlackBoardInterfaceListener::bbil_release_maps() throw()
+BlackBoardInterfaceListener::bbil_release_maps() noexcept
 {
 	bbil_queue_mutex_->lock();
 
@@ -483,7 +483,7 @@ BlackBoardInterfaceListener::bbil_find_interface(const char *iuid, InterfaceMap 
  * @return interface instance, NULL if not in list (non-fatal error)
  */
 Interface *
-BlackBoardInterfaceListener::bbil_data_interface(const char *iuid) throw()
+BlackBoardInterfaceListener::bbil_data_interface(const char *iuid) noexcept
 {
 	return bbil_find_interface(iuid, bbil_maps_.data);
 }
@@ -495,7 +495,7 @@ BlackBoardInterfaceListener::bbil_data_interface(const char *iuid) throw()
  * @return interface instance, NULL if not in list (non-fatal error)
  */
 Interface *
-BlackBoardInterfaceListener::bbil_message_interface(const char *iuid) throw()
+BlackBoardInterfaceListener::bbil_message_interface(const char *iuid) noexcept
 {
 	return bbil_find_interface(iuid, bbil_maps_.messages);
 }
@@ -507,7 +507,7 @@ BlackBoardInterfaceListener::bbil_message_interface(const char *iuid) throw()
  * @return interface instance, NULL if not in list (non-fatal error)
  */
 Interface *
-BlackBoardInterfaceListener::bbil_reader_interface(const char *iuid) throw()
+BlackBoardInterfaceListener::bbil_reader_interface(const char *iuid) noexcept
 {
 	return bbil_find_interface(iuid, bbil_maps_.reader);
 }
@@ -519,7 +519,7 @@ BlackBoardInterfaceListener::bbil_reader_interface(const char *iuid) throw()
  * @return interface instance, NULL if not in list (non-fatal error)
  */
 Interface *
-BlackBoardInterfaceListener::bbil_writer_interface(const char *iuid) throw()
+BlackBoardInterfaceListener::bbil_writer_interface(const char *iuid) noexcept
 {
 	return bbil_find_interface(iuid, bbil_maps_.writer);
 }

--- a/src/libs/blackboard/interface_listener.h
+++ b/src/libs/blackboard/interface_listener.h
@@ -79,13 +79,13 @@ public:
 
 	const char *bbil_name() const;
 
-	virtual void bb_interface_data_refreshed(Interface *interface) throw();
-	virtual void bb_interface_data_changed(Interface *interface) throw();
-	virtual bool bb_interface_message_received(Interface *interface, Message *message) throw();
-	virtual void bb_interface_writer_added(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_reader_added(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_reader_removed(Interface *interface, Uuid instance_serial) throw();
+	virtual void bb_interface_data_refreshed(Interface *interface) noexcept;
+	virtual void bb_interface_data_changed(Interface *interface) noexcept;
+	virtual bool bb_interface_message_received(Interface *interface, Message *message) noexcept;
+	virtual void bb_interface_writer_added(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_writer_removed(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_reader_added(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_reader_removed(Interface *interface, Uuid instance_serial) noexcept;
 
 protected:
 	void bbil_add_data_interface(Interface *interface);
@@ -98,10 +98,10 @@ protected:
 	void bbil_remove_reader_interface(Interface *interface);
 	void bbil_remove_writer_interface(Interface *interface);
 
-	Interface *bbil_data_interface(const char *iuid) throw();
-	Interface *bbil_message_interface(const char *iuid) throw();
-	Interface *bbil_reader_interface(const char *iuid) throw();
-	Interface *bbil_writer_interface(const char *iuid) throw();
+	Interface *bbil_data_interface(const char *iuid) noexcept;
+	Interface *bbil_message_interface(const char *iuid) noexcept;
+	Interface *bbil_reader_interface(const char *iuid) noexcept;
+	Interface *bbil_writer_interface(const char *iuid) noexcept;
 
 private:
 	void       bbil_queue_add(QueueEntryType type,
@@ -111,11 +111,11 @@ private:
 	                          const char *   hint);
 	Interface *bbil_find_interface(const char *iuid, InterfaceMap &map);
 
-	const InterfaceQueue &bbil_acquire_queue() throw();
-	void                  bbil_release_queue(BlackBoard::ListenerRegisterFlag flag) throw();
+	const InterfaceQueue &bbil_acquire_queue() noexcept;
+	void                  bbil_release_queue(BlackBoard::ListenerRegisterFlag flag) noexcept;
 
-	const InterfaceMaps &bbil_acquire_maps() throw();
-	void                 bbil_release_maps() throw();
+	const InterfaceMaps &bbil_acquire_maps() noexcept;
+	void                 bbil_release_maps() noexcept;
 
 private:
 	Mutex *bbil_queue_mutex_;

--- a/src/libs/blackboard/interface_observer.cpp
+++ b/src/libs/blackboard/interface_observer.cpp
@@ -88,7 +88,7 @@ BlackBoardInterfaceObserver::~BlackBoardInterfaceObserver()
  * the duration of the method call
  */
 void
-BlackBoardInterfaceObserver::bb_interface_created(const char *type, const char *id) throw()
+BlackBoardInterfaceObserver::bb_interface_created(const char *type, const char *id) noexcept
 {
 }
 
@@ -103,7 +103,7 @@ BlackBoardInterfaceObserver::bb_interface_created(const char *type, const char *
  * the duration of the method call
  */
 void
-BlackBoardInterfaceObserver::bb_interface_destroyed(const char *type, const char *id) throw()
+BlackBoardInterfaceObserver::bb_interface_destroyed(const char *type, const char *id) noexcept
 {
 }
 
@@ -117,7 +117,7 @@ BlackBoardInterfaceObserver::bb_interface_destroyed(const char *type, const char
  */
 void
 BlackBoardInterfaceObserver::bbio_add_observed_create(const char *type_pattern,
-                                                      const char *id_pattern) throw()
+                                                      const char *id_pattern) noexcept
 {
 	bbio_observed_create_.lock();
 	bbio_observed_create_[type_pattern].push_back(id_pattern);
@@ -136,7 +136,7 @@ BlackBoardInterfaceObserver::bbio_add_observed_create(const char *type_pattern,
  */
 void
 BlackBoardInterfaceObserver::bbio_add_observed_destroy(const char *type_pattern,
-                                                       const char *id_pattern) throw()
+                                                       const char *id_pattern) noexcept
 {
 	bbio_observed_destroy_.lock();
 	bbio_observed_destroy_[type_pattern].push_back(id_pattern);
@@ -149,7 +149,7 @@ BlackBoardInterfaceObserver::bbio_add_observed_destroy(const char *type_pattern,
  * @return interface type watch list
  */
 BlackBoardInterfaceObserver::ObservedInterfaceLockMap *
-BlackBoardInterfaceObserver::bbio_get_observed_create() throw()
+BlackBoardInterfaceObserver::bbio_get_observed_create() noexcept
 {
 	return &bbio_observed_create_;
 }
@@ -158,7 +158,7 @@ BlackBoardInterfaceObserver::bbio_get_observed_create() throw()
  * @return interface type watch list
  */
 BlackBoardInterfaceObserver::ObservedInterfaceLockMap *
-BlackBoardInterfaceObserver::bbio_get_observed_destroy() throw()
+BlackBoardInterfaceObserver::bbio_get_observed_destroy() noexcept
 {
 	return &bbio_observed_destroy_;
 }

--- a/src/libs/blackboard/interface_observer.h
+++ b/src/libs/blackboard/interface_observer.h
@@ -41,12 +41,12 @@ public:
 	BlackBoardInterfaceObserver();
 	virtual ~BlackBoardInterfaceObserver();
 
-	virtual void bb_interface_created(const char *type, const char *id) throw();
-	virtual void bb_interface_destroyed(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
+	virtual void bb_interface_destroyed(const char *type, const char *id) noexcept;
 
 protected:
-	void bbio_add_observed_create(const char *type_pattern, const char *id_pattern = "*") throw();
-	void bbio_add_observed_destroy(const char *type_pattern, const char *id_pattern = "*") throw();
+	void bbio_add_observed_create(const char *type_pattern, const char *id_pattern = "*") noexcept;
+	void bbio_add_observed_destroy(const char *type_pattern, const char *id_pattern = "*") noexcept;
 
 	/** Type for lockable interface type hash sets. */
 	typedef LockMap<std::string, std::list<std::string>> ObservedInterfaceLockMap;
@@ -54,8 +54,8 @@ protected:
 	/** Type for iterator of lockable interface type hash sets. */
 	typedef ObservedInterfaceLockMap::iterator ObservedInterfaceLockMapIterator;
 
-	ObservedInterfaceLockMap *bbio_get_observed_create() throw();
-	ObservedInterfaceLockMap *bbio_get_observed_destroy() throw();
+	ObservedInterfaceLockMap *bbio_get_observed_create() noexcept;
+	ObservedInterfaceLockMap *bbio_get_observed_destroy() noexcept;
 
 private:
 	ObservedInterfaceLockMap         bbio_observed_create_;

--- a/src/libs/blackboard/internal/notifier.cpp
+++ b/src/libs/blackboard/internal/notifier.cpp
@@ -398,7 +398,7 @@ BlackBoardNotifier::unregister_observer(BlackBoardInterfaceObserver *observer)
  * @param id ID of the interface
  */
 void
-BlackBoardNotifier::notify_of_interface_created(const char *type, const char *id) throw()
+BlackBoardNotifier::notify_of_interface_created(const char *type, const char *id) noexcept
 {
 	bbio_mutex_->lock();
 	bbio_events_ += 1;
@@ -433,7 +433,7 @@ BlackBoardNotifier::notify_of_interface_created(const char *type, const char *id
  * @param id ID of the interface
  */
 void
-BlackBoardNotifier::notify_of_interface_destroyed(const char *type, const char *id) throw()
+BlackBoardNotifier::notify_of_interface_destroyed(const char *type, const char *id) noexcept
 {
 	bbio_mutex_->lock();
 	bbio_events_ += 1;
@@ -493,7 +493,7 @@ BlackBoardNotifier::process_bbio_queue()
  */
 void
 BlackBoardNotifier::notify_of_writer_added(const Interface *interface,
-                                           Uuid             event_instance_serial) throw()
+                                           Uuid             event_instance_serial) noexcept
 {
 	bbil_writer_mutex_->lock();
 	bbil_writer_events_ += 1;
@@ -530,7 +530,7 @@ BlackBoardNotifier::notify_of_writer_added(const Interface *interface,
  */
 void
 BlackBoardNotifier::notify_of_writer_removed(const Interface *interface,
-                                             Uuid             event_instance_serial) throw()
+                                             Uuid             event_instance_serial) noexcept
 {
 	bbil_writer_mutex_->lock();
 	bbil_writer_events_ += 1;
@@ -587,7 +587,7 @@ BlackBoardNotifier::process_writer_queue()
  */
 void
 BlackBoardNotifier::notify_of_reader_added(const Interface *interface,
-                                           Uuid             event_instance_serial) throw()
+                                           Uuid             event_instance_serial) noexcept
 {
 	bbil_reader_mutex_->lock();
 	bbil_reader_events_ += 1;
@@ -624,7 +624,7 @@ BlackBoardNotifier::notify_of_reader_added(const Interface *interface,
  */
 void
 BlackBoardNotifier::notify_of_reader_removed(const Interface *interface,
-                                             Uuid             event_instance_serial) throw()
+                                             Uuid             event_instance_serial) noexcept
 {
 	bbil_reader_mutex_->lock();
 	bbil_reader_events_ += 1;

--- a/src/libs/blackboard/internal/notifier.h
+++ b/src/libs/blackboard/internal/notifier.h
@@ -57,12 +57,12 @@ public:
 
 	void notify_of_data_refresh(const Interface *interface, bool has_changed);
 	bool notify_of_message_received(const Interface *interface, Message *message);
-	void notify_of_interface_created(const char *type, const char *id) throw();
-	void notify_of_interface_destroyed(const char *type, const char *id) throw();
-	void notify_of_writer_added(const Interface *interface, Uuid event_instance_serial) throw();
-	void notify_of_writer_removed(const Interface *interface, Uuid event_instance_serial) throw();
-	void notify_of_reader_added(const Interface *interface, Uuid event_instance_serial) throw();
-	void notify_of_reader_removed(const Interface *interface, Uuid event_instance_serial) throw();
+	void notify_of_interface_created(const char *type, const char *id) noexcept;
+	void notify_of_interface_destroyed(const char *type, const char *id) noexcept;
+	void notify_of_writer_added(const Interface *interface, Uuid event_instance_serial) noexcept;
+	void notify_of_writer_removed(const Interface *interface, Uuid event_instance_serial) noexcept;
+	void notify_of_reader_added(const Interface *interface, Uuid event_instance_serial) noexcept;
+	void notify_of_reader_removed(const Interface *interface, Uuid event_instance_serial) noexcept;
 
 private:
 	/// @cond INTERNALS

--- a/src/libs/blackboard/local.cpp
+++ b/src/libs/blackboard/local.cpp
@@ -143,13 +143,13 @@ LocalBlackBoard::list(const char *type_pattern, const char *id_pattern)
 }
 
 bool
-LocalBlackBoard::is_alive() const throw()
+LocalBlackBoard::is_alive() const noexcept
 {
 	return true;
 }
 
 bool
-LocalBlackBoard::try_aliveness_restore() throw()
+LocalBlackBoard::try_aliveness_restore() noexcept
 {
 	return true;
 }

--- a/src/libs/blackboard/local.h
+++ b/src/libs/blackboard/local.h
@@ -56,8 +56,8 @@ public:
 
 	virtual InterfaceInfoList *list_all();
 	virtual InterfaceInfoList *list(const char *type_pattern, const char *id_pattern);
-	virtual bool               is_alive() const throw();
-	virtual bool               try_aliveness_restore() throw();
+	virtual bool               is_alive() const noexcept;
+	virtual bool               try_aliveness_restore() noexcept;
 
 	virtual std::list<Interface *> open_multiple_for_reading(const char *type_pattern,
 	                                                         const char *id_pattern = "*",

--- a/src/libs/blackboard/net/interface_listener.cpp
+++ b/src/libs/blackboard/net/interface_listener.cpp
@@ -78,7 +78,7 @@ BlackBoardNetHandlerInterfaceListener::~BlackBoardNetHandlerInterfaceListener()
 }
 
 void
-BlackBoardNetHandlerInterfaceListener::bb_interface_data_refreshed(Interface *interface) throw()
+BlackBoardNetHandlerInterfaceListener::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	// send out data refreshed notification
 	interface->read();
@@ -99,7 +99,7 @@ BlackBoardNetHandlerInterfaceListener::bb_interface_data_refreshed(Interface *in
 }
 
 void
-BlackBoardNetHandlerInterfaceListener::bb_interface_data_changed(Interface *interface) throw()
+BlackBoardNetHandlerInterfaceListener::bb_interface_data_changed(Interface *interface) noexcept
 {
 	// send out data changed notification
 	interface->read();
@@ -121,7 +121,7 @@ BlackBoardNetHandlerInterfaceListener::bb_interface_data_changed(Interface *inte
 
 bool
 BlackBoardNetHandlerInterfaceListener::bb_interface_message_received(Interface *interface,
-                                                                     Message *  message) throw()
+                                                                     Message *  message) noexcept
 {
 	// send out interface message
 	size_t             payload_size = sizeof(bb_imessage_msg_t) + message->datasize();
@@ -169,28 +169,28 @@ BlackBoardNetHandlerInterfaceListener::send_event_serial(Interface *  interface,
 
 void
 BlackBoardNetHandlerInterfaceListener::bb_interface_writer_added(Interface *interface,
-                                                                 Uuid       instance_serial) throw()
+                                                                 Uuid instance_serial) noexcept
 {
 	send_event_serial(interface, MSG_BB_WRITER_ADDED, instance_serial);
 }
 
 void
 BlackBoardNetHandlerInterfaceListener::bb_interface_writer_removed(Interface *interface,
-                                                                   Uuid instance_serial) throw()
+                                                                   Uuid instance_serial) noexcept
 {
 	send_event_serial(interface, MSG_BB_WRITER_REMOVED, instance_serial);
 }
 
 void
 BlackBoardNetHandlerInterfaceListener::bb_interface_reader_added(Interface *interface,
-                                                                 Uuid       instance_serial) throw()
+                                                                 Uuid instance_serial) noexcept
 {
 	send_event_serial(interface, MSG_BB_READER_ADDED, instance_serial);
 }
 
 void
 BlackBoardNetHandlerInterfaceListener::bb_interface_reader_removed(Interface *interface,
-                                                                   Uuid instance_serial) throw()
+                                                                   Uuid instance_serial) noexcept
 {
 	send_event_serial(interface, MSG_BB_READER_REMOVED, instance_serial);
 }

--- a/src/libs/blackboard/net/interface_listener.h
+++ b/src/libs/blackboard/net/interface_listener.h
@@ -40,13 +40,13 @@ public:
 	                                      unsigned int      clid);
 	virtual ~BlackBoardNetHandlerInterfaceListener();
 
-	virtual void bb_interface_data_refreshed(Interface *interface) throw();
-	virtual void bb_interface_data_changed(Interface *interface) throw();
-	virtual bool bb_interface_message_received(Interface *interface, Message *message) throw();
-	virtual void bb_interface_writer_added(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_reader_added(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_reader_removed(Interface *interface, Uuid instance_serial) throw();
+	virtual void bb_interface_data_refreshed(Interface *interface) noexcept;
+	virtual void bb_interface_data_changed(Interface *interface) noexcept;
+	virtual bool bb_interface_message_received(Interface *interface, Message *message) noexcept;
+	virtual void bb_interface_writer_added(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_writer_removed(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_reader_added(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_reader_removed(Interface *interface, Uuid instance_serial) noexcept;
 
 private:
 	void send_event_serial(Interface *interface, unsigned int msg_id, Uuid event_serial);

--- a/src/libs/blackboard/net/interface_observer.cpp
+++ b/src/libs/blackboard/net/interface_observer.cpp
@@ -88,14 +88,14 @@ BlackBoardNetHandlerInterfaceObserver::send_event(unsigned int msg_id,
 
 void
 BlackBoardNetHandlerInterfaceObserver::bb_interface_created(const char *type,
-                                                            const char *id) throw()
+                                                            const char *id) noexcept
 {
 	send_event(MSG_BB_INTERFACE_CREATED, type, id);
 }
 
 void
 BlackBoardNetHandlerInterfaceObserver::bb_interface_destroyed(const char *type,
-                                                              const char *id) throw()
+                                                              const char *id) noexcept
 {
 	send_event(MSG_BB_INTERFACE_DESTROYED, type, id);
 }

--- a/src/libs/blackboard/net/interface_observer.h
+++ b/src/libs/blackboard/net/interface_observer.h
@@ -37,8 +37,8 @@ public:
 	BlackBoardNetHandlerInterfaceObserver(BlackBoard *blackboard, FawkesNetworkHub *hub);
 	virtual ~BlackBoardNetHandlerInterfaceObserver();
 
-	virtual void bb_interface_created(const char *type, const char *id) throw();
-	virtual void bb_interface_destroyed(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
+	virtual void bb_interface_destroyed(const char *type, const char *id) noexcept;
 
 private:
 	void send_event(unsigned int msg_id, const char *type, const char *id);

--- a/src/libs/blackboard/ownership.cpp
+++ b/src/libs/blackboard/ownership.cpp
@@ -101,13 +101,13 @@ BlackBoardWithOwnership::list(const char *type_pattern, const char *id_pattern)
 }
 
 bool
-BlackBoardWithOwnership::is_alive() const throw()
+BlackBoardWithOwnership::is_alive() const noexcept
 {
 	return blackboard_->is_alive();
 }
 
 bool
-BlackBoardWithOwnership::try_aliveness_restore() throw()
+BlackBoardWithOwnership::try_aliveness_restore() noexcept
 {
 	return blackboard_->try_aliveness_restore();
 }

--- a/src/libs/blackboard/ownership.h
+++ b/src/libs/blackboard/ownership.h
@@ -41,8 +41,8 @@ public:
 
 	virtual InterfaceInfoList *list_all();
 	virtual InterfaceInfoList *list(const char *type_pattern, const char *id_pattern);
-	virtual bool               is_alive() const throw();
-	virtual bool               try_aliveness_restore() throw();
+	virtual bool               is_alive() const noexcept;
+	virtual bool               try_aliveness_restore() noexcept;
 
 	virtual std::list<Interface *> open_multiple_for_reading(const char *type_pattern,
 	                                                         const char *id_pattern = "*",

--- a/src/libs/blackboard/qa/qa_bb_notify.cpp
+++ b/src/libs/blackboard/qa/qa_bb_notify.cpp
@@ -54,25 +54,25 @@ public:
 	}
 
 	virtual void
-	bb_interface_created(const char *type, const char *id) throw()
+	bb_interface_created(const char *type, const char *id) noexcept
 	{
 		printf("BBIO: Interface %s of type %s has been created\n", id, type);
 	}
 
 	virtual void
-	bb_interface_destroyed(const char *type, const char *id) throw()
+	bb_interface_destroyed(const char *type, const char *id) noexcept
 	{
 		printf("BBIO: Interface %s of type %s has been destroyed\n", id, type);
 	}
 
 	virtual void
-	bb_interface_data_refreshed(Interface *interface) throw()
+	bb_interface_data_refreshed(Interface *interface) noexcept
 	{
 		printf("BBIL: Data in interface %s has been modified\n", interface->uid());
 	}
 
 	virtual bool
-	bb_interface_message_received(Interface *interface, Message *message) throw()
+	bb_interface_message_received(Interface *interface, Message *message) noexcept
 	{
 		printf("BBIL: Message of type %s for interface %s has been received\n",
 		       message->type(),
@@ -89,7 +89,7 @@ public:
 	}
 
 	virtual void
-	bb_interface_writer_added(Interface *interface, unsigned int instance_serial) throw()
+	bb_interface_writer_added(Interface *interface, unsigned int instance_serial) noexcept
 	{
 		printf("BBIL: Writer has been added to interface %s/%u (event serial %u)\n",
 		       interface->uid(),
@@ -98,7 +98,7 @@ public:
 	}
 
 	virtual void
-	bb_interface_writer_removed(Interface *interface, unsigned int instance_serial) throw()
+	bb_interface_writer_removed(Interface *interface, unsigned int instance_serial) noexcept
 	{
 		printf("BBIL: Writer has been removed from interface %s/%u (event serial %u)\n",
 		       interface->uid(),
@@ -107,7 +107,7 @@ public:
 	}
 
 	virtual void
-	bb_interface_reader_added(Interface *interface, unsigned int instance_serial) throw()
+	bb_interface_reader_added(Interface *interface, unsigned int instance_serial) noexcept
 	{
 		printf("BBIL: Reader has been added to interface %s/%u (event serial %u)\n",
 		       interface->uid(),
@@ -116,7 +116,7 @@ public:
 	}
 
 	virtual void
-	bb_interface_reader_removed(Interface *interface, unsigned int instance_serial) throw()
+	bb_interface_reader_removed(Interface *interface, unsigned int instance_serial) noexcept
 	{
 		printf("BBIL: Reader has been removed from interface %s/%u (event serial %u)\n",
 		       interface->uid(),
@@ -125,7 +125,7 @@ public:
 	}
 
 	virtual void
-	add_interface(Interface *interface) throw()
+	add_interface(Interface *interface) noexcept
 	{
 		printf("Listener: Adding interface %s (this: %p)\n", interface->uid(), this);
 		bbil_add_data_interface(interface);

--- a/src/libs/blackboard/qa/qa_bb_remote.cpp
+++ b/src/libs/blackboard/qa/qa_bb_remote.cpp
@@ -143,7 +143,7 @@ public:
 	}
 
 	bool
-	bb_interface_message_received(Interface *interface, Message *message) throw()
+	bb_interface_message_received(Interface *interface, Message *message) noexcept
 	{
 		try {
 			if (interface == writer_) {
@@ -168,7 +168,7 @@ public:
 	}
 
 	void
-	bb_interface_data_refreshed(Interface *interface) throw()
+	bb_interface_data_refreshed(Interface *interface) noexcept
 	{
 		try {
 			if (interface == reader_) {

--- a/src/libs/blackboard/remote.cpp
+++ b/src/libs/blackboard/remote.cpp
@@ -129,7 +129,7 @@ RemoteBlackBoard::~RemoteBlackBoard()
 }
 
 bool
-RemoteBlackBoard::is_alive() const throw()
+RemoteBlackBoard::is_alive() const noexcept
 {
 	return fnc_->connected();
 }
@@ -154,7 +154,7 @@ RemoteBlackBoard::reopen_interfaces()
 }
 
 bool
-RemoteBlackBoard::try_aliveness_restore() throw()
+RemoteBlackBoard::try_aliveness_restore() noexcept
 {
 	bool rv = true;
 	try {
@@ -444,12 +444,12 @@ RemoteBlackBoard::list(const char *type_pattern, const char *id_pattern)
  * @param id the id of the calling client
  */
 void
-RemoteBlackBoard::deregistered(unsigned int id) throw()
+RemoteBlackBoard::deregistered(unsigned int id) noexcept
 {
 }
 
 void
-RemoteBlackBoard::inbound_received(FawkesNetworkMessage *m, unsigned int id) throw()
+RemoteBlackBoard::inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept
 {
 	mutex_->lock();
 	inbound_thread_ = Thread::current_thread()->name();
@@ -512,7 +512,7 @@ RemoteBlackBoard::inbound_received(FawkesNetworkMessage *m, unsigned int id) thr
 }
 
 void
-RemoteBlackBoard::connection_died(unsigned int id) throw()
+RemoteBlackBoard::connection_died(unsigned int id) noexcept
 {
 	// mark all assigned interfaces as invalid
 	proxies_.lock();
@@ -526,7 +526,7 @@ RemoteBlackBoard::connection_died(unsigned int id) throw()
 }
 
 void
-RemoteBlackBoard::connection_established(unsigned int id) throw()
+RemoteBlackBoard::connection_established(unsigned int id) noexcept
 {
 }
 

--- a/src/libs/blackboard/remote.h
+++ b/src/libs/blackboard/remote.h
@@ -61,18 +61,18 @@ public:
 
 	virtual InterfaceInfoList *list_all();
 	virtual InterfaceInfoList *list(const char *type_pattern, const char *id_pattern);
-	virtual bool               is_alive() const throw();
-	virtual bool               try_aliveness_restore() throw();
+	virtual bool               is_alive() const noexcept;
+	virtual bool               try_aliveness_restore() noexcept;
 
 	std::list<Interface *> open_multiple_for_reading(const char *interface_type,
 	                                                 const char *id_pattern = "*",
 	                                                 const char *owner      = NULL);
 
 	/* for FawkesNetworkClientHandler */
-	virtual void deregistered(unsigned int id) throw();
-	virtual void inbound_received(FawkesNetworkMessage *msg, unsigned int id) throw();
-	virtual void connection_died(unsigned int id) throw();
-	virtual void connection_established(unsigned int id) throw();
+	virtual void deregistered(unsigned int id) noexcept;
+	virtual void inbound_received(FawkesNetworkMessage *msg, unsigned int id) noexcept;
+	virtual void connection_died(unsigned int id) noexcept;
+	virtual void connection_established(unsigned int id) noexcept;
 
 	/* extensions for RemoteBlackBoard */
 

--- a/src/libs/blackboard/utils/on_message_waker.cpp
+++ b/src/libs/blackboard/utils/on_message_waker.cpp
@@ -60,7 +60,7 @@ BlackBoardOnMessageWaker::~BlackBoardOnMessageWaker()
 
 bool
 BlackBoardOnMessageWaker::bb_interface_message_received(Interface *interface,
-                                                        Message *  message) throw()
+                                                        Message *  message) noexcept
 {
 	try {
 		interface->msgq_append(message);

--- a/src/libs/blackboard/utils/on_message_waker.h
+++ b/src/libs/blackboard/utils/on_message_waker.h
@@ -38,7 +38,7 @@ public:
 	BlackBoardOnMessageWaker(BlackBoard *bb, Interface *interface, Thread *thread);
 	virtual ~BlackBoardOnMessageWaker();
 
-	virtual bool bb_interface_message_received(Interface *interface, Message *message) throw();
+	virtual bool bb_interface_message_received(Interface *interface, Message *message) noexcept;
 
 private:
 	BlackBoard *bb_;

--- a/src/libs/blackboard/utils/on_update_waker.cpp
+++ b/src/libs/blackboard/utils/on_update_waker.cpp
@@ -59,7 +59,7 @@ BlackBoardOnUpdateWaker::~BlackBoardOnUpdateWaker()
 }
 
 void
-BlackBoardOnUpdateWaker::bb_interface_data_refreshed(Interface *interface) throw()
+BlackBoardOnUpdateWaker::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	thread_->wakeup();
 }

--- a/src/libs/blackboard/utils/on_update_waker.h
+++ b/src/libs/blackboard/utils/on_update_waker.h
@@ -37,7 +37,7 @@ public:
 	BlackBoardOnUpdateWaker(BlackBoard *bb, Interface *interface, Thread *thread);
 	virtual ~BlackBoardOnUpdateWaker();
 
-	virtual void bb_interface_data_refreshed(Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(Interface *interface) noexcept;
 
 private:
 	BlackBoard *bb_;

--- a/src/libs/config/netconf.cpp
+++ b/src/libs/config/netconf.cpp
@@ -918,12 +918,12 @@ NetworkConfiguration::erase_default(const char *path)
  * @param id the id of the calling client
  */
 void
-NetworkConfiguration::deregistered(unsigned int id) throw()
+NetworkConfiguration::deregistered(unsigned int id) noexcept
 {
 }
 
 void
-NetworkConfiguration::inbound_received(FawkesNetworkMessage *m, unsigned int id) throw()
+NetworkConfiguration::inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept
 {
 	if (m->cid() == FAWKES_CID_CONFIGMANAGER) {
 		if (mirror_mode_) {
@@ -1228,7 +1228,7 @@ NetworkConfiguration::inbound_received(FawkesNetworkMessage *m, unsigned int id)
 }
 
 void
-NetworkConfiguration::connection_died(unsigned int id) throw()
+NetworkConfiguration::connection_died(unsigned int id) noexcept
 {
 	connected_                          = false;
 	mirror_mode_before_connection_dead_ = mirror_mode_;
@@ -1237,7 +1237,7 @@ NetworkConfiguration::connection_died(unsigned int id) throw()
 }
 
 void
-NetworkConfiguration::connection_established(unsigned int id) throw()
+NetworkConfiguration::connection_established(unsigned int id) noexcept
 {
 	connected_ = true;
 	set_mirror_mode(mirror_mode_before_connection_dead_);

--- a/src/libs/config/netconf.h
+++ b/src/libs/config/netconf.h
@@ -112,10 +112,10 @@ public:
 
 	virtual void erase_default(const char *path);
 
-	virtual void deregistered(unsigned int id) throw();
-	virtual void inbound_received(FawkesNetworkMessage *msg, unsigned int id) throw();
-	virtual void connection_died(unsigned int id) throw();
-	virtual void connection_established(unsigned int id) throw();
+	virtual void deregistered(unsigned int id) noexcept;
+	virtual void inbound_received(FawkesNetworkMessage *msg, unsigned int id) noexcept;
+	virtual void connection_died(unsigned int id) noexcept;
+	virtual void connection_established(unsigned int id) noexcept;
 
 	virtual void set_mirror_mode(bool mirror);
 

--- a/src/libs/core/exception.cpp
+++ b/src/libs/core/exception.cpp
@@ -141,7 +141,7 @@ namespace fawkes {
  * arguments as append(). The message is copied and not just referenced.
  * Thus the memory has to be freed if it is a dynamic  string on the heap.
  */
-Exception::Exception(const char *format, ...) throw()
+Exception::Exception(const char *format, ...) noexcept
 {
 	messages_mutex = new Mutex();
 
@@ -171,7 +171,7 @@ Exception::Exception(const char *format, ...) throw()
  * arguments as append(). The message is copied and not just referenced.
  * Thus the memory has to be freed if it is a dynamic  string on the heap.
  */
-Exception::Exception(int errnoval, const char *format, ...) throw()
+Exception::Exception(int errnoval, const char *format, ...) noexcept
 {
 	messages_mutex = new Mutex();
 
@@ -232,7 +232,7 @@ Exception::Exception(int errnoval, const char *format, ...) throw()
  * and copy the memory area or take care that only one exception frees the memory.
  * @param exc Exception to copy
  */
-Exception::Exception(const Exception &exc) throw()
+Exception::Exception(const Exception &exc) noexcept
 {
 	messages_mutex = new Mutex();
 
@@ -250,7 +250,7 @@ Exception::Exception(const Exception &exc) throw()
  * needed (like sprintf) to assign the message. At least assign the empty
  * string to the message.
  */
-Exception::Exception() throw()
+Exception::Exception() noexcept
 {
 	messages_mutex    = new Mutex();
 	_errno            = 0;
@@ -261,7 +261,7 @@ Exception::Exception() throw()
 }
 
 /** Destructor. */
-Exception::~Exception() throw()
+Exception::~Exception() noexcept
 {
 	message_list_t *msg_this;
 	messages_iterator = messages;
@@ -311,7 +311,7 @@ Exception::type_id() const
  * options.
  */
 void
-Exception::prepend(const char *format, ...) throw()
+Exception::prepend(const char *format, ...) noexcept
 {
 	// do not append empty messages
 	if (format == NULL)
@@ -330,7 +330,7 @@ Exception::prepend(const char *format, ...) throw()
  * options.
  */
 void
-Exception::append(const char *format, ...) throw()
+Exception::append(const char *format, ...) noexcept
 {
 	// do not append empty messages
 	if (format == NULL)
@@ -350,7 +350,7 @@ Exception::append(const char *format, ...) throw()
  * @param va va_list with arguments matching the format
  */
 void
-Exception::append_va(const char *format, va_list va) throw()
+Exception::append_va(const char *format, va_list va) noexcept
 {
 	// do not append empty messages
 	if (format == NULL)
@@ -365,7 +365,7 @@ Exception::append_va(const char *format, va_list va) throw()
  * @param e Exception to copy messages from
  */
 void
-Exception::append(const Exception &e) throw()
+Exception::append(const Exception &e) noexcept
 {
 	copy_messages(e);
 }
@@ -380,7 +380,7 @@ Exception::append(const Exception &e) throw()
  * Thus the memory has to be freed if it is a dynamic  string on the heap.
  */
 void
-Exception::append_nolock(const char *format, ...) throw()
+Exception::append_nolock(const char *format, ...) noexcept
 {
 	va_list arg;
 	va_start(arg, format);
@@ -416,7 +416,7 @@ Exception::append_nolock(const char *format, ...) throw()
  * @param ap argument va_list for format
  */
 void
-Exception::prepend_nolock_va(const char *format, va_list ap) throw()
+Exception::prepend_nolock_va(const char *format, va_list ap) noexcept
 {
 	char *msg;
 	if (vasprintf(&msg, format, ap) == -1) {
@@ -446,7 +446,7 @@ Exception::prepend_nolock_va(const char *format, va_list ap) throw()
  * @param ap argument va_list for format
  */
 void
-Exception::append_nolock_va(const char *format, va_list ap) throw()
+Exception::append_nolock_va(const char *format, va_list ap) noexcept
 {
 	char *msg;
 	if (vasprintf(&msg, format, ap) == -1) {
@@ -476,7 +476,7 @@ Exception::append_nolock_va(const char *format, va_list ap) throw()
  * @param msg Message to append.
  */
 void
-Exception::append_nolock_nocopy(char *msg) throw()
+Exception::append_nolock_nocopy(char *msg) noexcept
 {
 	if (messages == NULL) {
 		// This is our first message
@@ -503,7 +503,7 @@ Exception::append_nolock_nocopy(char *msg) throw()
  * @return reference to this object. Allows assignment chaining.
  */
 Exception &
-Exception::operator=(const Exception &exc) throw()
+Exception::operator=(const Exception &exc) noexcept
 {
 	messages_mutex = new Mutex();
 	copy_messages(exc);
@@ -516,7 +516,7 @@ Exception::operator=(const Exception &exc) throw()
  * @param exc Exception to copy messages from.
  */
 void
-Exception::copy_messages(const Exception &exc) throw()
+Exception::copy_messages(const Exception &exc) noexcept
 {
 	messages_mutex->lock();
 	exc.messages_mutex->lock();
@@ -544,7 +544,7 @@ Exception::raise()
 
 /** Prints a backtrace. */
 void
-Exception::print_backtrace() const throw()
+Exception::print_backtrace() const noexcept
 {
 #ifdef HAVE_EXECINFO
 	void * array[25];
@@ -566,7 +566,7 @@ Exception::print_backtrace() const throw()
  * @return freshly allocated string of backtrace. Free after you are done.
  */
 char *
-Exception::generate_backtrace() const throw()
+Exception::generate_backtrace() const noexcept
 {
 #ifdef HAVE_BACKTRACE
 	void * array[25];
@@ -598,7 +598,7 @@ Exception::generate_backtrace() const throw()
  * via constructor or append(). Output will be sent to stderr.
  */
 void
-Exception::print_trace() throw()
+Exception::print_trace() noexcept
 {
 	messages_mutex->lock();
 	fprintf(stderr, "=================================================== BEGIN OF EXCEPTION =====\n");
@@ -619,7 +619,7 @@ Exception::print_trace() throw()
  * @return error number, may be 0 if not set
  */
 int
-Exception::get_errno() throw()
+Exception::get_errno() noexcept
 {
 	return _errno;
 }
@@ -636,7 +636,7 @@ Exception::get_errno() throw()
  * @return string describing the general cause of the current error
  */
 const char *
-Exception::what() const throw()
+Exception::what() const noexcept
 {
 #ifdef HAVE_EXECINFO
 	print_backtrace();
@@ -660,7 +660,7 @@ Exception::what() const throw()
  * @return string describing the general cause of the current error
  */
 const char *
-Exception::what_no_backtrace() const throw()
+Exception::what_no_backtrace() const noexcept
 {
 	if (messages != NULL) {
 		return messages->msg;
@@ -673,7 +673,7 @@ Exception::what_no_backtrace() const throw()
  * @return iterator for messages
  */
 Exception::iterator
-Exception::begin() throw()
+Exception::begin() noexcept
 {
 	Exception::iterator i(messages);
 	return i;
@@ -689,7 +689,7 @@ Exception::begin() throw()
  * @return end iterator for messages.
  */
 Exception::iterator
-Exception::end() throw()
+Exception::end() noexcept
 {
 	Exception::iterator i;
 	return i;

--- a/src/libs/core/exception.h
+++ b/src/libs/core/exception.h
@@ -35,29 +35,29 @@ class Mutex;
 class Exception : public std::exception
 {
 public:
-	Exception(const char *format, ...) throw();
-	Exception(int errnoval, const char *format, ...) throw();
-	Exception(const Exception &exc) throw();
-	virtual ~Exception() throw();
+	Exception(const char *format, ...) noexcept;
+	Exception(int errnoval, const char *format, ...) noexcept;
+	Exception(const Exception &exc) noexcept;
+	virtual ~Exception() noexcept;
 
 	virtual void raise();
-	void         prepend(const char *format, ...) throw();
-	void         append(const char *format, ...) throw();
-	void         append_va(const char *format, va_list va) throw();
-	void         append(const Exception &e) throw();
-	void         print_trace() throw();
-	void         print_backtrace() const throw();
-	char *       generate_backtrace() const throw();
+	void         prepend(const char *format, ...) noexcept;
+	void         append(const char *format, ...) noexcept;
+	void         append_va(const char *format, va_list va) noexcept;
+	void         append(const Exception &e) noexcept;
+	void         print_trace() noexcept;
+	void         print_backtrace() const noexcept;
+	char *       generate_backtrace() const noexcept;
 
-	int get_errno() throw();
+	int get_errno() noexcept;
 
 	void        set_type_id(const char *id);
 	const char *type_id() const;
 
-	virtual const char *what() const throw();
-	virtual const char *what_no_backtrace() const throw();
+	virtual const char *what() const noexcept;
+	virtual const char *what_no_backtrace() const noexcept;
 
-	Exception &operator=(const Exception &exc) throw();
+	Exception &operator=(const Exception &exc) noexcept;
 
 protected:
 	/** Internal exception message list */
@@ -93,17 +93,17 @@ public:
 		message_list_t *mlist;
 	};
 
-	iterator begin() throw();
-	iterator end() throw();
+	iterator begin() noexcept;
+	iterator end() noexcept;
 
 protected:
-	Exception() throw();
+	Exception() noexcept;
 
-	void append_nolock(const char *format, ...) throw();
-	void append_nolock_va(const char *format, va_list va) throw();
-	void append_nolock_nocopy(char *msg) throw();
-	void prepend_nolock_va(const char *format, va_list va) throw();
-	void copy_messages(const Exception &exc) throw();
+	void append_nolock(const char *format, ...) noexcept;
+	void append_nolock_va(const char *format, va_list va) noexcept;
+	void append_nolock_nocopy(char *msg) noexcept;
+	void prepend_nolock_va(const char *format, va_list va) noexcept;
+	void copy_messages(const Exception &exc) noexcept;
 
 	message_list_t *messages;
 	message_list_t *messages_iterator;

--- a/src/libs/core/exceptions/software.cpp
+++ b/src/libs/core/exceptions/software.cpp
@@ -36,7 +36,7 @@ namespace fawkes {
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-NullPointerException::NullPointerException(const char *format, ...) throw() : Exception()
+NullPointerException::NullPointerException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -52,7 +52,7 @@ NullPointerException::NullPointerException(const char *format, ...) throw() : Ex
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-DivisionByZeroException::DivisionByZeroException(const char *format, ...) throw() : Exception()
+DivisionByZeroException::DivisionByZeroException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -68,7 +68,7 @@ DivisionByZeroException::DivisionByZeroException(const char *format, ...) throw(
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-TypeMismatchException::TypeMismatchException(const char *format, ...) throw() : Exception()
+TypeMismatchException::TypeMismatchException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -84,7 +84,7 @@ TypeMismatchException::TypeMismatchException(const char *format, ...) throw() : 
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-UnknownTypeException::UnknownTypeException(const char *format, ...) throw() : Exception()
+UnknownTypeException::UnknownTypeException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -101,7 +101,7 @@ UnknownTypeException::UnknownTypeException(const char *format, ...) throw() : Ex
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-DestructionInProgressException::DestructionInProgressException(const char *format, ...) throw()
+DestructionInProgressException::DestructionInProgressException(const char *format, ...) noexcept
 : Exception()
 {
 	va_list va;
@@ -119,7 +119,7 @@ DestructionInProgressException::DestructionInProgressException(const char *forma
 /** Constructor.
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-NotLockedException::NotLockedException(const char *format, ...) throw() : Exception()
+NotLockedException::NotLockedException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -136,7 +136,7 @@ NotLockedException::NotLockedException(const char *format, ...) throw() : Except
 /** Constructor.
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-NonPointerTypeExpectedException::NonPointerTypeExpectedException(const char *format, ...) throw()
+NonPointerTypeExpectedException::NonPointerTypeExpectedException(const char *format, ...) noexcept
 : Exception()
 {
 	va_list va;
@@ -154,7 +154,7 @@ NonPointerTypeExpectedException::NonPointerTypeExpectedException(const char *for
 /** Constructor.
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-MissingParameterException::MissingParameterException(const char *format, ...) throw() : Exception()
+MissingParameterException::MissingParameterException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -171,7 +171,7 @@ MissingParameterException::MissingParameterException(const char *format, ...) th
 /** Constructor.
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-IllegalArgumentException::IllegalArgumentException(const char *format, ...) throw() : Exception()
+IllegalArgumentException::IllegalArgumentException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -190,7 +190,7 @@ IllegalArgumentException::IllegalArgumentException(const char *format, ...) thro
  * @param msg informative message, appended to exception, base message is
  * "Out Of Bounds"
  */
-OutOfBoundsException::OutOfBoundsException(const char *msg) throw()
+OutOfBoundsException::OutOfBoundsException(const char *msg) noexcept
 : Exception("Out Of Bounds: %s", msg)
 {
 }
@@ -203,7 +203,10 @@ OutOfBoundsException::OutOfBoundsException(const char *msg) throw()
  * @param min minimum required value
  * @param max maximum allowed value
  */
-OutOfBoundsException::OutOfBoundsException(const char *msg, float val, float min, float max) throw()
+OutOfBoundsException::OutOfBoundsException(const char *msg,
+                                           float       val,
+                                           float       min,
+                                           float       max) noexcept
 : Exception()
 {
 	if ((roundf(val) == val) && (roundf(min) == min) && (roundf(max) == max)) {
@@ -224,7 +227,7 @@ OutOfBoundsException::OutOfBoundsException(const char *msg, float val, float min
 /** Constructor.
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-AccessViolationException::AccessViolationException(const char *format, ...) throw() : Exception()
+AccessViolationException::AccessViolationException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -241,7 +244,7 @@ AccessViolationException::AccessViolationException(const char *format, ...) thro
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-SyntaxErrorException::SyntaxErrorException(const char *format, ...) throw() : Exception()
+SyntaxErrorException::SyntaxErrorException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -259,7 +262,7 @@ SyntaxErrorException::SyntaxErrorException(const char *format, ...) throw() : Ex
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-NotImplementedException::NotImplementedException(const char *format, ...) throw() : Exception()
+NotImplementedException::NotImplementedException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);

--- a/src/libs/core/exceptions/software.h
+++ b/src/libs/core/exceptions/software.h
@@ -31,80 +31,80 @@ namespace fawkes {
 class NullPointerException : public Exception
 {
 public:
-	NullPointerException(const char *format, ...) throw();
+	NullPointerException(const char *format, ...) noexcept;
 };
 
 class DivisionByZeroException : public Exception
 {
 public:
-	DivisionByZeroException(const char *format, ...) throw();
+	DivisionByZeroException(const char *format, ...) noexcept;
 };
 
 class TypeMismatchException : public Exception
 {
 public:
-	TypeMismatchException(const char *format, ...) throw();
+	TypeMismatchException(const char *format, ...) noexcept;
 };
 
 class UnknownTypeException : public Exception
 {
 public:
-	UnknownTypeException(const char *format, ...) throw();
+	UnknownTypeException(const char *format, ...) noexcept;
 };
 
 class DestructionInProgressException : public Exception
 {
 public:
-	DestructionInProgressException(const char *format, ...) throw();
+	DestructionInProgressException(const char *format, ...) noexcept;
 };
 
 class NotLockedException : public Exception
 {
 public:
-	NotLockedException(const char *format, ...) throw();
+	NotLockedException(const char *format, ...) noexcept;
 };
 
 class NonPointerTypeExpectedException : public Exception
 {
 public:
-	NonPointerTypeExpectedException(const char *format, ...) throw();
+	NonPointerTypeExpectedException(const char *format, ...) noexcept;
 };
 
 class MissingParameterException : public Exception
 {
 public:
-	MissingParameterException(const char *format, ...) throw();
+	MissingParameterException(const char *format, ...) noexcept;
 };
 
 class IllegalArgumentException : public Exception
 {
 public:
-	IllegalArgumentException(const char *format, ...) throw();
+	IllegalArgumentException(const char *format, ...) noexcept;
 };
 
 class OutOfBoundsException : public Exception
 {
 public:
-	OutOfBoundsException(const char *msg) throw();
-	OutOfBoundsException(const char *msg, float val, float min, float max) throw();
+	OutOfBoundsException(const char *msg) noexcept;
+	OutOfBoundsException(const char *msg, float val, float min, float max) noexcept;
 };
 
 class AccessViolationException : public Exception
 {
 public:
-	AccessViolationException(const char *format, ...) throw();
+	AccessViolationException(const char *format, ...) noexcept;
 };
 
 class SyntaxErrorException : public Exception
 {
 public:
-	SyntaxErrorException(const char *format, ...) throw();
+	SyntaxErrorException(const char *format, ...) noexcept;
 };
 
 class NotImplementedException : public Exception
 {
 public:
-	NotImplementedException(const char *format, ...) throw();
+	NotImplementedException(const char *format, ...) noexcept;
 };
 
 } // end namespace fawkes

--- a/src/libs/core/exceptions/system.cpp
+++ b/src/libs/core/exceptions/system.cpp
@@ -32,7 +32,7 @@ namespace fawkes {
 /** Constructor
  * @param format message format string
  */
-OutOfMemoryException::OutOfMemoryException(const char *format, ...) throw() : Exception()
+OutOfMemoryException::OutOfMemoryException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -43,7 +43,7 @@ OutOfMemoryException::OutOfMemoryException(const char *format, ...) throw() : Ex
 /** Constructor.
  * Message simply is "Out of memory"
  */
-OutOfMemoryException::OutOfMemoryException() throw() : Exception("Out of memory")
+OutOfMemoryException::OutOfMemoryException() noexcept : Exception("Out of memory")
 {
 }
 
@@ -54,14 +54,14 @@ OutOfMemoryException::OutOfMemoryException() throw() : Exception("Out of memory"
  * @ingroup Exceptions
  */
 /** Constructor */
-InterruptedException::InterruptedException() throw() : Exception("Interrupted system call")
+InterruptedException::InterruptedException() noexcept : Exception("Interrupted system call")
 {
 }
 
 /** Constructor
  * @param format message format string
  */
-InterruptedException::InterruptedException(const char *format, ...) throw() : Exception()
+InterruptedException::InterruptedException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -76,14 +76,14 @@ InterruptedException::InterruptedException(const char *format, ...) throw() : Ex
  * @ingroup Exceptions
  */
 /** Constructor */
-TimeoutException::TimeoutException() throw() : Exception("Timeout reached.")
+TimeoutException::TimeoutException() noexcept : Exception("Timeout reached.")
 {
 }
 
 /** Constructor
  * @param format message format string
  */
-TimeoutException::TimeoutException(const char *format, ...) throw() : Exception()
+TimeoutException::TimeoutException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -105,7 +105,7 @@ TimeoutException::TimeoutException(const char *format, ...) throw() : Exception(
  */
 CouldNotOpenFileException::CouldNotOpenFileException(const char *filename,
                                                      int         errnum,
-                                                     const char *additional_msg) throw()
+                                                     const char *additional_msg) noexcept
 : Exception(errnum,
             "Could not open file '%s' %s%s%s",
             filename,
@@ -120,7 +120,7 @@ CouldNotOpenFileException::CouldNotOpenFileException(const char *filename,
  * @param additional_msg optional additional message
  */
 CouldNotOpenFileException::CouldNotOpenFileException(const char *filename,
-                                                     const char *additional_msg) throw()
+                                                     const char *additional_msg) noexcept
 : Exception("Could not open file '%s' %s%s%s",
             filename,
             (additional_msg) ? "(" : "",
@@ -143,7 +143,7 @@ CouldNotOpenFileException::CouldNotOpenFileException(const char *filename,
  */
 FileReadException::FileReadException(const char *filename,
                                      int         errnum,
-                                     const char *additional_msg) throw()
+                                     const char *additional_msg) noexcept
 : Exception(errnum,
             "Could not read from file '%s' %s%s%s",
             filename,
@@ -157,7 +157,7 @@ FileReadException::FileReadException(const char *filename,
  * @param filename name of file which could not be read
  * @param additional_msg optional additional message
  */
-FileReadException::FileReadException(const char *filename, const char *additional_msg) throw()
+FileReadException::FileReadException(const char *filename, const char *additional_msg) noexcept
 : Exception("Could not read from file '%s' %s%s%s",
             filename,
             (additional_msg) ? "(" : "",
@@ -180,7 +180,7 @@ FileReadException::FileReadException(const char *filename, const char *additiona
  */
 FileWriteException::FileWriteException(const char *filename,
                                        int         errnum,
-                                       const char *additional_msg) throw()
+                                       const char *additional_msg) noexcept
 : Exception(errnum,
             "Could not write to file '%s' %s%s%s",
             filename,
@@ -194,7 +194,7 @@ FileWriteException::FileWriteException(const char *filename,
  * @param filename name of file which could not be written
  * @param additional_msg optional additional message
  */
-FileWriteException::FileWriteException(const char *filename, const char *additional_msg) throw()
+FileWriteException::FileWriteException(const char *filename, const char *additional_msg) noexcept
 : Exception("Could not write to file '%s' %s%s%s",
             filename,
             (additional_msg) ? "(" : "",

--- a/src/libs/core/exceptions/system.h
+++ b/src/libs/core/exceptions/system.h
@@ -31,22 +31,22 @@ namespace fawkes {
 class OutOfMemoryException : public Exception
 {
 public:
-	OutOfMemoryException(const char *format, ...) throw();
-	OutOfMemoryException() throw();
+	OutOfMemoryException(const char *format, ...) noexcept;
+	OutOfMemoryException() noexcept;
 };
 
 class InterruptedException : public Exception
 {
 public:
-	InterruptedException() throw();
-	InterruptedException(const char *format, ...) throw();
+	InterruptedException() noexcept;
+	InterruptedException(const char *format, ...) noexcept;
 };
 
 class TimeoutException : public Exception
 {
 public:
-	TimeoutException() throw();
-	TimeoutException(const char *format, ...) throw();
+	TimeoutException() noexcept;
+	TimeoutException(const char *format, ...) noexcept;
 };
 
 class CouldNotOpenFileException : public Exception
@@ -54,22 +54,22 @@ class CouldNotOpenFileException : public Exception
 public:
 	CouldNotOpenFileException(const char *filename,
 	                          int         errnum,
-	                          const char *additional_msg = 0) throw();
-	CouldNotOpenFileException(const char *filename, const char *additional_msg = 0) throw();
+	                          const char *additional_msg = 0) noexcept;
+	CouldNotOpenFileException(const char *filename, const char *additional_msg = 0) noexcept;
 };
 
 class FileReadException : public Exception
 {
 public:
-	FileReadException(const char *filename, int errnum, const char *additional_msg = 0) throw();
-	FileReadException(const char *filename, const char *additional_msg = 0) throw();
+	FileReadException(const char *filename, int errnum, const char *additional_msg = 0) noexcept;
+	FileReadException(const char *filename, const char *additional_msg = 0) noexcept;
 };
 
 class FileWriteException : public Exception
 {
 public:
-	FileWriteException(const char *filename, int errnum, const char *additional_msg = 0) throw();
-	FileWriteException(const char *filename, const char *additional_msg = 0) throw();
+	FileWriteException(const char *filename, int errnum, const char *additional_msg = 0) noexcept;
+	FileWriteException(const char *filename, const char *additional_msg = 0) noexcept;
 };
 
 } // end namespace fawkes

--- a/src/libs/core/threading/interruptible_barrier.cpp
+++ b/src/libs/core/threading/interruptible_barrier.cpp
@@ -186,7 +186,7 @@ InterruptibleBarrier::passed_threads()
  * the next time.
  */
 void
-InterruptibleBarrier::interrupt() throw()
+InterruptibleBarrier::interrupt() noexcept
 {
 	if (likely(data_->own_mutex))
 		data_->mutex->lock();
@@ -202,7 +202,7 @@ InterruptibleBarrier::interrupt() throw()
  * passed the barrier the last time did pass it.
  */
 void
-InterruptibleBarrier::reset() throw()
+InterruptibleBarrier::reset() noexcept
 {
 	if (likely(data_->own_mutex))
 		data_->mutex->lock();

--- a/src/libs/core/threading/interruptible_barrier.h
+++ b/src/libs/core/threading/interruptible_barrier.h
@@ -46,8 +46,8 @@ public:
 		wait(0, 0);
 	}
 
-	void interrupt() throw();
-	void reset() throw();
+	void interrupt() noexcept;
+	void reset() noexcept;
 
 	RefPtr<ThreadList> passed_threads();
 

--- a/src/libs/core/threading/thread.cpp
+++ b/src/libs/core/threading/thread.cpp
@@ -1378,7 +1378,7 @@ Thread::current_thread()
  * @return Thread instance of the current thread
  */
 Thread *
-Thread::current_thread_noexc() throw()
+Thread::current_thread_noexc() noexcept
 {
 	if (THREAD_KEY == PTHREAD_KEYS_MAX) {
 		return 0;

--- a/src/libs/core/threading/thread.h
+++ b/src/libs/core/threading/thread.h
@@ -108,7 +108,7 @@ public:
 	bool flagged_bad() const;
 
 	static Thread *    current_thread();
-	static Thread *    current_thread_noexc() throw();
+	static Thread *    current_thread_noexc() noexcept;
 	static pthread_t   current_thread_id();
 	static std::string current_thread_name();
 	static void        current_thread_name(const std::string &thread_name);

--- a/src/libs/core/threading/thread_notification_listener.cpp
+++ b/src/libs/core/threading/thread_notification_listener.cpp
@@ -33,14 +33,14 @@ namespace fawkes {
  *
  * @author Tim Niemueller
  *
- * @fn bool ThreadNotificationListener::thread_started(Thread *thread) throw()
+ * @fn bool ThreadNotificationListener::thread_started(Thread *thread) noexcept
  * Thread started successfully.
  * This is called by the thread itself when the thread started successfully.
  * @param thread thread that started successfully
  * @return true to stay registered for further thread notifications, false to
  * unregister.
  *
- * @fn bool ThreadNotificationListener::thread_init_failed(Thread *thread) throw()
+ * @fn bool ThreadNotificationListener::thread_init_failed(Thread *thread) noexcept
  * Thread initialization failed.
  * This method is called by ThreadList if one of the threads in the list failed
  * to initialize. This is not necessarily the thread that you registered the

--- a/src/libs/core/threading/thread_notification_listener.h
+++ b/src/libs/core/threading/thread_notification_listener.h
@@ -33,8 +33,8 @@ class ThreadNotificationListener
 public:
 	virtual ~ThreadNotificationListener();
 
-	virtual bool thread_started(Thread *thread) throw()     = 0;
-	virtual bool thread_init_failed(Thread *thread) throw() = 0;
+	virtual bool thread_started(Thread *thread) noexcept     = 0;
+	virtual bool thread_init_failed(Thread *thread) noexcept = 0;
 };
 
 } // end namespace fawkes

--- a/src/libs/core/utils/circular_buffer.h
+++ b/src/libs/core/utils/circular_buffer.h
@@ -45,7 +45,7 @@ class CircularBuffer
 {
 public:
 	/** The size_type of the buffer */
-	typedef size_t size_type;
+	typedef std::size_t size_type;
 	/** The CircularBuffer's iterator is a std::deque iterator */
 	typedef typename std::deque<Type>::const_iterator const_iterator;
 	/** The CircularBuffer's reverse iterator is a std::deque reverse iterator */

--- a/src/libs/fvcams/net.cpp
+++ b/src/libs/fvcams/net.cpp
@@ -428,26 +428,26 @@ NetworkCamera::image_list()
 }
 
 void
-NetworkCamera::fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) throw()
+NetworkCamera::fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) noexcept
 {
 	local_version_  = local_version;
 	remote_version_ = remote_version;
 }
 
 void
-NetworkCamera::fuse_connection_established() throw()
+NetworkCamera::fuse_connection_established() noexcept
 {
 	connected_ = true;
 }
 
 void
-NetworkCamera::fuse_connection_died() throw()
+NetworkCamera::fuse_connection_died() noexcept
 {
 	connected_ = false;
 }
 
 void
-NetworkCamera::fuse_inbound_received(FuseNetworkMessage *m) throw()
+NetworkCamera::fuse_inbound_received(FuseNetworkMessage *m) noexcept
 {
 	switch (m->type()) {
 	case FUSE_MT_IMAGE:

--- a/src/libs/fvcams/net.h
+++ b/src/libs/fvcams/net.h
@@ -70,10 +70,11 @@ public:
 
 	virtual std::vector<FUSE_imageinfo_t> &image_list();
 
-	virtual void fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) throw();
-	virtual void fuse_connection_established() throw();
-	virtual void fuse_connection_died() throw();
-	virtual void fuse_inbound_received(FuseNetworkMessage *m) throw();
+	virtual void fuse_invalid_server_version(uint32_t local_version,
+	                                         uint32_t remote_version) noexcept;
+	virtual void fuse_connection_established() noexcept;
+	virtual void fuse_connection_died() noexcept;
+	virtual void fuse_inbound_received(FuseNetworkMessage *m) noexcept;
 
 private:
 	bool started_;

--- a/src/libs/fvutils/net/fuse_client_handler.cpp
+++ b/src/libs/fvutils/net/fuse_client_handler.cpp
@@ -31,20 +31,20 @@ namespace firevision {
  * @ingroup FireVision
  * @author Tim Niemueller
  *
- * @fn void FuseClientHandler::fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) throw() = 0
+ * @fn void FuseClientHandler::fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) noexcept = 0
  * Invalid version string received.
  * The remote end has a different incompatible FUSE version.
  * @param local_version version that the FuseClient speaks
  * @param remote_version version that the remote FUSE server speaks.
  *
- * @fn void FuseClientHandler::fuse_connection_established() throw() = 0
+ * @fn void FuseClientHandler::fuse_connection_established() noexcept = 0
  * Connection has been established.
  *
- * @fn void FuseClientHandler::fuse_connection_died()  throw() = 0
+ * @fn void FuseClientHandler::fuse_connection_died()  noexcept = 0
  * Connection died.
  *
  *
- * @fn void FuseClientHandler::fuse_inbound_received(FuseNetworkMessage *m) throw() = 0
+ * @fn void FuseClientHandler::fuse_inbound_received(FuseNetworkMessage *m) noexcept = 0
  * Message received.
  * An incoming message has been received and can now be processed. Note that if you want
  * to work on the message after this method has finished you have to reference the message

--- a/src/libs/fvutils/net/fuse_client_handler.h
+++ b/src/libs/fvutils/net/fuse_client_handler.h
@@ -36,10 +36,10 @@ public:
 	virtual ~FuseClientHandler();
 
 	virtual void fuse_invalid_server_version(uint32_t local_version,
-	                                         uint32_t remote_version) throw() = 0;
-	virtual void fuse_connection_established() throw()                        = 0;
-	virtual void fuse_connection_died() throw()                               = 0;
-	virtual void fuse_inbound_received(FuseNetworkMessage *m) throw()         = 0;
+	                                         uint32_t remote_version) noexcept = 0;
+	virtual void fuse_connection_established() noexcept                        = 0;
+	virtual void fuse_connection_died() noexcept                               = 0;
+	virtual void fuse_inbound_received(FuseNetworkMessage *m) noexcept         = 0;
 };
 
 } // end namespace firevision

--- a/src/libs/fvutils/net/fuse_server.cpp
+++ b/src/libs/fvutils/net/fuse_server.cpp
@@ -110,7 +110,7 @@ FuseServer::~FuseServer()
 }
 
 void
-FuseServer::add_connection(StreamSocket *s) throw()
+FuseServer::add_connection(StreamSocket *s) noexcept
 {
 	FuseServerClientThread *client = new FuseServerClientThread(this, s);
 	if (thread_collector_) {
@@ -125,7 +125,7 @@ FuseServer::add_connection(StreamSocket *s) throw()
  * @param client client whose connection died
  */
 void
-FuseServer::connection_died(FuseServerClientThread *client) throw()
+FuseServer::connection_died(FuseServerClientThread *client) noexcept
 {
 	dead_clients_.push_back_locked(client);
 	wakeup();

--- a/src/libs/fvutils/net/fuse_server.h
+++ b/src/libs/fvutils/net/fuse_server.h
@@ -51,8 +51,8 @@ public:
 	           fawkes::ThreadCollector *collector = 0);
 	virtual ~FuseServer();
 
-	virtual void add_connection(fawkes::StreamSocket *s) throw();
-	void         connection_died(FuseServerClientThread *client) throw();
+	virtual void add_connection(fawkes::StreamSocket *s) noexcept;
+	void         connection_died(FuseServerClientThread *client) noexcept;
 
 	virtual void loop();
 

--- a/src/libs/fvwidgets/fuse_image_list_widget.cpp
+++ b/src/libs/fvwidgets/fuse_image_list_widget.cpp
@@ -418,18 +418,18 @@ FuseImageListWidget::update_image_list()
 
 void
 FuseImageListWidget::fuse_invalid_server_version(uint32_t local_version,
-                                                 uint32_t remote_version) throw()
+                                                 uint32_t remote_version) noexcept
 {
 	printf("Invalid versions: local: %u   remote: %u\n", local_version, remote_version);
 }
 
 void
-FuseImageListWidget::fuse_connection_established() throw()
+FuseImageListWidget::fuse_connection_established() noexcept
 {
 }
 
 void
-FuseImageListWidget::fuse_connection_died() throw()
+FuseImageListWidget::fuse_connection_died() noexcept
 {
 	if (m_cur_client.active) {
 		m_delete_clients.push_locked(m_cur_client.client);
@@ -440,7 +440,7 @@ FuseImageListWidget::fuse_connection_died() throw()
 }
 
 void
-FuseImageListWidget::fuse_inbound_received(FuseNetworkMessage *m) throw()
+FuseImageListWidget::fuse_inbound_received(FuseNetworkMessage *m) noexcept
 {
 	switch (m->type()) {
 	case FUSE_MT_IMAGE_LIST: {

--- a/src/libs/fvwidgets/fuse_image_list_widget.h
+++ b/src/libs/fvwidgets/fuse_image_list_widget.h
@@ -56,10 +56,10 @@ public:
 	                        bool &          compression);
 
 	// Fuse client handler
-	void fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) throw();
-	void fuse_connection_established() throw();
-	void fuse_connection_died() throw();
-	void fuse_inbound_received(FuseNetworkMessage *m) throw();
+	void fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) noexcept;
+	void fuse_connection_established() noexcept;
+	void fuse_connection_died() noexcept;
+	void fuse_inbound_received(FuseNetworkMessage *m) noexcept;
 
 private:
 	/// @cond INTERNALS

--- a/src/libs/fvwidgets/image_widget.cpp
+++ b/src/libs/fvwidgets/image_widget.cpp
@@ -432,7 +432,7 @@ ImageWidget::set_cam()
  * @return true on success, false otherwise
  */
 bool
-ImageWidget::save_image(std::string filename, Glib::ustring type) const throw()
+ImageWidget::save_image(std::string filename, Glib::ustring type) const noexcept
 {
 	cam_mutex_->lock();
 

--- a/src/libs/fvwidgets/image_widget.h
+++ b/src/libs/fvwidgets/image_widget.h
@@ -98,7 +98,7 @@ public:
 	Glib::RefPtr<Gdk::Pixbuf> get_buffer() const;
 	void set_rgb(unsigned int x, unsigned int y, unsigned char r, unsigned char g, unsigned char b);
 	void set_rgb(unsigned int x, unsigned int y, RGB_t rgb);
-	bool save_image(std::string filename, Glib::ustring type) const throw();
+	bool save_image(std::string filename, Glib::ustring type) const noexcept;
 	void save_on_refresh_cam(bool          enabled,
 	                         std::string   path    = "",
 	                         Glib::ustring type    = "",

--- a/src/libs/fvwidgets/sdl_keeper.cpp
+++ b/src/libs/fvwidgets/sdl_keeper.cpp
@@ -82,7 +82,7 @@ SDLKeeper::init(unsigned int flags)
  * users of SDL quit the usage. Then the whole SDL will be released at once.
  */
 void
-SDLKeeper::quit() throw()
+SDLKeeper::quit() noexcept
 {
 	MutexLocker lock(&_mutex);
 

--- a/src/libs/fvwidgets/sdl_keeper.h
+++ b/src/libs/fvwidgets/sdl_keeper.h
@@ -32,7 +32,7 @@ class SDLKeeper
 {
 public:
 	static void init(unsigned int flags);
-	static void quit() throw();
+	static void quit() noexcept;
 
 	static void force_quit();
 

--- a/src/libs/gui_utils/connection_dispatcher.cpp
+++ b/src/libs/gui_utils/connection_dispatcher.cpp
@@ -172,13 +172,13 @@ ConnectionDispatcher::on_message_received()
 }
 
 void
-ConnectionDispatcher::deregistered(unsigned int id) throw()
+ConnectionDispatcher::deregistered(unsigned int id) noexcept
 {
 	// ignored
 }
 
 void
-ConnectionDispatcher::inbound_received(FawkesNetworkMessage *m, unsigned int id) throw()
+ConnectionDispatcher::inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept
 {
 	m->ref();
 	queue_message_received_.push_locked(m);
@@ -186,13 +186,13 @@ ConnectionDispatcher::inbound_received(FawkesNetworkMessage *m, unsigned int id)
 }
 
 void
-ConnectionDispatcher::connection_died(unsigned int id) throw()
+ConnectionDispatcher::connection_died(unsigned int id) noexcept
 {
 	dispatcher_disconnected_();
 }
 
 void
-ConnectionDispatcher::connection_established(unsigned int id) throw()
+ConnectionDispatcher::connection_established(unsigned int id) noexcept
 {
 	dispatcher_connected_();
 }

--- a/src/libs/gui_utils/connection_dispatcher.h
+++ b/src/libs/gui_utils/connection_dispatcher.h
@@ -52,10 +52,10 @@ public:
 	sigc::signal<void>                         signal_disconnected();
 	sigc::signal<void, FawkesNetworkMessage *> signal_message_received();
 
-	virtual void deregistered(unsigned int id) throw();
-	virtual void inbound_received(FawkesNetworkMessage *m, unsigned int id) throw();
-	virtual void connection_died(unsigned int id) throw();
-	virtual void connection_established(unsigned int id) throw();
+	virtual void deregistered(unsigned int id) noexcept;
+	virtual void inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept;
+	virtual void connection_died(unsigned int id) noexcept;
+	virtual void connection_established(unsigned int id) noexcept;
 
 	operator bool();
 

--- a/src/libs/gui_utils/interface_dispatcher.cpp
+++ b/src/libs/gui_utils/interface_dispatcher.cpp
@@ -204,14 +204,14 @@ InterfaceDispatcher::on_reader_removed()
 }
 
 void
-InterfaceDispatcher::bb_interface_data_refreshed(Interface *interface) throw()
+InterfaceDispatcher::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	queue_data_changed_.push_locked(interface);
 	dispatcher_data_changed_();
 }
 
 bool
-InterfaceDispatcher::bb_interface_message_received(Interface *interface, Message *message) throw()
+InterfaceDispatcher::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	message->ref();
 	queue_message_received_.push_locked(std::make_pair(interface, message));
@@ -220,28 +220,30 @@ InterfaceDispatcher::bb_interface_message_received(Interface *interface, Message
 }
 
 void
-InterfaceDispatcher::bb_interface_writer_added(Interface *interface, Uuid instance_serial) throw()
+InterfaceDispatcher::bb_interface_writer_added(Interface *interface, Uuid instance_serial) noexcept
 {
 	queue_writer_added_.push_locked(interface);
 	dispatcher_writer_added_();
 }
 
 void
-InterfaceDispatcher::bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw()
+InterfaceDispatcher::bb_interface_writer_removed(Interface *interface,
+                                                 Uuid       instance_serial) noexcept
 {
 	queue_writer_removed_.push_locked(interface);
 	dispatcher_writer_removed_();
 }
 
 void
-InterfaceDispatcher::bb_interface_reader_added(Interface *interface, Uuid instance_serial) throw()
+InterfaceDispatcher::bb_interface_reader_added(Interface *interface, Uuid instance_serial) noexcept
 {
 	queue_reader_added_.push_locked(interface);
 	dispatcher_reader_added_();
 }
 
 void
-InterfaceDispatcher::bb_interface_reader_removed(Interface *interface, Uuid instance_serial) throw()
+InterfaceDispatcher::bb_interface_reader_removed(Interface *interface,
+                                                 Uuid       instance_serial) noexcept
 {
 	queue_reader_removed_.push_locked(interface);
 	dispatcher_reader_removed_();

--- a/src/libs/gui_utils/interface_dispatcher.h
+++ b/src/libs/gui_utils/interface_dispatcher.h
@@ -53,12 +53,12 @@ public:
 	sigc::signal<void, Interface *>            signal_reader_added();
 	sigc::signal<void, Interface *>            signal_reader_removed();
 
-	virtual void bb_interface_data_refreshed(Interface *interface) throw();
-	virtual bool bb_interface_message_received(Interface *interface, Message *message) throw();
-	virtual void bb_interface_writer_added(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_reader_added(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_reader_removed(Interface *interface, Uuid instance_serial) throw();
+	virtual void bb_interface_data_refreshed(Interface *interface) noexcept;
+	virtual bool bb_interface_message_received(Interface *interface, Message *message) noexcept;
+	virtual void bb_interface_writer_added(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_writer_removed(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_reader_added(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_reader_removed(Interface *interface, Uuid instance_serial) noexcept;
 
 protected:
 	virtual void on_data_changed();

--- a/src/libs/interface/interface.h
+++ b/src/libs/interface/interface.h
@@ -181,7 +181,7 @@ public:
    * @return pointer to message if it is of the desired type, 0 otherwise
    */
 	template <class MessageType>
-	MessageType *msgq_first_safe(MessageType *&msg) throw();
+	MessageType *msgq_first_safe(MessageType *&msg) noexcept;
 
 	MessageQueue::MessageIterator msgq_begin();
 	MessageQueue::MessageIterator msgq_end();
@@ -337,7 +337,7 @@ Interface::msgq_first(MessageType *&msg)
 
 template <class MessageType>
 MessageType *
-Interface::msgq_first_safe(MessageType *&msg) throw()
+Interface::msgq_first_safe(MessageType *&msg) noexcept
 {
 	msg = dynamic_cast<MessageType *>(message_queue_->first());
 	return msg;

--- a/src/libs/lua/interface_importer.cpp
+++ b/src/libs/lua/interface_importer.cpp
@@ -458,7 +458,7 @@ LuaInterfaceImporter::InterfaceObserver::InterfaceObserver(LuaInterfaceImporter 
 
 void
 LuaInterfaceImporter::InterfaceObserver::bb_interface_created(const char *type,
-                                                              const char *id) throw()
+                                                              const char *id) noexcept
 {
 	lii_->add_observed_interface(varname_, type, id);
 }

--- a/src/libs/lua/interface_importer.h
+++ b/src/libs/lua/interface_importer.h
@@ -48,7 +48,7 @@ class LuaInterfaceImporter : public LuaContextWatcher
 		                  const char *          type,
 		                  const char *          id_pattern);
 
-		virtual void bb_interface_created(const char *type, const char *id) throw();
+		virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	private:
 		LuaInterfaceImporter *lii_;

--- a/src/libs/navgraph/constraints/edge_constraint.cpp
+++ b/src/libs/navgraph/constraints/edge_constraint.cpp
@@ -28,7 +28,7 @@ namespace fawkes {
  * @author Sebastian Reuter
  * @author Tim Niemueller
  *
- * @fn bool NavGraphEdgeConstraint::blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) throw() = 0
+ * @fn bool NavGraphEdgeConstraint::blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) noexcept = 0
  * Check if constraint blocks an edge.
  * This method must be implemented by constraint classes. It is called
  * to determine if an edge should be considered blocked and therefore
@@ -98,7 +98,7 @@ NavGraphEdgeConstraint::name()
  * the last call, false otherwise
  */
 bool
-NavGraphEdgeConstraint::compute(void) throw()
+NavGraphEdgeConstraint::compute(void) noexcept
 {
 	return false;
 }

--- a/src/libs/navgraph/constraints/edge_constraint.h
+++ b/src/libs/navgraph/constraints/edge_constraint.h
@@ -40,8 +40,9 @@ public:
 
 	std::string name();
 
-	virtual bool compute(void) throw();
-	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) throw() = 0;
+	virtual bool compute(void) noexcept;
+	virtual bool blocks(const fawkes::NavGraphNode &from,
+	                    const fawkes::NavGraphNode &to) noexcept = 0;
 
 	bool operator==(const std::string &name) const;
 

--- a/src/libs/navgraph/constraints/edge_cost_constraint.cpp
+++ b/src/libs/navgraph/constraints/edge_cost_constraint.cpp
@@ -26,7 +26,7 @@ namespace fawkes {
  * Constraint that can be queried for an edge cost factor.
  * @author Tim Niemueller
  *
- * @fn bool NavGraphEdgeCostConstraint::cost_factor(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) throw() = 0
+ * @fn bool NavGraphEdgeCostConstraint::cost_factor(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) noexcept = 0
  * Get cost factor for given edge.
  * This method must be implemented by constraint classes. It is called
  * to determine a cost factor for an edge. That is, the path costs
@@ -100,7 +100,7 @@ NavGraphEdgeCostConstraint::name()
  * the last call, false otherwise
  */
 bool
-NavGraphEdgeCostConstraint::compute(void) throw()
+NavGraphEdgeCostConstraint::compute(void) noexcept
 {
 	return false;
 }

--- a/src/libs/navgraph/constraints/edge_cost_constraint.h
+++ b/src/libs/navgraph/constraints/edge_cost_constraint.h
@@ -39,9 +39,9 @@ public:
 
 	std::string name();
 
-	virtual bool  compute(void) throw();
+	virtual bool  compute(void) noexcept;
 	virtual float cost_factor(const fawkes::NavGraphNode &from,
-	                          const fawkes::NavGraphNode &to) throw() = 0;
+	                          const fawkes::NavGraphNode &to) noexcept = 0;
 
 	bool operator==(const std::string &name) const;
 

--- a/src/libs/navgraph/constraints/node_constraint.cpp
+++ b/src/libs/navgraph/constraints/node_constraint.cpp
@@ -28,7 +28,7 @@ namespace fawkes {
  * @author Sebastian Reuter
  * @author Tim Niemueller
  *
- * @fn bool NavGraphNodeConstraint::blocks(fawkes::NavGraphNode &node) throw() = 0
+ * @fn bool NavGraphNodeConstraint::blocks(fawkes::NavGraphNode &node) noexcept = 0
  * Check if constraint blocks a node.
  * This method must be implemented by constraint classes. It is called
  * to determine if a node should be considered blocked and therefore
@@ -90,7 +90,7 @@ NavGraphNodeConstraint::name()
  * the last call, false otherwise
  */
 bool
-NavGraphNodeConstraint::compute(void) throw()
+NavGraphNodeConstraint::compute(void) noexcept
 {
 	return false;
 }

--- a/src/libs/navgraph/constraints/node_constraint.h
+++ b/src/libs/navgraph/constraints/node_constraint.h
@@ -40,8 +40,8 @@ public:
 
 	std::string name();
 
-	virtual bool compute(void) throw();
-	virtual bool blocks(const fawkes::NavGraphNode &node) throw() = 0;
+	virtual bool compute(void) noexcept;
+	virtual bool blocks(const fawkes::NavGraphNode &node) noexcept = 0;
 
 	bool operator==(const std::string &name) const;
 

--- a/src/libs/navgraph/constraints/polygon_edge_constraint.cpp
+++ b/src/libs/navgraph/constraints/polygon_edge_constraint.cpp
@@ -53,7 +53,7 @@ NavGraphPolygonEdgeConstraint::~NavGraphPolygonEdgeConstraint()
 }
 
 bool
-NavGraphPolygonEdgeConstraint::compute(void) throw()
+NavGraphPolygonEdgeConstraint::compute(void) noexcept
 {
 	if (!polygons_.empty()) {
 		return true;
@@ -64,7 +64,7 @@ NavGraphPolygonEdgeConstraint::compute(void) throw()
 
 bool
 NavGraphPolygonEdgeConstraint::blocks(const fawkes::NavGraphNode &from,
-                                      const fawkes::NavGraphNode &to) throw()
+                                      const fawkes::NavGraphNode &to) noexcept
 {
 	for (auto p : polygons_) {
 		Point from_p(from.x(), from.y());

--- a/src/libs/navgraph/constraints/polygon_edge_constraint.h
+++ b/src/libs/navgraph/constraints/polygon_edge_constraint.h
@@ -39,9 +39,9 @@ public:
 
 	virtual ~NavGraphPolygonEdgeConstraint();
 
-	virtual bool compute(void) throw();
+	virtual bool compute(void) noexcept;
 
-	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) throw();
+	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) noexcept;
 };
 
 } // end namespace fawkes

--- a/src/libs/navgraph/constraints/polygon_node_constraint.cpp
+++ b/src/libs/navgraph/constraints/polygon_node_constraint.cpp
@@ -53,7 +53,7 @@ NavGraphPolygonNodeConstraint::~NavGraphPolygonNodeConstraint()
 }
 
 bool
-NavGraphPolygonNodeConstraint::compute(void) throw()
+NavGraphPolygonNodeConstraint::compute(void) noexcept
 {
 	if (!polygons_.empty()) {
 		return true;
@@ -63,7 +63,7 @@ NavGraphPolygonNodeConstraint::compute(void) throw()
 }
 
 bool
-NavGraphPolygonNodeConstraint::blocks(const fawkes::NavGraphNode &node) throw()
+NavGraphPolygonNodeConstraint::blocks(const fawkes::NavGraphNode &node) noexcept
 {
 	for (auto p : polygons_) {
 		Point point(node.x(), node.y());

--- a/src/libs/navgraph/constraints/polygon_node_constraint.h
+++ b/src/libs/navgraph/constraints/polygon_node_constraint.h
@@ -39,9 +39,9 @@ public:
 
 	virtual ~NavGraphPolygonNodeConstraint();
 
-	virtual bool compute(void) throw();
+	virtual bool compute(void) noexcept;
 
-	virtual bool blocks(const fawkes::NavGraphNode &node) throw();
+	virtual bool blocks(const fawkes::NavGraphNode &node) noexcept;
 };
 
 } // end namespace fawkes

--- a/src/libs/navgraph/constraints/static_list_edge_constraint.cpp
+++ b/src/libs/navgraph/constraints/static_list_edge_constraint.cpp
@@ -60,7 +60,7 @@ NavGraphStaticListEdgeConstraint::~NavGraphStaticListEdgeConstraint()
 }
 
 bool
-NavGraphStaticListEdgeConstraint::compute(void) throw()
+NavGraphStaticListEdgeConstraint::compute(void) noexcept
 {
 	if (modified_) {
 		modified_ = false;
@@ -137,7 +137,7 @@ NavGraphStaticListEdgeConstraint::clear_edges()
 
 bool
 NavGraphStaticListEdgeConstraint::blocks(const fawkes::NavGraphNode &from,
-                                         const fawkes::NavGraphNode &to) throw()
+                                         const fawkes::NavGraphNode &to) noexcept
 {
 	for (NavGraphEdge &e : edge_list_) {
 		if ((e.from() == from.name() && e.to() == to.name())

--- a/src/libs/navgraph/constraints/static_list_edge_constraint.h
+++ b/src/libs/navgraph/constraints/static_list_edge_constraint.h
@@ -48,9 +48,9 @@ public:
 	void clear_edges();
 	bool has_edge(const fawkes::NavGraphEdge &edge);
 
-	virtual bool compute(void) throw();
+	virtual bool compute(void) noexcept;
 
-	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) throw();
+	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) noexcept;
 
 private:
 	std::vector<fawkes::NavGraphEdge> edge_list_;

--- a/src/libs/navgraph/constraints/static_list_edge_cost_constraint.cpp
+++ b/src/libs/navgraph/constraints/static_list_edge_cost_constraint.cpp
@@ -46,7 +46,7 @@ NavGraphStaticListEdgeCostConstraint::~NavGraphStaticListEdgeCostConstraint()
 }
 
 bool
-NavGraphStaticListEdgeCostConstraint::compute(void) throw()
+NavGraphStaticListEdgeCostConstraint::compute(void) noexcept
 {
 	if (modified_) {
 		modified_ = false;
@@ -145,7 +145,7 @@ NavGraphStaticListEdgeCostConstraint::clear_edges()
 
 float
 NavGraphStaticListEdgeCostConstraint::cost_factor(const fawkes::NavGraphNode &from,
-                                                  const fawkes::NavGraphNode &to) throw()
+                                                  const fawkes::NavGraphNode &to) noexcept
 {
 	for (std::pair<NavGraphEdge, float> &ec : edge_cost_list_) {
 		if ((ec.first.from() == from.name() && ec.first.to() == to.name())

--- a/src/libs/navgraph/constraints/static_list_edge_cost_constraint.h
+++ b/src/libs/navgraph/constraints/static_list_edge_cost_constraint.h
@@ -46,10 +46,10 @@ public:
 	void clear_edges();
 	bool has_edge(const fawkes::NavGraphEdge &edge);
 
-	virtual bool compute(void) throw();
+	virtual bool compute(void) noexcept;
 
 	virtual float cost_factor(const fawkes::NavGraphNode &from,
-	                          const fawkes::NavGraphNode &to) throw();
+	                          const fawkes::NavGraphNode &to) noexcept;
 
 private:
 	std::vector<std::pair<fawkes::NavGraphEdge, float>>        edge_cost_list_;

--- a/src/libs/navgraph/constraints/static_list_node_constraint.cpp
+++ b/src/libs/navgraph/constraints/static_list_node_constraint.cpp
@@ -59,7 +59,7 @@ NavGraphStaticListNodeConstraint::~NavGraphStaticListNodeConstraint()
 }
 
 bool
-NavGraphStaticListNodeConstraint::compute(void) throw()
+NavGraphStaticListNodeConstraint::compute(void) noexcept
 {
 	if (modified_) {
 		modified_ = false;

--- a/src/libs/navgraph/constraints/static_list_node_constraint.h
+++ b/src/libs/navgraph/constraints/static_list_node_constraint.h
@@ -48,10 +48,10 @@ public:
 	void clear_nodes();
 	bool has_node(const fawkes::NavGraphNode &node);
 
-	virtual bool compute(void) throw();
+	virtual bool compute(void) noexcept;
 
 	virtual bool
-	blocks(const fawkes::NavGraphNode &node) throw()
+	blocks(const fawkes::NavGraphNode &node) noexcept
 	{
 		return has_node(node);
 	}

--- a/src/libs/navgraph/constraints/timed_reservation_list_edge_constraint.cpp
+++ b/src/libs/navgraph/constraints/timed_reservation_list_edge_constraint.cpp
@@ -73,7 +73,7 @@ NavGraphTimedReservationListEdgeConstraint::~NavGraphTimedReservationListEdgeCon
 }
 
 bool
-NavGraphTimedReservationListEdgeConstraint::compute(void) throw()
+NavGraphTimedReservationListEdgeConstraint::compute(void) noexcept
 {
 	fawkes::Time                                       now(clock_);
 	std::vector<std::pair<NavGraphEdge, fawkes::Time>> erase_list;
@@ -182,7 +182,7 @@ NavGraphTimedReservationListEdgeConstraint::has_edge(const fawkes::NavGraphEdge 
 
 bool
 NavGraphTimedReservationListEdgeConstraint::blocks(const fawkes::NavGraphNode &from,
-                                                   const fawkes::NavGraphNode &to) throw()
+                                                   const fawkes::NavGraphNode &to) noexcept
 {
 	for (const std::pair<fawkes::NavGraphEdge, fawkes::Time> &te : edge_time_list_) {
 		if (((te.first.from() == from.name()) && (te.first.to() == to.name()))

--- a/src/libs/navgraph/constraints/timed_reservation_list_edge_constraint.h
+++ b/src/libs/navgraph/constraints/timed_reservation_list_edge_constraint.h
@@ -56,8 +56,8 @@ public:
 	void clear_edges();
 	bool has_edge(const fawkes::NavGraphEdge &edge);
 
-	virtual bool compute(void) throw();
-	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) throw();
+	virtual bool compute(void) noexcept;
+	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) noexcept;
 
 private:
 	std::vector<std::pair<fawkes::NavGraphEdge, fawkes::Time>> edge_time_list_;

--- a/src/libs/navgraph/constraints/timed_reservation_list_node_constraint.cpp
+++ b/src/libs/navgraph/constraints/timed_reservation_list_node_constraint.cpp
@@ -72,7 +72,7 @@ NavGraphTimedReservationListNodeConstraint::~NavGraphTimedReservationListNodeCon
 }
 
 bool
-NavGraphTimedReservationListNodeConstraint::compute(void) throw()
+NavGraphTimedReservationListNodeConstraint::compute(void) noexcept
 {
 	fawkes::Time                                       now(clock_);
 	std::vector<std::pair<NavGraphNode, fawkes::Time>> erase_list;
@@ -175,7 +175,7 @@ NavGraphTimedReservationListNodeConstraint::has_node(const fawkes::NavGraphNode 
 }
 
 bool
-NavGraphTimedReservationListNodeConstraint::blocks(const fawkes::NavGraphNode &node) throw()
+NavGraphTimedReservationListNodeConstraint::blocks(const fawkes::NavGraphNode &node) noexcept
 {
 	for (const std::pair<fawkes::NavGraphNode, fawkes::Time> &te : node_time_list_) {
 		if (te.first.name() == node.name()) {

--- a/src/libs/navgraph/constraints/timed_reservation_list_node_constraint.h
+++ b/src/libs/navgraph/constraints/timed_reservation_list_node_constraint.h
@@ -56,8 +56,8 @@ public:
 	void clear_nodes();
 	bool has_node(const fawkes::NavGraphNode &node);
 
-	virtual bool compute(void) throw();
-	virtual bool blocks(const fawkes::NavGraphNode &node) throw();
+	virtual bool compute(void) noexcept;
+	virtual bool blocks(const fawkes::NavGraphNode &node) noexcept;
 
 private:
 	std::vector<std::pair<fawkes::NavGraphNode, fawkes::Time>> node_time_list_;

--- a/src/libs/navgraph/generators/voronoi.cpp
+++ b/src/libs/navgraph/generators/voronoi.cpp
@@ -192,7 +192,7 @@ NavGraphGeneratorVoronoi::compute(fawkes::LockPtr<fawkes::NavGraph> graph)
 		}
 
 		polygons_.remove_if([&node_coords](const Polygon2D &poly) {
-			for (const auto nc : node_coords) {
+			for (const auto &nc : node_coords) {
 				if (polygon_contains(poly, nc))
 					return true;
 			}

--- a/src/libs/navgraph/navgraph.cpp
+++ b/src/libs/navgraph/navgraph.cpp
@@ -1502,7 +1502,7 @@ NavGraph::set_notifications_enabled(bool enabled)
 
 /** Notify all listeners of a change. */
 void
-NavGraph::notify_of_change() throw()
+NavGraph::notify_of_change() noexcept
 {
 	if (!notifications_enabled_)
 		return;
@@ -1519,7 +1519,7 @@ NavGraph::notify_of_change() throw()
  * Topological graph change listener.
  * @author Tim Niemueller
  *
- * @fn void NavGraph::ChangeListener::graph_changed() throw() = 0
+ * @fn void NavGraph::ChangeListener::graph_changed() noexcept = 0
  * Function called if the graph has been changed.
  */
 

--- a/src/libs/navgraph/navgraph.h
+++ b/src/libs/navgraph/navgraph.h
@@ -173,13 +173,13 @@ public:
 	NavGraph &operator=(const NavGraph &g);
 
 	void set_notifications_enabled(bool enabled);
-	void notify_of_change() throw();
+	void notify_of_change() noexcept;
 
 	class ChangeListener
 	{
 	public:
 		virtual ~ChangeListener();
-		virtual void graph_changed() throw() = 0;
+		virtual void graph_changed() noexcept = 0;
 	};
 
 	void add_change_listener(ChangeListener *listener);

--- a/src/libs/netcomm/fawkes/client.cpp
+++ b/src/libs/netcomm/fawkes/client.cpp
@@ -825,7 +825,7 @@ FawkesNetworkClient::wake(unsigned int component_id)
  * @return true if connection is alive at the moment, false otherwise
  */
 bool
-FawkesNetworkClient::connected() const throw()
+FawkesNetworkClient::connected() const noexcept
 {
 	return (!connection_died_recently && (s != NULL));
 }

--- a/src/libs/netcomm/fawkes/client.h
+++ b/src/libs/netcomm/fawkes/client.h
@@ -76,7 +76,7 @@ public:
 	void register_handler(FawkesNetworkClientHandler *handler, unsigned int component_id);
 	void deregister_handler(unsigned int component_id);
 
-	bool connected() const throw();
+	bool connected() const noexcept;
 
 	bool         has_id() const;
 	unsigned int id() const;

--- a/src/libs/netcomm/fawkes/client_handler.cpp
+++ b/src/libs/netcomm/fawkes/client_handler.cpp
@@ -31,14 +31,14 @@ namespace fawkes {
  * @ingroup NetComm
  * @author Tim Niemueller
  *
- * @fn virtual void FawkesNetworkClientHandler::deregistered(unsigned int id) throw() = 0
+ * @fn virtual void FawkesNetworkClientHandler::deregistered(unsigned int id) noexcept = 0
  * This handler has been deregistered.
  * This is called when this handler is deregistered from the
  * FawkesNetworkClient. Sometimes you may not want to allow this and post
  * a big fat warning into the log.
  * @param id the id of the calling client
  *
- * @fn virtual void FawkesNetworkClientHandler::inbound_received(FawkesNetworkMessage *m, unsigned int id) throw() = 0
+ * @fn virtual void FawkesNetworkClientHandler::inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept = 0
  * Called for incoming messages.
  * This is called when an incoming message has been received. If this
  * method was called one or more times then the a previously carried out
@@ -46,7 +46,7 @@ namespace fawkes {
  * @param m Message to handle
  * @param id the id of the calling client
  *
- * @fn virtual void FawkesNetworkClientHandler::connection_established(unsigned int id) throw() = 0
+ * @fn virtual void FawkesNetworkClientHandler::connection_established(unsigned int id) noexcept = 0
  * Client has established a connection.
  * Whenever the client establishes a connection this is signaled to handlers with this
  * method. You can register to a client at any time, you may even enqueue messages to
@@ -56,7 +56,7 @@ namespace fawkes {
  * the user know about the connection status.
  * @param id the id of the calling client
  *
- * @fn virtual void FawkesNetworkClientHandler::connection_died(unsigned int id) throw() = 0
+ * @fn virtual void FawkesNetworkClientHandler::connection_died(unsigned int id) noexcept = 0
  * Client connection died.
  * This method is used to inform handlers that the connection has died for any reason.
  * No more data can be send and no more messages should be enqueued because it is unclear

--- a/src/libs/netcomm/fawkes/client_handler.h
+++ b/src/libs/netcomm/fawkes/client_handler.h
@@ -33,10 +33,10 @@ class FawkesNetworkClientHandler
 public:
 	virtual ~FawkesNetworkClientHandler();
 
-	virtual void deregistered(unsigned int id) throw()                              = 0;
-	virtual void inbound_received(FawkesNetworkMessage *m, unsigned int id) throw() = 0;
-	virtual void connection_died(unsigned int id) throw()                           = 0;
-	virtual void connection_established(unsigned int id) throw()                    = 0;
+	virtual void deregistered(unsigned int id) noexcept                              = 0;
+	virtual void inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept = 0;
+	virtual void connection_died(unsigned int id) noexcept                           = 0;
+	virtual void connection_established(unsigned int id) noexcept                    = 0;
 };
 
 } // end namespace fawkes

--- a/src/libs/netcomm/fawkes/server_thread.cpp
+++ b/src/libs/netcomm/fawkes/server_thread.cpp
@@ -120,7 +120,7 @@ FawkesNetworkServerThread::~FawkesNetworkServerThread()
  * @param s socket for new client
  */
 void
-FawkesNetworkServerThread::add_connection(StreamSocket *s) throw()
+FawkesNetworkServerThread::add_connection(StreamSocket *s) noexcept
 {
 	FawkesNetworkServerClientThread *client = new FawkesNetworkServerClientThread(s, this);
 

--- a/src/libs/netcomm/fawkes/server_thread.h
+++ b/src/libs/netcomm/fawkes/server_thread.h
@@ -81,7 +81,7 @@ public:
 	                  unsigned short int           msg_id,
 	                  FawkesNetworkMessageContent *content);
 
-	void add_connection(StreamSocket *s) throw();
+	void add_connection(StreamSocket *s) noexcept;
 	void dispatch(FawkesNetworkMessage *msg);
 
 	void force_send();

--- a/src/libs/netcomm/utils/incoming_connection_handler.cpp
+++ b/src/libs/netcomm/utils/incoming_connection_handler.cpp
@@ -29,7 +29,7 @@ namespace fawkes {
  * Interface for handling incoming connections.
  * @author Tim Niemueller
  *
- * @fn void NetworkIncomingConnectionHandler::add_connection(StreamSocket *s) throw() = 0
+ * @fn void NetworkIncomingConnectionHandler::add_connection(StreamSocket *s) noexcept = 0
  * Add an incoming connection.
  * This is called for instance by the NetworkAcceptorThread whenever a new connection has
  * been accepted.

--- a/src/libs/netcomm/utils/incoming_connection_handler.h
+++ b/src/libs/netcomm/utils/incoming_connection_handler.h
@@ -33,7 +33,7 @@ class NetworkIncomingConnectionHandler
 public:
 	virtual ~NetworkIncomingConnectionHandler();
 
-	virtual void add_connection(StreamSocket *s) throw() = 0;
+	virtual void add_connection(StreamSocket *s) noexcept = 0;
 };
 
 } // end namespace fawkes

--- a/src/libs/plugin/loader.cpp
+++ b/src/libs/plugin/loader.cpp
@@ -64,7 +64,7 @@ PluginLoadException::PluginLoadException(const char *plugin, const char *message
 }
 
 /** Destructor. */
-PluginLoadException::~PluginLoadException() throw()
+PluginLoadException::~PluginLoadException() noexcept
 {
 }
 

--- a/src/libs/plugin/loader.h
+++ b/src/libs/plugin/loader.h
@@ -40,7 +40,7 @@ class PluginLoadException : public Exception
 public:
 	PluginLoadException(const char *plugin, const char *message);
 	PluginLoadException(const char *plugin, const char *message, Exception &e);
-	~PluginLoadException() throw();
+	~PluginLoadException() noexcept;
 
 	std::string plugin_name() const;
 

--- a/src/libs/tf/transform_listener.cpp
+++ b/src/libs/tf/transform_listener.cpp
@@ -115,7 +115,7 @@ TransformListener::~TransformListener()
 }
 
 void
-TransformListener::bb_interface_created(const char *type, const char *id) throw()
+TransformListener::bb_interface_created(const char *type, const char *id) noexcept
 {
 	if (strncmp(type, "TransformInterface", INTERFACE_TYPE_SIZE_) != 0)
 		return;
@@ -141,19 +141,19 @@ TransformListener::bb_interface_created(const char *type, const char *id) throw(
 }
 
 void
-TransformListener::bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw()
+TransformListener::bb_interface_writer_removed(Interface *interface, Uuid instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-TransformListener::bb_interface_reader_removed(Interface *interface, Uuid instance_serial) throw()
+TransformListener::bb_interface_reader_removed(Interface *interface, Uuid instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-TransformListener::conditional_close(Interface *interface) throw()
+TransformListener::conditional_close(Interface *interface) noexcept
 {
 	if (bb_is_remote_) {
 		return;
@@ -179,7 +179,7 @@ TransformListener::conditional_close(Interface *interface) throw()
 }
 
 void
-TransformListener::bb_interface_data_refreshed(Interface *interface) throw()
+TransformListener::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	TransformInterface *tfif = dynamic_cast<TransformInterface *>(interface);
 	if (!tfif)

--- a/src/libs/tf/transform_listener.h
+++ b/src/libs/tf/transform_listener.h
@@ -74,15 +74,15 @@ public:
 	virtual ~TransformListener();
 
 	// for BlackBoardInterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	// for BlackBoardInterfaceListener
-	virtual void bb_interface_data_refreshed(Interface *interface) throw();
-	virtual void bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw();
-	virtual void bb_interface_reader_removed(Interface *interface, Uuid instance_serial) throw();
+	virtual void bb_interface_data_refreshed(Interface *interface) noexcept;
+	virtual void bb_interface_writer_removed(Interface *interface, Uuid instance_serial) noexcept;
+	virtual void bb_interface_reader_removed(Interface *interface, Uuid instance_serial) noexcept;
 
 private:
-	void conditional_close(Interface *interface) throw();
+	void conditional_close(Interface *interface) noexcept;
 
 private:
 	BlackBoard * bb_;

--- a/src/libs/webview/user_verifier.cpp
+++ b/src/libs/webview/user_verifier.cpp
@@ -30,7 +30,7 @@ namespace fawkes {
  * Note that the password might be a hash for digest authentication.
  * @author Tim Niemueller
  *
- * @fn bool WebUserVerifier::verify_user(const char *user, const char *password) throw()
+ * @fn bool WebUserVerifier::verify_user(const char *user, const char *password) noexcept
  * Verify a user.
  * Check if the passed credentials are valid.
  * @param user user name

--- a/src/libs/webview/user_verifier.h
+++ b/src/libs/webview/user_verifier.h
@@ -30,7 +30,7 @@ class WebUserVerifier
 public:
 	virtual ~WebUserVerifier();
 
-	virtual bool verify_user(const char *user, const char *password) throw() = 0;
+	virtual bool verify_user(const char *user, const char *password) noexcept = 0;
 };
 
 } // end namespace fawkes

--- a/src/plugins/amcl/amcl_thread.cpp
+++ b/src/plugins/amcl/amcl_thread.cpp
@@ -1127,7 +1127,7 @@ AmclThread::set_initial_pose(const std::string & frame_id,
 }
 
 bool
-AmclThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+AmclThread::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	LocalizationInterface::SetInitialPoseMessage *ipm =
 	  dynamic_cast<LocalizationInterface::SetInitialPoseMessage *>(message);

--- a/src/plugins/amcl/amcl_thread.h
+++ b/src/plugins/amcl/amcl_thread.h
@@ -109,7 +109,7 @@ private:
 	                                    const fawkes::tf::Pose &pose,
 	                                    const double *          covariance);
 	virtual bool       bb_interface_message_received(fawkes::Interface *interface,
-	                                                 fawkes::Message *  message) throw();
+	                                                 fawkes::Message *  message) noexcept;
 
 private:
 	fawkes::Mutex *conf_mutex_;

--- a/src/plugins/bblogger/log_thread.cpp
+++ b/src/plugins/bblogger/log_thread.cpp
@@ -346,7 +346,7 @@ BBLoggerThread::loop()
 }
 
 bool
-BBLoggerThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+BBLoggerThread::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	SwitchInterface::EnableSwitchMessage * enm;
 	SwitchInterface::DisableSwitchMessage *dism;
@@ -375,7 +375,7 @@ BBLoggerThread::bb_interface_message_received(Interface *interface, Message *mes
 }
 
 void
-BBLoggerThread::bb_interface_data_refreshed(Interface *interface) throw()
+BBLoggerThread::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	if (!enabled_)
 		return;
@@ -403,13 +403,13 @@ BBLoggerThread::bb_interface_data_refreshed(Interface *interface) throw()
 }
 
 void
-BBLoggerThread::bb_interface_writer_added(Interface *interface, Uuid instance_serial) throw()
+BBLoggerThread::bb_interface_writer_added(Interface *interface, Uuid instance_serial) noexcept
 {
 	session_start_ = num_data_items_;
 }
 
 void
-BBLoggerThread::bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw()
+BBLoggerThread::bb_interface_writer_removed(Interface *interface, Uuid instance_serial) noexcept
 {
 	logger->log_info(name(),
 	                 "Writer removed (wrote %u entries), flushing",

--- a/src/plugins/bblogger/log_thread.h
+++ b/src/plugins/bblogger/log_thread.h
@@ -68,12 +68,12 @@ public:
 	virtual void loop();
 
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	                                           fawkes::Message *  message) noexcept;
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 	virtual void bb_interface_writer_added(fawkes::Interface *interface,
-	                                       fawkes::Uuid       instance_serial) throw();
+	                                       fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/bbsync/sync_listener.cpp
+++ b/src/plugins/bbsync/sync_listener.cpp
@@ -75,7 +75,8 @@ SyncInterfaceListener::~SyncInterfaceListener()
 }
 
 bool
-SyncInterfaceListener::bb_interface_message_received(Interface *interface, Message *message) throw()
+SyncInterfaceListener::bb_interface_message_received(Interface *interface,
+                                                     Message *  message) noexcept
 {
 	try {
 		if (interface == writer_) {
@@ -110,7 +111,7 @@ SyncInterfaceListener::bb_interface_message_received(Interface *interface, Messa
 }
 
 void
-SyncInterfaceListener::bb_interface_data_refreshed(Interface *interface) throw()
+SyncInterfaceListener::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	try {
 		if (interface == reader_) {

--- a/src/plugins/bbsync/sync_listener.h
+++ b/src/plugins/bbsync/sync_listener.h
@@ -41,8 +41,8 @@ public:
 	virtual ~SyncInterfaceListener();
 
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	                                           fawkes::Message *  message) noexcept;
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 private:
 	fawkes::Logger *logger_;

--- a/src/plugins/bbsync/sync_thread.cpp
+++ b/src/plugins/bbsync/sync_thread.cpp
@@ -310,7 +310,7 @@ BlackBoardSynchronizationThread::close_interfaces()
  * @param interface the interface a writer has been added for.
  */
 void
-BlackBoardSynchronizationThread::writer_added(fawkes::Interface *interface) throw()
+BlackBoardSynchronizationThread::writer_added(fawkes::Interface *interface) noexcept
 {
 	MutexLocker lock(interfaces_.mutex());
 
@@ -358,7 +358,7 @@ BlackBoardSynchronizationThread::writer_added(fawkes::Interface *interface) thro
  * @param interface the interface a writer has been removed for.
  */
 void
-BlackBoardSynchronizationThread::writer_removed(fawkes::Interface *interface) throw()
+BlackBoardSynchronizationThread::writer_removed(fawkes::Interface *interface) noexcept
 {
 	MutexLocker lock(interfaces_.mutex());
 

--- a/src/plugins/bbsync/sync_thread.h
+++ b/src/plugins/bbsync/sync_thread.h
@@ -57,8 +57,8 @@ public:
 	virtual void loop();
 	virtual void finalize();
 
-	void writer_added(fawkes::Interface *interface) throw();
-	void writer_removed(fawkes::Interface *interface) throw();
+	void writer_added(fawkes::Interface *interface) noexcept;
+	void writer_removed(fawkes::Interface *interface) noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/bbsync/writer_listener.cpp
+++ b/src/plugins/bbsync/writer_listener.cpp
@@ -72,14 +72,14 @@ SyncWriterInterfaceListener::remove_interface(Interface *interface)
 
 void
 SyncWriterInterfaceListener::bb_interface_writer_added(fawkes::Interface *interface,
-                                                       fawkes::Uuid       instance_serial) throw()
+                                                       fawkes::Uuid       instance_serial) noexcept
 {
 	sync_thread_->writer_added(interface);
 }
 
 void
 SyncWriterInterfaceListener::bb_interface_writer_removed(fawkes::Interface *interface,
-                                                         fawkes::Uuid       instance_serial) throw()
+                                                         fawkes::Uuid instance_serial) noexcept
 {
 	sync_thread_->writer_removed(interface);
 }

--- a/src/plugins/bbsync/writer_listener.h
+++ b/src/plugins/bbsync/writer_listener.h
@@ -44,9 +44,9 @@ public:
 
 	// BlackBoardInterfaceListener
 	virtual void bb_interface_writer_added(fawkes::Interface *interface,
-	                                       fawkes::Uuid       instance_serial) throw();
+	                                       fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 
 private:
 	fawkes::Logger *                 logger_;

--- a/src/plugins/clips-executive/clips_executive_thread.cpp
+++ b/src/plugins/clips-executive/clips_executive_thread.cpp
@@ -123,7 +123,7 @@ ClipsExecutiveThread::init()
 	}
 
 	std::vector<std::string> files{SRCDIR "/clips/saliences.clp", SRCDIR "/clips/init.clp"};
-	for (const auto f : files) {
+	for (const auto &f : files) {
 		if (!clips->batch_evaluate(f)) {
 			logger->log_error(name(),
 			                  "Failed to initialize CLIPS environment, "

--- a/src/plugins/clips-navgraph/clips_navgraph_thread.cpp
+++ b/src/plugins/clips-navgraph/clips_navgraph_thread.cpp
@@ -185,7 +185,7 @@ ClipsNavGraphThread::clips_navgraph_unblock_edge(std::string env_name,
 }
 
 void
-ClipsNavGraphThread::graph_changed() throw()
+ClipsNavGraphThread::graph_changed() noexcept
 {
 	for (auto e : envs_) {
 		logger->log_debug(name(), "Graph changed, re-asserting in environment %s", e.first.c_str());

--- a/src/plugins/clips-navgraph/clips_navgraph_thread.h
+++ b/src/plugins/clips-navgraph/clips_navgraph_thread.h
@@ -59,7 +59,7 @@ public:
 	                                fawkes::LockPtr<CLIPS::Environment> &clips);
 	virtual void clips_context_destroyed(const std::string &env_name);
 
-	virtual void graph_changed() throw();
+	virtual void graph_changed() noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/dynamixel/driver_thread.cpp
+++ b/src/plugins/dynamixel/driver_thread.cpp
@@ -428,7 +428,8 @@ DynamixelDriverThread::exec_act()
 }
 
 bool
-DynamixelDriverThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+DynamixelDriverThread::bb_interface_message_received(Interface *interface,
+                                                     Message *  message) noexcept
 {
 	std::map<unsigned int, Servo>::iterator si =
 	  std::find_if(servos_.begin(),

--- a/src/plugins/dynamixel/driver_thread.h
+++ b/src/plugins/dynamixel/driver_thread.h
@@ -63,7 +63,7 @@ public:
 
 	// For BlackBoardInterfaceListener
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 	void exec_sensor();
 	void exec_act();

--- a/src/plugins/eclipse-clp/consoletool/skilltester.cpp
+++ b/src/plugins/eclipse-clp/consoletool/skilltester.cpp
@@ -177,17 +177,17 @@ public:
 	}
 
 	virtual void
-	deregistered(unsigned int id) throw()
+	deregistered(unsigned int id) noexcept
 	{
 	}
 
 	virtual void
-	inbound_received(FawkesNetworkMessage *m, unsigned int id) throw()
+	inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept
 	{
 	}
 
 	virtual void
-	connection_died(unsigned int id) throw()
+	connection_died(unsigned int id) noexcept
 	{
 		prompt = "-# ";
 
@@ -204,7 +204,7 @@ public:
 	}
 
 	virtual void
-	connection_established(unsigned int id) throw()
+	connection_established(unsigned int id) noexcept
 	{
 		printf("Connection established\n");
 		just_connected = true;

--- a/src/plugins/examples/basics/example_plugin_netping.cpp
+++ b/src/plugins/examples/basics/example_plugin_netping.cpp
@@ -47,7 +47,7 @@ public:
    * @param id the id of the calling client
    */
 	virtual void
-	deregistered(unsigned int id) throw()
+	deregistered(unsigned int id) noexcept
 	{
 		printf("Got deregistered\n");
 		quit = true;
@@ -58,7 +58,7 @@ public:
    * @param id the id of the calling thread
    */
 	virtual void
-	inbound_received(FawkesNetworkMessage *m, unsigned int id) throw()
+	inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept
 	{
 		if (m->payload_size() == sizeof(unsigned int)) {
 			unsigned int *u = (unsigned int *)m->payload();
@@ -70,14 +70,14 @@ public:
 	}
 
 	virtual void
-	connection_died(unsigned int id) throw()
+	connection_died(unsigned int id) noexcept
 	{
 		printf("Connection died.\n");
 		quit = true;
 	}
 
 	virtual void
-	connection_established(unsigned int id) throw()
+	connection_established(unsigned int id) noexcept
 	{
 		printf("Connection established\n");
 	}

--- a/src/plugins/festival/synth_thread.cpp
+++ b/src/plugins/festival/synth_thread.cpp
@@ -112,7 +112,7 @@ FestivalSynthThread::loop()
 }
 
 bool
-FestivalSynthThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+FestivalSynthThread::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	wakeup();
 	return true;

--- a/src/plugins/festival/synth_thread.h
+++ b/src/plugins/festival/synth_thread.h
@@ -54,7 +54,7 @@ public:
 
 	void         say(const char *text);
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/flite/synth_thread.cpp
+++ b/src/plugins/flite/synth_thread.cpp
@@ -93,7 +93,7 @@ FliteSynthThread::loop()
 }
 
 bool
-FliteSynthThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+FliteSynthThread::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	wakeup();
 	return true;

--- a/src/plugins/flite/synth_thread.h
+++ b/src/plugins/flite/synth_thread.h
@@ -55,7 +55,7 @@ public:
 	void say(const char *text);
 
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/gazebo/gazebo.mk
+++ b/src/plugins/gazebo/gazebo.mk
@@ -43,7 +43,7 @@ ifeq ($(HAVE_GAZEBO),1)
     # Disable the deprecated declarations warning with older gazebo versions.
     CFLAGS += -Wno-deprecated-declarations
   endif
-  LDFLAGS_GAZEBO = $(shell $(PKGCONFIG) --libs 'gazebo') -ldl
+  LDFLAGS_GAZEBO = $(shell $(PKGCONFIG) --libs 'gazebo') -ldl -lm
 
   ifeq ($(HAVE_GAZEBO_96)$(boost-have-lib system),11)
     LDFLAGS_GAZEBO += $(boost-lib-ldflags system)

--- a/src/plugins/gazebo/gazebo.mk
+++ b/src/plugins/gazebo/gazebo.mk
@@ -31,8 +31,12 @@ ifneq ($(PKGCONFIG),)
 endif
 
 ifeq ($(HAVE_GAZEBO),1)
+	# -Wno-range-loop-construct: gazebo uses range-based for loops without
+	#  references in its headers. Disable the warning until this is fixed
+	#  upstream.
   CFLAGS_GAZEBO  = -DHAVE_GAZEBO $(shell $(PKGCONFIG) --cflags 'gazebo') \
-                   -DTBB_SUPPRESS_DEPRECATED_MESSAGES
+                   -DTBB_SUPPRESS_DEPRECATED_MESSAGES \
+                   -Wno-range-loop-construct
   ifneq ($(HAVE_GAZEBO_101),1)
     # Gazebo 8 declared several symbols as deprecated but still uses them.
 		# Those were fixed in Gazebo 10.

--- a/src/plugins/gazebo/gazebo.mk
+++ b/src/plugins/gazebo/gazebo.mk
@@ -28,6 +28,7 @@ ifneq ($(PKGCONFIG),)
   HAVE_GAZEBO_96 = $(if $(shell $(PKGCONFIG) --atleast-version=9.6.0 'gazebo'; echo $${?/1/}),1,0)
   HAVE_GAZEBO_10 = $(if $(shell $(PKGCONFIG) --atleast-version=10 'gazebo'; echo $${?/1/}),1,0)
   HAVE_GAZEBO_11 = $(if $(shell $(PKGCONFIG) --atleast-version=11 'gazebo'; echo $${?/1/}),1,0)
+  HAVE_GAZEBO_12 = $(if $(shell $(PKGCONFIG) --atleast-version=12 'gazebo'; echo $${?/1/}),1,0)
 endif
 
 ifeq ($(HAVE_GAZEBO),1)
@@ -35,9 +36,8 @@ ifeq ($(HAVE_GAZEBO),1)
 	#  references in its headers. Disable the warning until this is fixed
 	#  upstream.
   CFLAGS_GAZEBO  = -DHAVE_GAZEBO $(shell $(PKGCONFIG) --cflags 'gazebo') \
-                   -DTBB_SUPPRESS_DEPRECATED_MESSAGES \
-                   -Wno-range-loop-construct
-  ifneq ($(HAVE_GAZEBO_101),1)
+                   -DTBB_SUPPRESS_DEPRECATED_MESSAGES
+  ifneq ($(HAVE_GAZEBO_10),1)
     # Gazebo 8 declared several symbols as deprecated but still uses them.
 		# Those were fixed in Gazebo 10.
     # Disable the deprecated declarations warning with older gazebo versions.
@@ -52,9 +52,12 @@ ifeq ($(HAVE_GAZEBO),1)
   ifneq ($(HAVE_GAZEBO_11),1)
     CFLAGS_GAZEBO += -DBOOST_BIND_GLOBAL_PLACEHOLDERS
   endif
-
+  # Assume that this is no longer necessary in Gazebo 12.
+  ifneq ($(HAVE_GAZEBO_12),1)
+    CFLAGS_GAZEBO += -Wno-range-loop-construct
+  endif
   # if ffmpeg is installed, gazebo may have been compiled with support for it
-  #   # hence check for headers and add the respective include directories
+  # hence check for headers and add the respective include directories
   ifneq ($(wildcard $(SYSROOT)/usr/include/ffmpeg/libavcodec/avcodec.h),)
     CFLAGS_GAZEBO += -I$(SYSROOT)/usr/include/ffmpeg
   endif

--- a/src/plugins/gologpp/exog_manager.cpp
+++ b/src/plugins/gologpp/exog_manager.cpp
@@ -271,7 +271,7 @@ ExogManager::BlackboardEventHandler::make_exog_event(Interface *iface) const
 }
 
 void
-ExogManager::InterfaceWatcher::bb_interface_data_refreshed(Interface *iface) throw()
+ExogManager::InterfaceWatcher::bb_interface_data_refreshed(Interface *iface) noexcept
 {
 	try {
 		exog_manager_.exog_queue_push(make_exog_event(iface));
@@ -302,7 +302,7 @@ ExogManager::PatternObserver::~PatternObserver()
 }
 
 void
-ExogManager::PatternObserver::bb_interface_created(const char *type, const char *id) throw()
+ExogManager::PatternObserver::bb_interface_created(const char *type, const char *id) noexcept
 {
 	std::lock_guard<std::mutex> locked{handler_mutex_};
 	exog_manager_.watchers_.push_back(std::make_unique<InterfaceWatcher>(

--- a/src/plugins/gologpp/exog_manager.h
+++ b/src/plugins/gologpp/exog_manager.h
@@ -95,7 +95,7 @@ private:
 		                 ExogManager &exog_mgr);
 		virtual ~InterfaceWatcher() override;
 
-		virtual void bb_interface_data_refreshed(Interface *) throw() override;
+		virtual void bb_interface_data_refreshed(Interface *) noexcept override;
 
 	private:
 		Interface *iface_;
@@ -111,7 +111,7 @@ private:
 		                ExogManager &exog_mgr);
 		virtual ~PatternObserver() override;
 
-		virtual void bb_interface_created(const char *type, const char *id) throw() override;
+		virtual void bb_interface_created(const char *type, const char *id) noexcept override;
 
 	private:
 		std::string pattern_;

--- a/src/plugins/gologpp/skiller_action_executor.cpp
+++ b/src/plugins/gologpp/skiller_action_executor.cpp
@@ -214,7 +214,7 @@ SkillerActionExecutor::map_activity_to_skill(std::shared_ptr<gologpp::Activity> 
  * @param iface The interface that has changed
  */
 void
-SkillerActionExecutor::bb_interface_data_refreshed(Interface *iface) throw()
+SkillerActionExecutor::bb_interface_data_refreshed(Interface *iface) noexcept
 {
 	if (!running_activity_) {
 		return;

--- a/src/plugins/gologpp/skiller_action_executor.h
+++ b/src/plugins/gologpp/skiller_action_executor.h
@@ -52,7 +52,7 @@ public:
 	void         start(std::shared_ptr<gologpp::Activity> activity) override;
 	void         stop(std::shared_ptr<gologpp::Grounding<gologpp::Action>> activity) override;
 	bool         can_execute_activity(std::shared_ptr<gologpp::Activity> activity) const override;
-	virtual void bb_interface_data_refreshed(Interface *) throw() override;
+	virtual void bb_interface_data_refreshed(Interface *) noexcept override;
 
 protected:
 	const char *name() const;

--- a/src/plugins/hardware-models/hardware_models_thread.cpp
+++ b/src/plugins/hardware-models/hardware_models_thread.cpp
@@ -270,7 +270,7 @@ void
 HardwareModelsThread::clips_add_transition(const std::string &component,
                                            const std::string &transition) throw()
 {
-	for (const auto e : envs_) {
+	for (const auto &e : envs_) {
 		fawkes::LockPtr<CLIPS::Environment> clips = e.second;
 		clips.lock();
 		CLIPS::Template::pointer temp = clips->get_template("hm-transition");

--- a/src/plugins/hardware-models/hardware_models_thread.cpp
+++ b/src/plugins/hardware-models/hardware_models_thread.cpp
@@ -268,7 +268,7 @@ HardwareModelsThread::clips_add_edge(LockPtr<CLIPS::Environment> &clips,
  */
 void
 HardwareModelsThread::clips_add_transition(const std::string &component,
-                                           const std::string &transition) throw()
+                                           const std::string &transition) noexcept
 {
 	for (const auto &e : envs_) {
 		fawkes::LockPtr<CLIPS::Environment> clips = e.second;

--- a/src/plugins/hardware-models/hardware_models_thread.h
+++ b/src/plugins/hardware-models/hardware_models_thread.h
@@ -86,7 +86,7 @@ private:
 	                    const std::string &                  from,
 	                    const std::string &                  to,
 	                    const std::string &                  trans);
-	void clips_add_transition(const std::string &component, const std::string &transition) throw();
+	void clips_add_transition(const std::string &component, const std::string &transition) noexcept;
 };
 
 #endif

--- a/src/plugins/joystick/ffjoystick.cpp
+++ b/src/plugins/joystick/ffjoystick.cpp
@@ -129,7 +129,7 @@ public:
 	}
 
 	virtual void
-	bb_interface_data_refreshed(Interface *interface) throw()
+	bb_interface_data_refreshed(Interface *interface) noexcept
 	{
 		if (!bb_->is_alive()) {
 			if (bb_->try_aliveness_restore()) {
@@ -226,7 +226,7 @@ public:
 	}
 
 	virtual bool
-	bb_interface_message_received(Interface *interface, Message *message) throw()
+	bb_interface_message_received(Interface *interface, Message *message) noexcept
 	{
 		try {
 			msgproc_->process();

--- a/src/plugins/katana/act_thread.cpp
+++ b/src/plugins/katana/act_thread.cpp
@@ -794,7 +794,7 @@ KatanaActThread::loop()
 }
 
 bool
-KatanaActThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+KatanaActThread::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	if (message->is_of_type<KatanaInterface::StopMessage>()) {
 		stop_motion();

--- a/src/plugins/katana/act_thread.h
+++ b/src/plugins/katana/act_thread.h
@@ -81,7 +81,7 @@ public:
 
 	// For BlackBoardInterfaceListener
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 	void update_sensor_values();
 

--- a/src/plugins/katana/exception.cpp
+++ b/src/plugins/katana/exception.cpp
@@ -34,7 +34,7 @@ namespace fawkes {
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-KatanaNoSolutionException::KatanaNoSolutionException(const char *format, ...) throw() : Exception()
+KatanaNoSolutionException::KatanaNoSolutionException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -49,7 +49,7 @@ KatanaNoSolutionException::KatanaNoSolutionException(const char *format, ...) th
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-KatanaOutOfRangeException::KatanaOutOfRangeException(const char *format, ...) throw() : Exception()
+KatanaOutOfRangeException::KatanaOutOfRangeException(const char *format, ...) noexcept : Exception()
 {
 	va_list va;
 	va_start(va, format);
@@ -64,7 +64,7 @@ KatanaOutOfRangeException::KatanaOutOfRangeException(const char *format, ...) th
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-KatanaMotorCrashedException::KatanaMotorCrashedException(const char *format, ...) throw()
+KatanaMotorCrashedException::KatanaMotorCrashedException(const char *format, ...) noexcept
 : Exception()
 {
 	va_list va;
@@ -80,7 +80,7 @@ KatanaMotorCrashedException::KatanaMotorCrashedException(const char *format, ...
 /** Constructor
  * @param format message format, takes sprintf() parameters as variadic arguments
  */
-KatanaUnsupportedException::KatanaUnsupportedException(const char *format, ...) throw()
+KatanaUnsupportedException::KatanaUnsupportedException(const char *format, ...) noexcept
 : Exception()
 {
 	va_list va;

--- a/src/plugins/katana/exception.h
+++ b/src/plugins/katana/exception.h
@@ -31,25 +31,25 @@ namespace fawkes {
 class KatanaNoSolutionException : public Exception
 {
 public:
-	KatanaNoSolutionException(const char *format, ...) throw();
+	KatanaNoSolutionException(const char *format, ...) noexcept;
 };
 
 class KatanaOutOfRangeException : public Exception
 {
 public:
-	KatanaOutOfRangeException(const char *format, ...) throw();
+	KatanaOutOfRangeException(const char *format, ...) noexcept;
 };
 
 class KatanaMotorCrashedException : public Exception
 {
 public:
-	KatanaMotorCrashedException(const char *format, ...) throw();
+	KatanaMotorCrashedException(const char *format, ...) noexcept;
 };
 
 class KatanaUnsupportedException : public Exception
 {
 public:
-	KatanaUnsupportedException(const char *format, ...) throw();
+	KatanaUnsupportedException(const char *format, ...) noexcept;
 };
 
 } // end namespace fawkes

--- a/src/plugins/laser-filter/deadspots/deadspots.cpp
+++ b/src/plugins/laser-filter/deadspots/deadspots.cpp
@@ -384,7 +384,7 @@ private:
 	}
 
 	virtual void
-	bb_interface_data_refreshed(Interface *interface) throw()
+	bb_interface_data_refreshed(Interface *interface) noexcept
 	{
 		if (!start_measuring_)
 			return;

--- a/src/plugins/laser-pointclouds/laser_pointcloud_thread.cpp
+++ b/src/plugins/laser-pointclouds/laser_pointcloud_thread.cpp
@@ -196,7 +196,7 @@ LaserPointCloudThread::loop()
 }
 
 void
-LaserPointCloudThread::bb_interface_created(const char *type, const char *id) throw()
+LaserPointCloudThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	InterfaceCloudMapping mapping;
 	mapping.id    = interface_to_pcl_name(id);
@@ -295,20 +295,20 @@ LaserPointCloudThread::bb_interface_created(const char *type, const char *id) th
 
 void
 LaserPointCloudThread::bb_interface_writer_removed(fawkes::Interface *interface,
-                                                   fawkes::Uuid       instance_serial) throw()
+                                                   fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
 LaserPointCloudThread::bb_interface_reader_removed(fawkes::Interface *interface,
-                                                   fawkes::Uuid       instance_serial) throw()
+                                                   fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-LaserPointCloudThread::conditional_close(Interface *interface) throw()
+LaserPointCloudThread::conditional_close(Interface *interface) noexcept
 {
 	Laser360Interface * l360if  = dynamic_cast<Laser360Interface *>(interface);
 	Laser720Interface * l720if  = dynamic_cast<Laser720Interface *>(interface);

--- a/src/plugins/laser-pointclouds/laser_pointcloud_thread.h
+++ b/src/plugins/laser-pointclouds/laser_pointcloud_thread.h
@@ -58,16 +58,16 @@ public:
 	virtual void finalize();
 
 	// for BlackBoardInterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	// for BlackBoardInterfaceListener
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 
 private:
-	void        conditional_close(fawkes::Interface *interface) throw();
+	void        conditional_close(fawkes::Interface *interface) noexcept;
 	std::string interface_to_pcl_name(const char *interface_id);
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */

--- a/src/plugins/metrics/metrics_thread.cpp
+++ b/src/plugins/metrics/metrics_thread.cpp
@@ -147,7 +147,7 @@ MetricsThread::loop()
 }
 
 void
-MetricsThread::bb_interface_created(const char *type, const char *id) throw()
+MetricsThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	MutexLocker            lock(metric_bbs_.mutex());
 	MetricFamilyInterface *mfi;
@@ -337,20 +337,20 @@ MetricsThread::parse_labels(const std::string &labels, io::prometheus::client::M
 
 void
 MetricsThread::bb_interface_writer_removed(fawkes::Interface *interface,
-                                           unsigned int       instance_serial) throw()
+                                           unsigned int       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
 MetricsThread::bb_interface_reader_removed(fawkes::Interface *interface,
-                                           unsigned int       instance_serial) throw()
+                                           unsigned int       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-MetricsThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
+MetricsThread::bb_interface_data_refreshed(fawkes::Interface *interface) noexcept
 {
 	MetricFamilyInterface *mfi = dynamic_cast<MetricFamilyInterface *>(interface);
 	if (!mfi)
@@ -447,7 +447,7 @@ MetricsThread::conditional_open(const std::string &id, MetricFamilyBB &mfbb)
 }
 
 void
-MetricsThread::conditional_close(Interface *interface) throw()
+MetricsThread::conditional_close(Interface *interface) noexcept
 {
 	MetricFamilyInterface *mfi = dynamic_cast<MetricFamilyInterface *>(interface);
 	if (!mfi)

--- a/src/plugins/metrics/metrics_thread.h
+++ b/src/plugins/metrics/metrics_thread.h
@@ -102,14 +102,14 @@ private:
 
 private:
 	// for BlackBoardInterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	// for BlackBoardInterfaceListener
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         unsigned int       instance_serial) throw();
+	                                         unsigned int       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         unsigned int       instance_serial) throw();
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	                                         unsigned int       instance_serial) noexcept;
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 	// for MetricsSupplier
 	virtual std::list<io::prometheus::client::MetricFamily> metrics();
@@ -123,7 +123,7 @@ private:
 	virtual const fawkes::LockList<MetricsSupplier *> &metrics_suppliers() const;
 
 	bool conditional_open(const std::string &id, MetricFamilyBB &mfbb);
-	void conditional_close(fawkes::Interface *interface) throw();
+	void conditional_close(fawkes::Interface *interface) noexcept;
 	void parse_labels(const std::string &labels, io::prometheus::client::Metric *m);
 
 private:

--- a/src/plugins/mongodb_log/mongodb_log_bb_thread.cpp
+++ b/src/plugins/mongodb_log/mongodb_log_bb_thread.cpp
@@ -131,7 +131,7 @@ MongoLogBlackboardThread::loop()
 
 // for BlackBoardInterfaceObserver
 void
-MongoLogBlackboardThread::bb_interface_created(const char *type, const char *id) throw()
+MongoLogBlackboardThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	MutexLocker lock(listeners_.mutex());
 
@@ -216,7 +216,7 @@ MongoLogBlackboardThread::InterfaceListener::~InterfaceListener()
 
 void
 MongoLogBlackboardThread::InterfaceListener::bb_interface_data_refreshed(
-  Interface *interface) throw()
+  Interface *interface) noexcept
 {
 	now_->stamp();
 	interface->read();

--- a/src/plugins/mongodb_log/mongodb_log_bb_thread.h
+++ b/src/plugins/mongodb_log/mongodb_log_bb_thread.h
@@ -53,7 +53,7 @@ public:
 	virtual void finalize();
 
 	// for BlackBoardInterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
@@ -87,7 +87,7 @@ private:
 		}
 
 		// for BlackBoardInterfaceListener
-		virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+		virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 	private:
 		fawkes::BlackBoard *          blackboard_;

--- a/src/plugins/nao/led_thread.cpp
+++ b/src/plugins/nao/led_thread.cpp
@@ -429,7 +429,7 @@ NaoQiLedThread::loop()
 }
 
 bool
-NaoQiLedThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+NaoQiLedThread::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	// some string magic to find the correct ALValue to write to
 	std::string kind     = "Merge";

--- a/src/plugins/nao/led_thread.h
+++ b/src/plugins/nao/led_thread.h
@@ -68,7 +68,7 @@ protected:
 
 protected:
 	bool bb_interface_message_received(fawkes::Interface *interface,
-	                                   fawkes::Message *  message) throw();
+	                                   fawkes::Message *  message) noexcept;
 
 private:
 	AL::ALPtr<AL::DCMProxy>           dcm_;

--- a/src/plugins/navgraph-clusters/clusters_block_constraint.cpp
+++ b/src/plugins/navgraph-clusters/clusters_block_constraint.cpp
@@ -44,7 +44,7 @@ NavGraphClustersBlockConstraint::~NavGraphClustersBlockConstraint()
 }
 
 bool
-NavGraphClustersBlockConstraint::compute(void) throw()
+NavGraphClustersBlockConstraint::compute(void) noexcept
 {
 	blocked_ = parent_->blocked_edges();
 	return true;
@@ -52,7 +52,7 @@ NavGraphClustersBlockConstraint::compute(void) throw()
 
 bool
 NavGraphClustersBlockConstraint::blocks(const fawkes::NavGraphNode &from,
-                                        const fawkes::NavGraphNode &to) throw()
+                                        const fawkes::NavGraphNode &to) noexcept
 {
 	std::string to_n   = to.name();
 	std::string from_n = from.name();

--- a/src/plugins/navgraph-clusters/clusters_block_constraint.h
+++ b/src/plugins/navgraph-clusters/clusters_block_constraint.h
@@ -34,8 +34,8 @@ public:
 	NavGraphClustersBlockConstraint(const char *name, NavGraphClustersThread *parent);
 	virtual ~NavGraphClustersBlockConstraint();
 
-	virtual bool compute(void) throw();
-	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) throw();
+	virtual bool compute(void) noexcept;
+	virtual bool blocks(const fawkes::NavGraphNode &from, const fawkes::NavGraphNode &to) noexcept;
 
 private:
 	NavGraphClustersThread *                       parent_;

--- a/src/plugins/navgraph-clusters/clusters_distance_cost_constraint.cpp
+++ b/src/plugins/navgraph-clusters/clusters_distance_cost_constraint.cpp
@@ -74,7 +74,7 @@ NavGraphClustersDistanceCostConstraint::~NavGraphClustersDistanceCostConstraint(
 }
 
 bool
-NavGraphClustersDistanceCostConstraint::compute(void) throw()
+NavGraphClustersDistanceCostConstraint::compute(void) noexcept
 {
 	blocked_ = parent_->blocked_edges_centroids();
 	valid_   = parent_->robot_pose(pose_);
@@ -83,7 +83,7 @@ NavGraphClustersDistanceCostConstraint::compute(void) throw()
 
 float
 NavGraphClustersDistanceCostConstraint::cost_factor(const fawkes::NavGraphNode &from,
-                                                    const fawkes::NavGraphNode &to) throw()
+                                                    const fawkes::NavGraphNode &to) noexcept
 {
 	if (valid_) {
 		std::string to_n   = to.name();

--- a/src/plugins/navgraph-clusters/clusters_distance_cost_constraint.h
+++ b/src/plugins/navgraph-clusters/clusters_distance_cost_constraint.h
@@ -42,9 +42,9 @@ public:
 	                                       float                   dist_max);
 	virtual ~NavGraphClustersDistanceCostConstraint();
 
-	virtual bool  compute(void) throw();
+	virtual bool  compute(void) noexcept;
 	virtual float cost_factor(const fawkes::NavGraphNode &from,
-	                          const fawkes::NavGraphNode &to) throw();
+	                          const fawkes::NavGraphNode &to) noexcept;
 
 private:
 	NavGraphClustersThread *                                         parent_;

--- a/src/plugins/navgraph-clusters/clusters_static_cost_constraint.cpp
+++ b/src/plugins/navgraph-clusters/clusters_static_cost_constraint.cpp
@@ -48,7 +48,7 @@ NavGraphClustersStaticCostConstraint::~NavGraphClustersStaticCostConstraint()
 }
 
 bool
-NavGraphClustersStaticCostConstraint::compute(void) throw()
+NavGraphClustersStaticCostConstraint::compute(void) noexcept
 {
 	blocked_ = parent_->blocked_edges();
 	return true;
@@ -56,7 +56,7 @@ NavGraphClustersStaticCostConstraint::compute(void) throw()
 
 float
 NavGraphClustersStaticCostConstraint::cost_factor(const fawkes::NavGraphNode &from,
-                                                  const fawkes::NavGraphNode &to) throw()
+                                                  const fawkes::NavGraphNode &to) noexcept
 {
 	std::string to_n   = to.name();
 	std::string from_n = from.name();

--- a/src/plugins/navgraph-clusters/clusters_static_cost_constraint.h
+++ b/src/plugins/navgraph-clusters/clusters_static_cost_constraint.h
@@ -36,9 +36,9 @@ public:
 	                                     float                   cost_factor);
 	virtual ~NavGraphClustersStaticCostConstraint();
 
-	virtual bool  compute(void) throw();
+	virtual bool  compute(void) noexcept;
 	virtual float cost_factor(const fawkes::NavGraphNode &from,
-	                          const fawkes::NavGraphNode &to) throw();
+	                          const fawkes::NavGraphNode &to) noexcept;
 
 private:
 	NavGraphClustersThread *                       parent_;

--- a/src/plugins/navgraph-clusters/navgraph_clusters_thread.cpp
+++ b/src/plugins/navgraph-clusters/navgraph_clusters_thread.cpp
@@ -128,7 +128,7 @@ NavGraphClustersThread::loop()
 }
 
 void
-NavGraphClustersThread::bb_interface_created(const char *type, const char *id) throw()
+NavGraphClustersThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	Position3DInterface *pif;
 	try {
@@ -162,20 +162,20 @@ NavGraphClustersThread::bb_interface_created(const char *type, const char *id) t
 
 void
 NavGraphClustersThread::bb_interface_writer_removed(fawkes::Interface *interface,
-                                                    fawkes::Uuid       instance_serial) throw()
+                                                    fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
 NavGraphClustersThread::bb_interface_reader_removed(fawkes::Interface *interface,
-                                                    fawkes::Uuid       instance_serial) throw()
+                                                    fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-NavGraphClustersThread::conditional_close(Interface *interface) throw()
+NavGraphClustersThread::conditional_close(Interface *interface) noexcept
 {
 	Position3DInterface *pif = dynamic_cast<Position3DInterface *>(interface);
 
@@ -211,7 +211,7 @@ NavGraphClustersThread::conditional_close(Interface *interface) throw()
  * @return list of pairs of blocked edges' start and end name.
  */
 std::list<std::pair<std::string, std::string>>
-NavGraphClustersThread::blocked_edges() throw()
+NavGraphClustersThread::blocked_edges() noexcept
 {
 	std::list<std::pair<std::string, std::string>>                   blocked;
 	std::list<std::tuple<std::string, std::string, Eigen::Vector2f>> blocked_c =
@@ -231,7 +231,7 @@ NavGraphClustersThread::blocked_edges() throw()
  * of the object close to the edge.
  */
 std::list<std::tuple<std::string, std::string, Eigen::Vector2f>>
-NavGraphClustersThread::blocked_edges_centroids() throw()
+NavGraphClustersThread::blocked_edges_centroids() noexcept
 {
 	MutexLocker                                                      lock(cluster_ifs_.mutex());
 	std::list<std::tuple<std::string, std::string, Eigen::Vector2f>> blocked;
@@ -310,7 +310,7 @@ NavGraphClustersThread::fixed_frame_pose(std::string         frame,
  * @return true if the pose could be determined, false otherwise
  */
 bool
-NavGraphClustersThread::robot_pose(Eigen::Vector2f &pose) throw()
+NavGraphClustersThread::robot_pose(Eigen::Vector2f &pose) noexcept
 {
 	tf::Stamped<tf::Point> tpose;
 	tf::Stamped<tf::Point> input(tf::Point(0, 0, 0), fawkes::Time(0, 0), cfg_base_frame_);

--- a/src/plugins/navgraph-clusters/navgraph_clusters_thread.h
+++ b/src/plugins/navgraph-clusters/navgraph_clusters_thread.h
@@ -62,12 +62,12 @@ public:
 	virtual void loop();
 	virtual void finalize();
 
-	std::list<std::pair<std::string, std::string>> blocked_edges() throw();
+	std::list<std::pair<std::string, std::string>> blocked_edges() noexcept;
 
 	std::list<std::tuple<std::string, std::string, Eigen::Vector2f>>
-	blocked_edges_centroids() throw();
+	blocked_edges_centroids() noexcept;
 
-	bool robot_pose(Eigen::Vector2f &pose) throw();
+	bool robot_pose(Eigen::Vector2f &pose) noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:
@@ -79,15 +79,15 @@ protected:
 
 private:
 	// for BlackBoardInterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	// for BlackBoardInterfaceListener
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 
-	void conditional_close(fawkes::Interface *interface) throw();
+	void conditional_close(fawkes::Interface *interface) noexcept;
 
 	Eigen::Vector2f
 	fixed_frame_pose(std::string frame, const fawkes::Time &timestamp, float x, float y);

--- a/src/plugins/navgraph-generator/navgraph_generator_thread.cpp
+++ b/src/plugins/navgraph-generator/navgraph_generator_thread.cpp
@@ -364,7 +364,7 @@ NavGraphGeneratorThread::loop()
 
 bool
 NavGraphGeneratorThread::bb_interface_message_received(Interface *interface,
-                                                       Message *  message) throw()
+                                                       Message *  message) noexcept
 {
 	// in continuous mode wait for signal if disabled
 	MutexLocker lock(loop_mutex);

--- a/src/plugins/navgraph-generator/navgraph_generator_thread.h
+++ b/src/plugins/navgraph-generator/navgraph_generator_thread.h
@@ -86,7 +86,7 @@ private:
 	typedef std::list<Edge>                                EdgeList;
 
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 	ObstacleMap map_obstacles(float line_max_dist);
 	map_t *     load_map(std::vector<std::pair<int, int>> &free_space_indices);

--- a/src/plugins/navgraph/rospub_thread.cpp
+++ b/src/plugins/navgraph/rospub_thread.cpp
@@ -80,7 +80,7 @@ NavGraphROSPubThread::loop()
 }
 
 void
-NavGraphROSPubThread::graph_changed() throw()
+NavGraphROSPubThread::graph_changed() noexcept
 {
 	try {
 		publish_graph();

--- a/src/plugins/navgraph/rospub_thread.h
+++ b/src/plugins/navgraph/rospub_thread.h
@@ -51,7 +51,7 @@ public:
 	virtual void loop();
 	virtual void finalize();
 
-	virtual void graph_changed() throw();
+	virtual void graph_changed() noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/navgraph/visualization_thread.cpp
+++ b/src/plugins/navgraph/visualization_thread.cpp
@@ -166,7 +166,7 @@ NavGraphVisualizationThread::set_current_edge(const std::string &from, const std
 }
 
 void
-NavGraphVisualizationThread::graph_changed() throw()
+NavGraphVisualizationThread::graph_changed() noexcept
 {
 	regenerate();
 }

--- a/src/plugins/navgraph/visualization_thread.h
+++ b/src/plugins/navgraph/visualization_thread.h
@@ -56,7 +56,7 @@ public:
 	void set_current_edge(const std::string &from, const std::string &to);
 	void reset_plan();
 
-	virtual void graph_changed() throw();
+	virtual void graph_changed() noexcept;
 
 private:
 	void  publish();

--- a/src/plugins/openni/pclviewer/pclviewer.cpp
+++ b/src/plugins/openni/pclviewer/pclviewer.cpp
@@ -128,7 +128,7 @@ draw_points()
 		for (unsigned int h = 0; h < height; ++h) {
 			for (unsigned int w = 0; w < width; ++w, rgb += 3, ++pcl) {
 				//++num_values;
-				register const pcl_point_t &p = *pcl;
+				const pcl_point_t &p = *pcl;
 				if ((p.x != 0) || (p.y != 0) || (p.z != 0)) {
 					glColor3f(rgb[0] / 255., rgb[1] / 255., rgb[2] / 255.);
 					glVertex3f(p.x, p.y, p.z);
@@ -140,7 +140,7 @@ draw_points()
 		for (unsigned int h = 0; h < height; ++h) {
 			for (unsigned int w = 0; w < width; ++w, ++pcl) {
 				//++num_values;
-				register const pcl_point_t &p = *pcl;
+				const pcl_point_t &p = *pcl;
 				if ((p.x != 0) || (p.y != 0) || (p.z != 0)) {
 					glVertex3f(p.x, p.y, p.z);
 				}

--- a/src/plugins/openni/utils/hand_if_observer.cpp
+++ b/src/plugins/openni/utils/hand_if_observer.cpp
@@ -65,7 +65,7 @@ HandIfObserver::~HandIfObserver()
 }
 
 void
-HandIfObserver::bb_interface_created(const char *type, const char *id) throw()
+HandIfObserver::bb_interface_created(const char *type, const char *id) noexcept
 {
 	if (hands_.find(id) == hands_.end()) {
 		queue_lock_->lock();

--- a/src/plugins/openni/utils/hand_if_observer.h
+++ b/src/plugins/openni/utils/hand_if_observer.h
@@ -41,7 +41,7 @@ public:
 	HandIfObserver(BlackBoard *bb, HandMap &hands);
 	~HandIfObserver();
 
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	void process_queue();
 

--- a/src/plugins/openni/utils/skel_if_observer.cpp
+++ b/src/plugins/openni/utils/skel_if_observer.cpp
@@ -74,7 +74,7 @@ SkelIfObserver::~SkelIfObserver()
 }
 
 void
-SkelIfObserver::bb_interface_created(const char *type, const char *id) throw()
+SkelIfObserver::bb_interface_created(const char *type, const char *id) noexcept
 {
 	if (users_.find(id) == users_.end()) {
 		queue_lock_->lock();

--- a/src/plugins/openni/utils/skel_if_observer.h
+++ b/src/plugins/openni/utils/skel_if_observer.h
@@ -41,7 +41,7 @@ public:
 	SkelIfObserver(BlackBoard *bb, UserMap &users);
 	~SkelIfObserver();
 
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	void process_queue();
 

--- a/src/plugins/pantilt/dirperc/dp_thread.cpp
+++ b/src/plugins/pantilt/dirperc/dp_thread.cpp
@@ -224,7 +224,7 @@ PanTiltDirectedPerceptionThread::loop()
 
 bool
 PanTiltDirectedPerceptionThread::bb_interface_message_received(Interface *interface,
-                                                               Message *  message) throw()
+                                                               Message *  message) noexcept
 {
 	if (message->is_of_type<PanTiltInterface::StopMessage>()) {
 		wt_->stop_motion();

--- a/src/plugins/pantilt/dirperc/dp_thread.h
+++ b/src/plugins/pantilt/dirperc/dp_thread.h
@@ -54,7 +54,7 @@ public:
 
 	// For BlackBoardInterfaceListener
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 	void update_sensor_values();
 

--- a/src/plugins/pantilt/robotis/rx28_thread.cpp
+++ b/src/plugins/pantilt/robotis/rx28_thread.cpp
@@ -415,7 +415,7 @@ PanTiltRX28Thread::loop()
 }
 
 bool
-PanTiltRX28Thread::bb_interface_message_received(Interface *interface, Message *message) throw()
+PanTiltRX28Thread::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	if (message->is_of_type<PanTiltInterface::StopMessage>()) {
 		wt_->stop_motion();

--- a/src/plugins/pantilt/robotis/rx28_thread.h
+++ b/src/plugins/pantilt/robotis/rx28_thread.h
@@ -65,7 +65,7 @@ public:
 
 	// For BlackBoardInterfaceListener
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 	void update_sensor_values();
 

--- a/src/plugins/pantilt/sony/evid100p_thread.cpp
+++ b/src/plugins/pantilt/sony/evid100p_thread.cpp
@@ -336,7 +336,7 @@ PanTiltSonyEviD100PThread::loop()
 
 bool
 PanTiltSonyEviD100PThread::bb_interface_message_received(Interface *interface,
-                                                         Message *  message) throw()
+                                                         Message *  message) noexcept
 {
 	if (message->is_of_type<PanTiltInterface::StopMessage>()) {
 		wt_->stop_motion();

--- a/src/plugins/pantilt/sony/evid100p_thread.h
+++ b/src/plugins/pantilt/sony/evid100p_thread.h
@@ -55,7 +55,7 @@ public:
 
 	// For BlackBoardInterfaceListener
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 	void update_sensor_values();
 

--- a/src/plugins/pddl-planner/pddl-planner_thread.cpp
+++ b/src/plugins/pddl-planner/pddl-planner_thread.cpp
@@ -355,7 +355,7 @@ PddlPlannerThread::run_planner(std::string command)
 
 bool
 PddlPlannerThread::bb_interface_message_received(Interface *      interface,
-                                                 fawkes::Message *message) throw()
+                                                 fawkes::Message *message) noexcept
 {
 	if (message->is_of_type<PddlPlannerInterface::PlanMessage>()) {
 		PddlPlannerInterface::PlanMessage *msg = (PddlPlannerInterface::PlanMessage *)message;

--- a/src/plugins/pddl-planner/pddl-planner_thread.h
+++ b/src/plugins/pddl-planner/pddl-planner_thread.h
@@ -83,7 +83,7 @@ private:
 	void                     print_action_list();
 	std::string              run_planner(std::string command);
 	virtual bool             bb_interface_message_received(fawkes::Interface *interface,
-	                                                       fawkes::Message *  message) throw();
+	                                                       fawkes::Message *  message) noexcept;
 };
 
 #endif

--- a/src/plugins/pddl-robot-memory/pddl_robot_memory_thread.cpp
+++ b/src/plugins/pddl-robot-memory/pddl_robot_memory_thread.cpp
@@ -225,7 +225,7 @@ PddlRobotMemoryThread::finalize()
 
 bool
 PddlRobotMemoryThread::bb_interface_message_received(Interface *      interface,
-                                                     fawkes::Message *message) throw()
+                                                     fawkes::Message *message) noexcept
 {
 	if (message->is_of_type<PddlGenInterface::GenerateMessage>()) {
 		PddlGenInterface::GenerateMessage *msg = (PddlGenInterface::GenerateMessage *)message;

--- a/src/plugins/pddl-robot-memory/pddl_robot_memory_thread.h
+++ b/src/plugins/pddl-robot-memory/pddl_robot_memory_thread.h
@@ -76,7 +76,7 @@ private:
 	void generate();
 
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 };
 
 #endif

--- a/src/plugins/perception/base/acquisition_thread.cpp
+++ b/src/plugins/perception/base/acquisition_thread.cpp
@@ -394,7 +394,7 @@ FvAcquisitionThread::loop()
 }
 
 bool
-FvAcquisitionThread::bb_interface_message_received(Interface *interface, Message *message) throw()
+FvAcquisitionThread::bb_interface_message_received(Interface *interface, Message *message) noexcept
 {
 	// in continuous mode wait for signal if disabled
 	MutexLocker lock(enabled_mutex_);

--- a/src/plugins/perception/base/acquisition_thread.h
+++ b/src/plugins/perception/base/acquisition_thread.h
@@ -99,7 +99,7 @@ protected:
 
 private:
 	virtual bool bb_interface_message_received(fawkes::Interface *interface,
-	                                           fawkes::Message *  message) throw();
+	                                           fawkes::Message *  message) noexcept;
 
 private:
 	bool                   enabled_;

--- a/src/plugins/perception/base/base_thread.cpp
+++ b/src/plugins/perception/base/base_thread.cpp
@@ -431,7 +431,7 @@ FvBaseThread::unregister_thread(Thread *thread)
 }
 
 bool
-FvBaseThread::thread_started(Thread *thread) throw()
+FvBaseThread::thread_started(Thread *thread) noexcept
 {
 	aqts_.lock();
 	for (ait_ = aqts_.begin(); ait_ != aqts_.end(); ++ait_) {
@@ -447,7 +447,7 @@ FvBaseThread::thread_started(Thread *thread) throw()
 }
 
 bool
-FvBaseThread::thread_init_failed(Thread *thread) throw()
+FvBaseThread::thread_init_failed(Thread *thread) noexcept
 {
 	aqts_.lock();
 	for (ait_ = aqts_.begin(); ait_ != aqts_.end(); ++ait_) {

--- a/src/plugins/perception/base/base_thread.h
+++ b/src/plugins/perception/base/base_thread.h
@@ -73,8 +73,8 @@ public:
 	virtual firevision::CameraControl *acquire_camctrl(const char *cam_string);
 	virtual void                       release_camctrl(firevision::CameraControl *cc);
 
-	virtual bool thread_started(fawkes::Thread *thread) throw();
-	virtual bool thread_init_failed(fawkes::Thread *thread) throw();
+	virtual bool thread_started(fawkes::Thread *thread) noexcept;
+	virtual bool thread_init_failed(fawkes::Thread *thread) noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/perception/tabletop-objects/visualization_thread.cpp
+++ b/src/plugins/perception/tabletop-objects/visualization_thread.cpp
@@ -629,7 +629,7 @@ TabletopVisualizationThread::visualize(const std::string &                 frame
                                        M_Vector4f &                        centroids,
                                        M_Vector4f &                        cylinder_params,
                                        std::map<unsigned int, double> &    obj_confidence,
-                                       std::map<unsigned int, signed int> &best_obj_guess) throw()
+                                       std::map<unsigned int, signed int> &best_obj_guess) noexcept
 {
 	MutexLocker lock(&mutex_);
 	frame_id_              = frame_id;

--- a/src/plugins/perception/tabletop-objects/visualization_thread.h
+++ b/src/plugins/perception/tabletop-objects/visualization_thread.h
@@ -60,7 +60,7 @@ public:
 	                       M_Vector4f &                        centroids,
 	                       M_Vector4f &                        cylinder_params,
 	                       std::map<unsigned int, double> &    obj_confidence,
-	                       std::map<unsigned int, signed int> &best_obj_guess) throw();
+	                       std::map<unsigned int, signed int> &best_obj_guess) noexcept;
 
 private:
 	void triangulate_hull();

--- a/src/plugins/perception/tabletop-objects/visualization_thread_base.cpp
+++ b/src/plugins/perception/tabletop-objects/visualization_thread_base.cpp
@@ -26,7 +26,7 @@
  * This is only required to create a level of indirection to cope
  * with the re-defined msgs problem in PCL.
  *
- * @fn void TabletopVisualizationThreadBase::visualize(std::string &frame_id, Eigen::Vector4f &table_centroid, Eigen::Vector4f &normal, std::vector<Eigen::Vector4f> &table_hull_vertices, V_Vector4f &table_model_vertices, V_Vector4f &good_table_hull_edges, std::vector<Eigen::Vector4f> &centroids) throw()
+ * @fn void TabletopVisualizationThreadBase::visualize(std::string &frame_id, Eigen::Vector4f &table_centroid, Eigen::Vector4f &normal, std::vector<Eigen::Vector4f> &table_hull_vertices, V_Vector4f &table_model_vertices, V_Vector4f &good_table_hull_edges, std::vector<Eigen::Vector4f> &centroids) noexcept
  * Visualize the given data.
  * @param frame_id reference frame ID
  * @param table_centroid centroid of table

--- a/src/plugins/perception/tabletop-objects/visualization_thread_base.h
+++ b/src/plugins/perception/tabletop-objects/visualization_thread_base.h
@@ -56,7 +56,7 @@ public:
 	                       M_Vector4f &                        centroids,
 	                       M_Vector4f &                        cylinder_params,
 	                       std::map<unsigned int, double> &    obj_confidence,
-	                       std::map<unsigned int, signed int> &best_obj_guess) throw() = 0;
+	                       std::map<unsigned int, signed int> &best_obj_guess) noexcept = 0;
 };
 
 #endif

--- a/src/plugins/plexil/Makefile
+++ b/src/plugins/plexil/Makefile
@@ -123,13 +123,15 @@ ifeq ($(HAVE_PLEXIL)$(HAVE_PLEXIL_BOOST_LIBS),11)
     WARN_TARGETS += warning_navgraph
   endif
 
+  ifeq ($(HAVE_CPP17),1)
+    # Enforce C++14, as plexil is not compatible with ISO C++17.
+    CFLAGS += -std=c++14
+  endif
+
 else
   ifneq ($(HAVE_PLEXIL),1)
     WARN_TARGETS += warning_plexil
   endif
-  #ifneq ($(HAVE_CPP17),1)
-  #  WARN_TARGETS += warning_cpp17
-  #endif
   ifneq ($(HAVE_OPENPRS_BOOST_LIBS),1)
     PLEXIL_ERROR += Boost libraries missing
     PLEXIL_WARN_TARGETS_BOOST = $(foreach l,$(PLEXIL_REQ_BOOST_LIBS),$(if $(call boost-have-lib,$l),, warning_plexil_boost_$l))

--- a/src/plugins/plexil/be_adapter.cpp
+++ b/src/plugins/plexil/be_adapter.cpp
@@ -379,7 +379,7 @@ BehaviorEnginePlexilAdapter::invokeAbort(PLEXIL::Command *cmd)
 }
 
 void
-BehaviorEnginePlexilAdapter::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
+BehaviorEnginePlexilAdapter::bb_interface_data_refreshed(fawkes::Interface *interface) noexcept
 {
 	std::lock_guard<std::mutex> lock(exec_mutex_);
 	skiller_if_->read();

--- a/src/plugins/plexil/be_adapter.h
+++ b/src/plugins/plexil/be_adapter.h
@@ -62,7 +62,7 @@ public:
 	void executeCommand(PLEXIL::Command *cmd);
 	void invokeAbort(PLEXIL::Command *cmd);
 
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 private:
 	struct skill_config

--- a/src/plugins/plexil/blackboard_adapter.cpp
+++ b/src/plugins/plexil/blackboard_adapter.cpp
@@ -411,7 +411,7 @@ BlackboardPlexilAdapter::unsubscribe(const PLEXIL::State &state)
 }
 
 void
-BlackboardPlexilAdapter::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
+BlackboardPlexilAdapter::bb_interface_data_refreshed(fawkes::Interface *interface) noexcept
 {
 	//logger_->log_debug("PlexilBB", "Event for %s", interface->uid());
 	interface->read();

--- a/src/plugins/plexil/blackboard_adapter.h
+++ b/src/plugins/plexil/blackboard_adapter.h
@@ -70,7 +70,7 @@ public:
 	virtual void executeCommand(PLEXIL::Command *cmd);
 
 private:
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 	void bb_open_for_reading(PLEXIL::Command *cmd);
 	void bb_close(PLEXIL::Command *cmd);

--- a/src/plugins/robot_state_publisher/robot_state_publisher_thread.cpp
+++ b/src/plugins/robot_state_publisher/robot_state_publisher_thread.cpp
@@ -235,7 +235,7 @@ RobotStatePublisherThread::joint_is_in_model(const char *id)
 
 // InterfaceObserver
 void
-RobotStatePublisherThread::bb_interface_created(const char *type, const char *id) throw()
+RobotStatePublisherThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	if (strncmp(type, "JointInterface", INTERFACE_TYPE_SIZE_) != 0)
 		return;
@@ -269,20 +269,20 @@ RobotStatePublisherThread::bb_interface_created(const char *type, const char *id
 
 void
 RobotStatePublisherThread::bb_interface_writer_removed(Interface *interface,
-                                                       Uuid       instance_serial) throw()
+                                                       Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
 RobotStatePublisherThread::bb_interface_reader_removed(Interface *interface,
-                                                       Uuid       instance_serial) throw()
+                                                       Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-RobotStatePublisherThread::conditional_close(Interface *interface) throw()
+RobotStatePublisherThread::conditional_close(Interface *interface) noexcept
 {
 	// Verify it's a JointInterface
 	JointInterface *jiface = dynamic_cast<JointInterface *>(interface);
@@ -307,7 +307,7 @@ RobotStatePublisherThread::conditional_close(Interface *interface) throw()
 }
 
 void
-RobotStatePublisherThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
+RobotStatePublisherThread::bb_interface_data_refreshed(fawkes::Interface *interface) noexcept
 {
 	JointInterface *jiface = dynamic_cast<JointInterface *>(interface);
 	if (!jiface)

--- a/src/plugins/robot_state_publisher/robot_state_publisher_thread.h
+++ b/src/plugins/robot_state_publisher/robot_state_publisher_thread.h
@@ -117,14 +117,14 @@ public:
 	virtual void finalize();
 
 	// InterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	// InterfaceListener
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 
 private:
 	void publish_fixed_transforms();
@@ -132,7 +132,7 @@ private:
 	void add_children(const KDL::SegmentMap::const_iterator segment);
 	void transform_kdl_to_tf(const KDL::Frame &k, fawkes::tf::Transform &t);
 	bool joint_is_in_model(const char *id);
-	void conditional_close(fawkes::Interface *interface) throw();
+	void conditional_close(fawkes::Interface *interface) noexcept;
 
 private:
 	std::map<std::string, SegmentPair> segments_, segments_fixed_;

--- a/src/plugins/ros/imu_thread.cpp
+++ b/src/plugins/ros/imu_thread.cpp
@@ -98,7 +98,7 @@ RosIMUThread::finalize()
  * @param interface interface instance that you supplied to bbil_add_data_interface()
  */
 void
-RosIMUThread::bb_interface_data_refreshed(Interface *interface) throw()
+RosIMUThread::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	IMUInterface *imu_iface = dynamic_cast<IMUInterface *>(interface);
 	if (!imu_iface)

--- a/src/plugins/ros/imu_thread.h
+++ b/src/plugins/ros/imu_thread.h
@@ -44,7 +44,7 @@ public:
 	virtual void init();
 	virtual void finalize();
 
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 private:
 	ros::Publisher        ros_pub_;

--- a/src/plugins/ros/joint_thread.cpp
+++ b/src/plugins/ros/joint_thread.cpp
@@ -74,7 +74,7 @@ RosJointThread::finalize()
 }
 
 void
-RosJointThread::bb_interface_created(const char *type, const char *id) throw()
+RosJointThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	if (strncmp(type, "JointInterface", INTERFACE_TYPE_SIZE_) != 0)
 		return;
@@ -97,19 +97,19 @@ RosJointThread::bb_interface_created(const char *type, const char *id) throw()
 }
 
 void
-RosJointThread::bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw()
+RosJointThread::bb_interface_writer_removed(Interface *interface, Uuid instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-RosJointThread::bb_interface_reader_removed(Interface *interface, Uuid instance_serial) throw()
+RosJointThread::bb_interface_reader_removed(Interface *interface, Uuid instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-RosJointThread::conditional_close(Interface *interface) throw()
+RosJointThread::conditional_close(Interface *interface) noexcept
 {
 	// Verify it's a JointInterface
 	JointInterface *jiface = dynamic_cast<JointInterface *>(interface);
@@ -132,7 +132,7 @@ RosJointThread::conditional_close(Interface *interface) throw()
 }
 
 void
-RosJointThread::bb_interface_data_refreshed(Interface *interface) throw()
+RosJointThread::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	JointInterface *jiface = dynamic_cast<JointInterface *>(interface);
 	if (!jiface)

--- a/src/plugins/ros/joint_thread.h
+++ b/src/plugins/ros/joint_thread.h
@@ -52,15 +52,15 @@ public:
 	virtual void init();
 	virtual void finalize();
 
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 private:
-	void conditional_close(fawkes::Interface *interface) throw();
+	void conditional_close(fawkes::Interface *interface) noexcept;
 
 private:
 	ros::Publisher                      ros_pub_;

--- a/src/plugins/ros/laserscan_thread.cpp
+++ b/src/plugins/ros/laserscan_thread.cpp
@@ -256,7 +256,7 @@ RosLaserScanThread::loop()
 }
 
 void
-RosLaserScanThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
+RosLaserScanThread::bb_interface_data_refreshed(fawkes::Interface *interface) noexcept
 {
 	Laser360Interface * ls360if  = dynamic_cast<Laser360Interface *>(interface);
 	Laser720Interface * ls720if  = dynamic_cast<Laser720Interface *>(interface);
@@ -331,7 +331,7 @@ RosLaserScanThread::bb_interface_data_refreshed(fawkes::Interface *interface) th
 }
 
 void
-RosLaserScanThread::bb_interface_created(const char *type, const char *id) throw()
+RosLaserScanThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	// Ignore ID pattern of our own interfaces
 	if (fnmatch("ROS *", id, FNM_NOESCAPE) == 0)
@@ -461,20 +461,20 @@ RosLaserScanThread::bb_interface_created(const char *type, const char *id) throw
 
 void
 RosLaserScanThread::bb_interface_writer_removed(fawkes::Interface *interface,
-                                                fawkes::Uuid       instance_serial) throw()
+                                                fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
 RosLaserScanThread::bb_interface_reader_removed(fawkes::Interface *interface,
-                                                fawkes::Uuid       instance_serial) throw()
+                                                fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-RosLaserScanThread::conditional_close(Interface *interface) throw()
+RosLaserScanThread::conditional_close(Interface *interface) noexcept
 {
 	// Verify it's a laser interface
 	Laser360Interface * ls360if  = dynamic_cast<Laser360Interface *>(interface);

--- a/src/plugins/ros/laserscan_thread.h
+++ b/src/plugins/ros/laserscan_thread.h
@@ -59,18 +59,18 @@ public:
 	virtual void finalize();
 
 	// for BlackBoardInterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	// for BlackBoardInterfaceListener
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 
 private:
 	void        laser_scan_message_cb(const ros::MessageEvent<sensor_msgs::LaserScan const> &msg_evt);
-	void        conditional_close(fawkes::Interface *interface) throw();
+	void        conditional_close(fawkes::Interface *interface) noexcept;
 	std::string topic_name(const char *if_id, const char *suffix);
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */

--- a/src/plugins/ros/pcl_thread.cpp
+++ b/src/plugins/ros/pcl_thread.cpp
@@ -64,8 +64,7 @@ RosPointCloudThread::finalize()
 	for (const std::string &item : ros_pointcloud_available_) {
 		pcl_manager->remove_pointcloud(item.c_str());
 	}
-	for (const std::pair<std::string, fawkes::pcl_utils::StorageAdapter *> &item :
-	     ros_pointcloud_available_ref_) {
+	for (const auto &item : ros_pointcloud_available_ref_) {
 		delete item.second;
 	}
 	for (std::pair<std::string, ros::Subscriber> item : ros_pointcloud_subs_) {
@@ -111,7 +110,7 @@ RosPointCloudThread::ros_pointcloud_search()
 		if (0 == info.datatype.compare("sensor_msgs/PointCloud2")) {
 			// check if this is a topic comming from fawkes
 			bool topic_not_from_fawkes = true;
-			for (const std::pair<std::string, PublisherInfo> &fawkes_cloud : fawkes_pubs_) {
+			for (const auto &fawkes_cloud : fawkes_pubs_) {
 				if (0 == info.name.compare(fawkes_cloud.second.pub.getTopic())) {
 					topic_not_from_fawkes = false;
 				}
@@ -164,8 +163,7 @@ RosPointCloudThread::ros_pointcloud_search()
 void
 RosPointCloudThread::ros_pointcloud_check_for_listener_in_fawkes()
 {
-	for (const std::pair<std::string, fawkes::pcl_utils::StorageAdapter *> &item :
-	     ros_pointcloud_available_ref_) {
+	for (const auto &item : ros_pointcloud_available_ref_) {
 		unsigned int use_count = 0;
 		if (item.second->is_pointtype<pcl::PointXYZ>()) {
 			use_count =

--- a/src/plugins/ros/position_3d_thread.cpp
+++ b/src/plugins/ros/position_3d_thread.cpp
@@ -82,7 +82,7 @@ RosPosition3DThread::finalize()
 }
 
 void
-RosPosition3DThread::bb_interface_created(const char *type, const char *id) throw()
+RosPosition3DThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	if (strncmp(type, "Position3DInterface", INTERFACE_TYPE_SIZE_) != 0)
 		return;
@@ -105,19 +105,21 @@ RosPosition3DThread::bb_interface_created(const char *type, const char *id) thro
 }
 
 void
-RosPosition3DThread::bb_interface_writer_removed(Interface *interface, Uuid instance_serial) throw()
+RosPosition3DThread::bb_interface_writer_removed(Interface *interface,
+                                                 Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-RosPosition3DThread::bb_interface_reader_removed(Interface *interface, Uuid instance_serial) throw()
+RosPosition3DThread::bb_interface_reader_removed(Interface *interface,
+                                                 Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-RosPosition3DThread::conditional_close(Interface *interface) throw()
+RosPosition3DThread::conditional_close(Interface *interface) noexcept
 {
 	// Verify it's a Position3DInterface
 	Position3DInterface *iface = dynamic_cast<Position3DInterface *>(interface);
@@ -140,7 +142,7 @@ RosPosition3DThread::conditional_close(Interface *interface) throw()
 }
 
 void
-RosPosition3DThread::bb_interface_data_refreshed(Interface *interface) throw()
+RosPosition3DThread::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	Position3DInterface *iface = dynamic_cast<Position3DInterface *>(interface);
 	if (!iface)

--- a/src/plugins/ros/position_3d_thread.h
+++ b/src/plugins/ros/position_3d_thread.h
@@ -54,15 +54,15 @@ public:
 	virtual void init();
 	virtual void finalize();
 
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 private:
-	void conditional_close(fawkes::Interface *interface) throw();
+	void conditional_close(fawkes::Interface *interface) noexcept;
 
 private:
 	ros::Publisher                           ros_pub_;

--- a/src/plugins/ros/tf_thread.cpp
+++ b/src/plugins/ros/tf_thread.cpp
@@ -163,7 +163,7 @@ RosTfThread::loop()
 }
 
 void
-RosTfThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
+RosTfThread::bb_interface_data_refreshed(fawkes::Interface *interface) noexcept
 {
 	TransformInterface *tfif = dynamic_cast<TransformInterface *>(interface);
 	if (!tfif)
@@ -197,7 +197,7 @@ RosTfThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
 }
 
 void
-RosTfThread::bb_interface_created(const char *type, const char *id) throw()
+RosTfThread::bb_interface_created(const char *type, const char *id) noexcept
 {
 	if (strncmp(type, "TransformInterface", INTERFACE_TYPE_SIZE_) != 0)
 		return;
@@ -233,20 +233,20 @@ RosTfThread::bb_interface_created(const char *type, const char *id) throw()
 
 void
 RosTfThread::bb_interface_writer_removed(fawkes::Interface *interface,
-                                         fawkes::Uuid       instance_serial) throw()
+                                         fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
 RosTfThread::bb_interface_reader_removed(fawkes::Interface *interface,
-                                         fawkes::Uuid       instance_serial) throw()
+                                         fawkes::Uuid       instance_serial) noexcept
 {
 	conditional_close(interface);
 }
 
 void
-RosTfThread::conditional_close(Interface *interface) throw()
+RosTfThread::conditional_close(Interface *interface) noexcept
 {
 	// Verify it's a TransformInterface
 	TransformInterface *tfif = dynamic_cast<TransformInterface *>(interface);

--- a/src/plugins/ros/tf_thread.h
+++ b/src/plugins/ros/tf_thread.h
@@ -66,14 +66,14 @@ public:
 	virtual void finalize();
 
 	// for BlackBoardInterfaceObserver
-	virtual void bb_interface_created(const char *type, const char *id) throw();
+	virtual void bb_interface_created(const char *type, const char *id) noexcept;
 
 	// for BlackBoardInterfaceListener
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 	virtual void bb_interface_writer_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 	virtual void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                         fawkes::Uuid       instance_serial) throw();
+	                                         fawkes::Uuid       instance_serial) noexcept;
 
 private:
 	void tf_message_cb(const ros::MessageEvent<::tf::tfMessage const> &msg_evt);
@@ -83,7 +83,7 @@ private:
 	void tf_message_cb(const ros::MessageEvent<tf2_msgs::TFMessage const> &msg_evt, bool static_tf);
 #endif
 
-	void conditional_close(fawkes::Interface *interface) throw();
+	void conditional_close(fawkes::Interface *interface) noexcept;
 	void publish_static_transforms_to_ros();
 	void publish_transform_to_fawkes(const geometry_msgs::TransformStamped &ts,
 	                                 bool                                   static_tf = false);

--- a/src/plugins/skiller/consoletool/skillet.cpp
+++ b/src/plugins/skiller/consoletool/skillet.cpp
@@ -188,17 +188,17 @@ public:
 	}
 
 	virtual void
-	deregistered(unsigned int id) throw()
+	deregistered(unsigned int id) noexcept
 	{
 	}
 
 	virtual void
-	inbound_received(FawkesNetworkMessage *m, unsigned int id) throw()
+	inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept
 	{
 	}
 
 	virtual void
-	connection_died(unsigned int id) throw()
+	connection_died(unsigned int id) noexcept
 	{
 		prompt = "-# ";
 
@@ -215,7 +215,7 @@ public:
 	}
 
 	virtual void
-	connection_established(unsigned int id) throw()
+	connection_established(unsigned int id) noexcept
 	{
 		printf("Connection established\n");
 		just_connected = true;

--- a/src/plugins/skiller/exec_thread.cpp
+++ b/src/plugins/skiller/exec_thread.cpp
@@ -208,7 +208,7 @@ SkillerExecutionThread::lua_restarted(LuaContext *context)
 
 void
 SkillerExecutionThread::bb_interface_reader_removed(Interface *interface,
-                                                    Uuid       instance_serial) throw()
+                                                    Uuid       instance_serial) noexcept
 {
 	skiller_if_removed_readers_.push_locked(instance_serial);
 }

--- a/src/plugins/skiller/exec_thread.h
+++ b/src/plugins/skiller/exec_thread.h
@@ -79,7 +79,7 @@ public:
 
 	/* BlackBoardInterfaceListener */
 	void bb_interface_reader_removed(fawkes::Interface *interface,
-	                                 fawkes::Uuid       instance_serial) throw();
+	                                 fawkes::Uuid       instance_serial) noexcept;
 
 	// LuaContextWatcher
 	void lua_restarted(fawkes::LuaContext *context);

--- a/src/plugins/stn-generator/stn-generator_thread.cpp
+++ b/src/plugins/stn-generator/stn-generator_thread.cpp
@@ -158,7 +158,7 @@ StnGeneratorThread::finalize()
 }
 
 void
-StnGeneratorThread::bb_interface_data_refreshed(Interface *interface) throw()
+StnGeneratorThread::bb_interface_data_refreshed(Interface *interface) noexcept
 {
 	if (interface->uid() == plan_if_->uid()) {
 		plan_if_->read();

--- a/src/plugins/stn-generator/stn-generator_thread.h
+++ b/src/plugins/stn-generator/stn-generator_thread.h
@@ -50,7 +50,7 @@ public:
 	virtual void finalize();
 	virtual void loop();
 
-	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw();
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept;
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
 protected:

--- a/src/plugins/stn-generator/stn_action.cpp
+++ b/src/plugins/stn-generator/stn_action.cpp
@@ -197,7 +197,7 @@ StnAction::genConditionEdgeLabel(size_t cond_action) const
 			edge_label += "<FONT COLOR=\"red\">";
 		}
 		edge_label += p.name() + ": ";
-		for (const std::string s : p.attrs()) {
+		for (const std::string &s : p.attrs()) {
 			edge_label += s + " ";
 		}
 		edge_label += "</FONT>";

--- a/src/plugins/webview/image-rest-api/jpeg_stream_producer.cpp
+++ b/src/plugins/webview/image-rest-api/jpeg_stream_producer.cpp
@@ -57,7 +57,7 @@ WebviewJpegStreamProducer::Buffer::~Buffer()
 /** @class WebviewJpegStreamProducer::Subscriber "jpeg_stream_producer.h"
  * JPEG stream subscriber.
  *
- * @fn void WebviewJpegStreamProducer::Subscriber::handle_buffer(std::shared_ptr<Buffer> buffer) throw() = 0
+ * @fn void WebviewJpegStreamProducer::Subscriber::handle_buffer(std::shared_ptr<Buffer> buffer) noexcept = 0
  * Notification if a new buffer is available.
  * @param buffer new buffer
  */

--- a/src/plugins/webview/user_verifier.cpp
+++ b/src/plugins/webview/user_verifier.cpp
@@ -59,7 +59,7 @@ WebviewUserVerifier::~WebviewUserVerifier()
 }
 
 bool
-WebviewUserVerifier::verify_user(const char *user, const char *password) throw()
+WebviewUserVerifier::verify_user(const char *user, const char *password) noexcept
 {
 	try {
 		std::string userpath = std::string("/webview/users/") + user;

--- a/src/plugins/webview/user_verifier.h
+++ b/src/plugins/webview/user_verifier.h
@@ -36,7 +36,7 @@ public:
 	WebviewUserVerifier(fawkes::Configuration *config, fawkes::Logger *logger);
 	virtual ~WebviewUserVerifier();
 
-	virtual bool verify_user(const char *user, const char *password) throw();
+	virtual bool verify_user(const char *user, const char *password) noexcept;
 
 private:
 	fawkes::Configuration *config;

--- a/src/tools/logview/main.cpp
+++ b/src/tools/logview/main.cpp
@@ -78,7 +78,7 @@ public:
 	}
 
 	virtual void
-	inbound_received(FawkesNetworkMessage *m, unsigned int id) throw()
+	inbound_received(FawkesNetworkMessage *m, unsigned int id) noexcept
 	{
 		if ((m->cid() == FAWKES_CID_NETWORKLOGGER)
 		    && (m->msgid() == NetworkLogger::MSGTYPE_LOGMESSAGE)) {
@@ -90,20 +90,20 @@ public:
 	}
 
 	virtual void
-	deregistered(unsigned int id) throw()
+	deregistered(unsigned int id) noexcept
 	{
 		quit = true;
 	}
 
 	virtual void
-	connection_died(unsigned int id) throw()
+	connection_died(unsigned int id) noexcept
 	{
 		printf("Connection to host died. Aborting.\n");
 		quit = true;
 	}
 
 	virtual void
-	connection_established(unsigned int id) throw()
+	connection_established(unsigned int id) noexcept
 	{
 	}
 

--- a/src/tools/plugin/plugin_tool.cpp
+++ b/src/tools/plugin/plugin_tool.cpp
@@ -329,7 +329,8 @@ PluginTool::inbound_received(FawkesNetworkMessage *msg, unsigned int id) noexcep
 				if (plm->has_next()) {
 					plugin_desc = plm->next();
 				} else {
-					throw Exception("Invalid plugin list received");
+					printf("Invalid plugin list received");
+					return;
 				}
 				printf(" %-16s (%s)\n", plugin_name, plugin_desc);
 				free(plugin_name);

--- a/src/tools/plugin/plugin_tool.cpp
+++ b/src/tools/plugin/plugin_tool.cpp
@@ -249,7 +249,7 @@ PluginTool::watch()
 /** Handler has been deregistered.
  */
 void
-PluginTool::deregistered(unsigned int id) throw()
+PluginTool::deregistered(unsigned int id) noexcept
 {
 	quit = true;
 }
@@ -258,7 +258,7 @@ PluginTool::deregistered(unsigned int id) throw()
  * @param msg message.
  */
 void
-PluginTool::inbound_received(FawkesNetworkMessage *msg, unsigned int id) throw()
+PluginTool::inbound_received(FawkesNetworkMessage *msg, unsigned int id) noexcept
 {
 	if (msg->cid() != FAWKES_CID_PLUGINMANAGER)
 		return;
@@ -362,13 +362,13 @@ PluginTool::inbound_received(FawkesNetworkMessage *msg, unsigned int id) throw()
 }
 
 void
-PluginTool::connection_established(unsigned int id) throw()
+PluginTool::connection_established(unsigned int id) noexcept
 {
 	// ignored, client has to be connected already
 }
 
 void
-PluginTool::connection_died(unsigned int id) throw()
+PluginTool::connection_died(unsigned int id) noexcept
 {
 	printf("Connection died, exiting\n");
 	quit = true;

--- a/src/tools/plugin/plugin_tool.h
+++ b/src/tools/plugin/plugin_tool.h
@@ -57,10 +57,10 @@ private:
 	void watch();
 	void list_avail();
 
-	virtual void deregistered(unsigned int id) throw();
-	virtual void inbound_received(fawkes::FawkesNetworkMessage *msg, unsigned int id) throw();
-	virtual void connection_died(unsigned int id) throw();
-	virtual void connection_established(unsigned int id) throw();
+	virtual void deregistered(unsigned int id) noexcept;
+	virtual void inbound_received(fawkes::FawkesNetworkMessage *msg, unsigned int id) noexcept;
+	virtual void connection_died(unsigned int id) noexcept;
+	virtual void connection_established(unsigned int id) noexcept;
 
 private:
 	typedef enum {

--- a/src/tools/vision/firestation/fuse_transfer_widget.cpp
+++ b/src/tools/vision/firestation/fuse_transfer_widget.cpp
@@ -451,18 +451,18 @@ FuseTransferWidget::remote_lut_selected()
 
 void
 FuseTransferWidget::fuse_invalid_server_version(uint32_t local_version,
-                                                uint32_t remote_version) throw()
+                                                uint32_t remote_version) noexcept
 {
 	printf("Invalid versions: local: %u   remote: %u\n", local_version, remote_version);
 }
 
 void
-FuseTransferWidget::fuse_connection_established() throw()
+FuseTransferWidget::fuse_connection_established() noexcept
 {
 }
 
 void
-FuseTransferWidget::fuse_connection_died() throw()
+FuseTransferWidget::fuse_connection_died() noexcept
 {
 	if (m_cur_client.active) {
 		m_delete_clients.push_locked(m_cur_client.client);
@@ -473,7 +473,7 @@ FuseTransferWidget::fuse_connection_died() throw()
 }
 
 void
-FuseTransferWidget::fuse_inbound_received(FuseNetworkMessage *m) throw()
+FuseTransferWidget::fuse_inbound_received(FuseNetworkMessage *m) noexcept
 {
 	switch (m->type()) {
 	case FUSE_MT_LUT_LIST:

--- a/src/tools/vision/firestation/fuse_transfer_widget.h
+++ b/src/tools/vision/firestation/fuse_transfer_widget.h
@@ -55,10 +55,10 @@ public:
 	void set_remote_lut_list_trv(Gtk::TreeView *lut_list);
 
 	// Fuse client handler
-	void fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) throw();
-	void fuse_connection_established() throw();
-	void fuse_connection_died() throw();
-	void fuse_inbound_received(firevision::FuseNetworkMessage *m) throw();
+	void fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) noexcept;
+	void fuse_connection_established() noexcept;
+	void fuse_connection_died() noexcept;
+	void fuse_inbound_received(firevision::FuseNetworkMessage *m) noexcept;
 
 private:
 	class LutRecord : public Gtk::TreeModelColumnRecord

--- a/src/tools/vision/net.cpp
+++ b/src/tools/vision/net.cpp
@@ -68,23 +68,23 @@ public:
 	}
 
 	void
-	fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) throw()
+	fuse_invalid_server_version(uint32_t local_version, uint32_t remote_version) noexcept
 	{
 		printf("Invalid version received (local: %u, remote: %u)\n", local_version, remote_version);
 	}
 
 	virtual void
-	fuse_connection_established() throw()
+	fuse_connection_established() noexcept
 	{
 	}
 
 	virtual void
-	fuse_connection_died() throw()
+	fuse_connection_died() noexcept
 	{
 	}
 
 	virtual void
-	fuse_inbound_received(FuseNetworkMessage *m) throw()
+	fuse_inbound_received(FuseNetworkMessage *m) noexcept
 	{
 		// printf("Received message of type %u\n", m->type());
 


### PR DESCRIPTION
Fix a bunch of new compiler errors that started occurring with GCC 11 on Fedora 34.

Note that this does not yet update buildkite to Fedora 34, nor does it take the changes in clang-format into account.