### PR TITLE
skiller: fix crash on reader-removed event

### DIFF
--- a/src/plugins/skiller/exec_thread.cpp
+++ b/src/plugins/skiller/exec_thread.cpp
@@ -222,7 +222,7 @@ SkillerExecutionThread::loop()
 
 	skiller_if_removed_readers_.lock();
 	while (!skiller_if_removed_readers_.empty()) {
-		lua_->do_string("skiller.fawkes.notify_reader_removed(%s)",
+		lua_->do_string("skiller.fawkes.notify_reader_removed(\"%s\")",
 		                skiller_if_removed_readers_.front().get_string().c_str());
 		skiller_if_removed_readers_.pop();
 	}


### PR DESCRIPTION
The string needs to be quoted, otherwise lua treats it as an (invalid)
integer.