### PR TITLE
CX: add custom goal meta to goals

### DIFF
--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -192,6 +192,11 @@
 	; Amount of information to print. If set to quiet, regular events such as a
 	; committed or dispatched goal will only be logged to the debug log.
 	(slot verbosity (type SYMBOL) (allowed-values QUIET DEFAULT NOISY) (default DEFAULT))
+
+	; Indicates whether the given goal is executable, meaning if it is generally
+	; feasible to expand it in the current situation.
+	(slot is-executable (type SYMBOL) (allowed-values TRUE FALSE)
+	                    (default FALSE))
 )
 
 (deffunction goal-retract-goal-tree (?id)

--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -262,6 +262,7 @@
 )
 
 (defrule goal-meta-ambiguous-meta-facts
+	(declare (salience ?*SALIENCE-HIGH*))
 	?g <- (goal (id ?id) (meta-fact ~0) (meta-template ?t&~nil))
 	(test (> (length$ (find-all-facts ((?fact ?t)) (eq ?fact:goal-id ?id))) 1))
 	=>
@@ -318,7 +319,7 @@
 )
 
 (defrule goal-meta-template-invalid
-	(declare (salience ?*SALIENCE-HIGH*))
+	(declare (salience ?*SALIENCE-FIRST*))
 	?g <- (goal (id ?id) (meta-template ?t&:
 	            (and (neq ?t nil)
 	                 (not (member$ ?t (get-deftemplate-list)))))

--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -279,6 +279,30 @@
 	(modify ?g (meta-template (fact-relation ?f)))
 )
 
+(defrule goal-meta-fact-init-fact-id
+" The meta fact template is specified and a goal meta fact exists for the goal.
+  Update the goal meta fact-index.
+"
+	(declare (salience ?*SALIENCE-HIGH*))
+	?g <- (goal (id ?id) (meta-fact 0) (meta-template ?t&~nil))
+	(test (any-factp ((?f ?t)) (eq ?f:goal-id ?id)))
+	=>
+	(do-for-fact ((?f ?t)) (eq ?f:goal-id ?id)
+	  (modify ?g (meta-fact (fact-index ?f)))
+	)
+)
+
+(defrule goal-meta-fact-init-goal-id
+" The meta-fact is already set, but the goal id does not match, update the
+  goal-id of the goal meta fact.
+"
+	(declare (salience ?*SALIENCE-HIGH*))
+	?g <- (goal (id ?id) (meta-fact ?f&~0) (meta-template ?t&~nil))
+	(test (and (fact-existp ?f) (neq (fact-slot-value ?f goal-id) ?id)))
+	=>
+	(modify ?f (goal-id ?id))
+)
+
 (defrule goal-meta-fact-update
 " The stored meta fact does not exist anymore, it was updated or deleted.
   If another goal meta fact exists with matching goal id, then update the

--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -272,7 +272,7 @@
 (defrule goal-update-meta-template
 " A goal meta is set via fact-index. Update the template name accordingly."
 	(declare (salience ?*SALIENCE-HIGH*))
-	?g <- (goal (id ?id) (meta-fact ?f&:(and (> ?f 0) (?fact-existp ?f)))
+	?g <- (goal (id ?id) (meta-fact ?f&:(and (> ?f 0) (fact-existp ?f)))
 	            (meta-template ?t&:(neq ?t (fact-relation ?f))))
 	=>
 	(modify ?g (meta-template (fact-relation ?f)))
@@ -334,6 +334,7 @@
 	?g <- (goal (id ?id) (meta-fact 0) (verbosity ?v)
 	            (meta-template ?t&:(member$ ?t (get-deftemplate-list)))
 	            (mode ~RETRACTED))
+	(test (not (any-factp ((?fact ?t)) (eq ?fact:goal-id ?id))))
 	=>
 	(modify ?g (meta-fact (fact-index (assert-string (str-cat "(" ?t
 	        " (goal-id " ?id"))")))))

--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -309,12 +309,13 @@
 "
 	(declare (salience ?*SALIENCE-HIGH*))
 	?g <- (goal (id ?id) (meta-fact ?f&~0) (meta-template ?t&~nil))
+	(time $?) ; Re-evaluate the LHS continuously
 	(test (not (fact-existp ?f)))
 	=>
 	(if (not (do-for-fact ((?new-fact ?t)) (eq ?new-fact:goal-id ?id)
 	                      (modify ?g (meta-fact (fact-index ?new-fact)))))
 	 then
-		(modify ?g (meta-fact 0))
+		(modify ?g (meta-fact 0) (meta-template nil))
 	)
 )
 

--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -287,3 +287,27 @@
 	=>
 	(retract ?f)
 )
+
+(defrule goal-assert-default-meta
+	(declare (salience ?*SALIENCE-HIGH*))
+	?g <- (goal (id ?id) (meta-fact 0) (verbosity ?v)
+	            (meta-template ?t&:(member$ ?t (get-deftemplate-list)))
+	            (mode ~RETRACTED))
+	=>
+	(modify ?g (meta-fact (fact-index (assert-string (str-cat "(" ?t
+	        " (goal-id " ?id"))")))))
+	(if (eq ?v NOISY) then
+		(printout t "Goal " ?id " attached default meta fact from template " ?t crlf)
+	)
+)
+
+(defrule goal-meta-template-invalid
+	(declare (salience ?*SALIENCE-HIGH*))
+	?g <- (goal (id ?id) (meta-template ?t&:
+	            (and (neq ?t nil)
+	                 (not (member$ ?t (get-deftemplate-list)))))
+	            (mode ~RETRACTED))
+	=>
+	(printout error "Goal " ?id " attached goal meta template '"
+	                ?t "' unknown" crlf)
+)

--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -272,9 +272,8 @@
 (defrule goal-update-meta-template
 " A goal meta is set via fact-index. Update the template name accordingly."
 	(declare (salience ?*SALIENCE-HIGH*))
-	?g <- (goal (id ?id) (meta-fact ?f&:(> ?f 0))
+	?g <- (goal (id ?id) (meta-fact ?f&:(and (> ?f 0) (?fact-existp ?f)))
 	            (meta-template ?t&:(neq ?t (fact-relation ?f))))
-	(test (fact-existp ?f))
 	=>
 	(modify ?g (meta-template (fact-relation ?f)))
 )

--- a/src/plugins/clips-executive/clips/goal.clp
+++ b/src/plugins/clips-executive/clips/goal.clp
@@ -191,7 +191,7 @@
 
 	; Amount of information to print. If set to quiet, regular events such as a
 	; committed or dispatched goal will only be logged to the debug log.
-	(slot verbosity (type SYMBOL) (allowed-values QUIET DEFAULT) (default DEFAULT))
+	(slot verbosity (type SYMBOL) (allowed-values QUIET DEFAULT NOISY) (default DEFAULT))
 )
 
 (deffunction goal-retract-goal-tree (?id)


### PR DESCRIPTION
This PR extends goals through the option to register a custom templated fact as goal-meta, see the code comments for details:
https://github.com/fawkesrobotics/fawkes/blob/9605f045031d912637529e59ec5b0ac1fbcc9f23/src/plugins/clips-executive/clips/goal.clp#L171-L185
Also a slot `is-executable` is added which is useful for agents that formulate goals that are not to be executed right away. The slot is not used for the core features yet.
https://github.com/fawkesrobotics/fawkes/blob/9605f045031d912637529e59ec5b0ac1fbcc9f23/src/plugins/clips-executive/clips/goal.clp#L211-L214
Also the slot `verbosity` is extended by a value `NOISY`
