### PR TITLE
Fix UUID handling in skillgui and avoid direct UUID comparisons

### DIFF
--- a/src/libs/blackboard/net/handler.cpp
+++ b/src/libs/blackboard/net/handler.cpp
@@ -289,10 +289,6 @@ BlackBoardNetworkHandler::loop()
 			bb_imessage_msg_t *mm        = (bb_imessage_msg_t *)payload;
 			Uuid               mm_serial = mm->serial;
 			Uuid               mm_source = mm->source;
-			LibLogger::log_debug("BlackBoardNetworkHandler",
-			                     "Received message from sender %s, source %s",
-			                     mm_serial.get_string().c_str(),
-			                     mm_source.get_string().c_str());
 			if (interfaces_.find(mm_serial) != interfaces_.end()) {
 				if (!interfaces_[mm_serial]->is_writer()) {
 					try {

--- a/src/libs/blackboard/net/interface_listener.cpp
+++ b/src/libs/blackboard/net/interface_listener.cpp
@@ -129,10 +129,6 @@ BlackBoardNetHandlerInterfaceListener::bb_interface_message_received(Interface *
 	bb_imessage_msg_t *dm           = (bb_imessage_msg_t *)payload;
 	dm->serial                      = interface->serial();
 	dm->source                      = message->source_id();
-	LibLogger::log_debug(bbil_name(),
-	                     "Received message from sender %s, source %s",
-	                     dm->serial.get_string().c_str(),
-	                     dm->source.get_string().c_str());
 	strncpy(dm->msg_type, message->type(), INTERFACE_MESSAGE_TYPE_SIZE_ - 1);
 	dm->data_size = htonl(message->datasize());
 	dm->msgid     = htonl(message->id());

--- a/src/libs/blackboard/net/interface_proxy.cpp
+++ b/src/libs/blackboard/net/interface_proxy.cpp
@@ -95,10 +95,6 @@ BlackBoardInterfaceProxy::BlackBoardInterfaceProxy(FawkesNetworkClient * client,
 	ih->num_readers        = num_readers_;
 	ih->refcount           = 1;
 
-	LibLogger::log_debug("BlackBoardInterfaceProxy",
-	                     "Old serial: %s, new serial: %s",
-	                     interface->serial().get_string().c_str(),
-	                     instance_serial_.get_string().c_str());
 	interface->set_instance_serial(instance_serial_);
 	interface->set_memory(0, mem_chunk_, data_chunk_);
 	interface->set_mediators(this, this);
@@ -349,12 +345,9 @@ BlackBoardInterfaceProxy::transmit(Message *message)
 	bb_imessage_msg_t *dm           = (bb_imessage_msg_t *)payload;
 	dm->serial                      = interface_->serial();
 	dm->source                      = message->source_id();
-	LibLogger::log_debug("BlackBoardInterfaceProxy",
-	                     "Transmitting from sender %s",
-	                     dm->serial.get_string().c_str());
-	unsigned int msgid = next_msg_id();
-	dm->msgid          = htonl(msgid);
-	dm->hops           = htonl(message->hops());
+	unsigned int msgid              = next_msg_id();
+	dm->msgid                       = htonl(msgid);
+	dm->hops                        = htonl(message->hops());
 	message->set_id(msgid);
 	strncpy(dm->msg_type, message->type(), INTERFACE_MESSAGE_TYPE_SIZE_ - 1);
 	dm->data_size = htonl(message->datasize());

--- a/src/libs/utils/uuid.h
+++ b/src/libs/utils/uuid.h
@@ -32,7 +32,7 @@ public:
 	~Uuid() noexcept;
 	Uuid(const Uuid &other) noexcept;
 	Uuid(Uuid &&other) noexcept;
-	Uuid(const char *string);
+	explicit Uuid(const char *string);
 	Uuid &      operator=(const Uuid &other) noexcept;
 	Uuid &      operator=(Uuid &&other) noexcept;
 	std::string get_string() const;

--- a/src/lua/skiller/fawkes/init.lua
+++ b/src/lua/skiller/fawkes/init.lua
@@ -89,7 +89,6 @@ function process_skiller_messages()
 	 
 	 while not skiller_if:msgq_empty() do
 			local m = skiller_if:msgq_first()
-      print_info("Received message, sender: %s, source: %s", m:sender_id():get_string(), m:source_id():get_string())
 			local mtype = m:type()
 			if mtype == "AcquireControlMessage" then
 				 if skiller_if:exclusive_controller() == "" then

--- a/src/lua/skiller/fawkes/init.lua
+++ b/src/lua/skiller/fawkes/init.lua
@@ -49,7 +49,7 @@ local loop_has_run = false
 function notify_reader_removed(instance_serial)
 	 if instance_serial == skiller_if:exclusive_controller() then
 			print_info("Controlling interface instance was closed, revoking exclusive control")
-			skiller_if:set_exclusive_controller(0)
+			skiller_if:set_exclusive_controller("")
 			skiller_if:write()
 	 end
 end
@@ -92,7 +92,7 @@ function process_skiller_messages()
       print_info("Received message, sender: %s, source: %s", m:sender_id():get_string(), m:source_id():get_string())
 			local mtype = m:type()
 			if mtype == "AcquireControlMessage" then
-				 if skiller_if:exclusive_controller() == 0 then
+				 if skiller_if:exclusive_controller() == "" then
 						print_debug("%s (serial %s) is new exclusive controller", m:sender_thread_name(), m:source_id():get_string())
 						skiller_if:set_exclusive_controller(m:source_id():get_string())
 						write_skiller_if = true
@@ -112,20 +112,20 @@ function process_skiller_messages()
 
 						-- __continuous_reset = true
 						-- __last_exclusive_controller = __skiller_if->exclusive_controller()
-						skiller_if:set_exclusive_controller(0)
+						skiller_if:set_exclusive_controller("")
 						write_skiller_if = true
-				 elseif skiller_if:exclusive_controller() ~= 0 then
+				 elseif skiller_if:exclusive_controller() ~= "" then
 						print_warn("%s tried to release exclusive control, but it's not the controller",
 											 m:sender_thread_name())						
 				 end
 
 			elseif mtype == "ExecSkillMessage" then
-				 if skiller_if:exclusive_controller() == 0 or skiller_if:exclusive_controller() == m:source_id():get_string() then
+				 if skiller_if:exclusive_controller() == "" or skiller_if:exclusive_controller() == m:source_id():get_string() then
 						if skill_enqueued then
 							 print_warn("More than one skill string enqueued, ignoring previous string (%s).",
                                                                     skiller_if:skill_string())
 						end
-						if skiller_if:exclusive_controller() == 0 then
+						if skiller_if:exclusive_controller() == "" then
 							 if m:sender_thread_name() == "Unknown" then
 									print_debug("Remote executes '%s' without any exclusive controller",
 															m:skill_string())

--- a/src/plugins/clips-agent/clips_agent_thread.cpp
+++ b/src/plugins/clips-agent/clips_agent_thread.cpp
@@ -179,7 +179,7 @@ ClipsAgentThread::loop()
 	if (!cfg_skill_sim_) {
 		skiller_if_->read();
 
-		if ((skiller_if_->exclusive_controller() != skiller_if_->serial())
+		if ((skiller_if_->exclusive_controller() != skiller_if_->serial().get_string())
 		    && skiller_if_->has_writer()) {
 			if (ctrl_recheck_) {
 				logger->log_info(name(), "Acquiring exclusive skiller control");

--- a/src/plugins/ros/skiller_thread.cpp
+++ b/src/plugins/ros/skiller_thread.cpp
@@ -87,7 +87,7 @@ RosSkillerThread::once()
 void
 RosSkillerThread::stop()
 {
-	if (skiller_if_->exclusive_controller() != skiller_if_->serial()) {
+	if (skiller_if_->exclusive_controller() != skiller_if_->serial().get_string()) {
 		logger->log_warn(name(), "Skill abortion requested, but currently not in control");
 		return;
 	}
@@ -158,7 +158,7 @@ RosSkillerThread::loop()
 
 	// currently idle, release skiller control
 	if (!exec_running_ && !exec_request_
-	    && skiller_if_->exclusive_controller() == skiller_if_->serial()) {
+	    && skiller_if_->exclusive_controller() == skiller_if_->serial().get_string()) {
 		logger->log_debug(name(), "No skill running and no skill requested, releasing control");
 		skiller_if_->msgq_enqueue(new SkillerInterface::ReleaseControlMessage());
 		return;
@@ -171,7 +171,7 @@ RosSkillerThread::loop()
 			return;
 		}
 
-		if (skiller_if_->exclusive_controller() != skiller_if_->serial()) {
+		if (skiller_if_->exclusive_controller() != skiller_if_->serial().get_string()) {
 			// we need the skiller control, acquire it first
 			logger->log_debug(name(), "Skill execution requested, but currently not in control");
 			skiller_if_->msgq_enqueue(new SkillerInterface::AcquireControlMessage());

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -54,7 +54,7 @@ SkillerSimulatorExecutionThread::loop()
 		if (skiller_if_->msgq_first_is<SkillerInterface::AcquireControlMessage>()) {
 			SkillerInterface::AcquireControlMessage *m =
 			  skiller_if_->msgq_first<SkillerInterface::AcquireControlMessage>();
-			if (skiller_if_->exclusive_controller() == 0) {
+			if (strcmp(skiller_if_->exclusive_controller(), "") == 0) {
 				const std::string new_controller = m->source_id().get_string();
 				logger->log_debug(name(),
 				                  "%s is new exclusive controller (ID %s)",
@@ -81,9 +81,9 @@ SkillerSimulatorExecutionThread::loop()
 		} else if (skiller_if_->msgq_first_is<SkillerInterface::ReleaseControlMessage>()) {
 			SkillerInterface::ReleaseControlMessage *m =
 			  skiller_if_->msgq_first<SkillerInterface::ReleaseControlMessage>();
-			if (skiller_if_->exclusive_controller() == m->source_id()) {
+			if (skiller_if_->exclusive_controller() == m->source_id().get_string()) {
 				logger->log_debug(name(), "%s releases exclusive control", m->sender_thread_name());
-			} else if (skiller_if_->exclusive_controller() != 0) {
+			} else if (strcmp(skiller_if_->exclusive_controller(), "") != 0) {
 				logger->log_warn(name(),
 				                 "%s tried to release exclusive control, but it's not the controller",
 				                 m->sender_thread_name());
@@ -91,14 +91,14 @@ SkillerSimulatorExecutionThread::loop()
 		} else if (skiller_if_->msgq_first_is<SkillerInterface::ExecSkillMessage>()) {
 			SkillerInterface::ExecSkillMessage *m =
 			  skiller_if_->msgq_first<SkillerInterface::ExecSkillMessage>();
-			if (skiller_if_->exclusive_controller() == 0
-			    || skiller_if_->exclusive_controller() == m->source_id()) {
+			if (strcmp(skiller_if_->exclusive_controller(), "") == 0
+			    || skiller_if_->exclusive_controller() == m->source_id().get_string()) {
 				if (skill_enqueued) {
 					logger->log_warn(name(),
 					                 "More than one skill string enqueued, ignoring previous string (%s).",
 					                 skiller_if_->skill_string());
 				}
-				if (skiller_if_->exclusive_controller() == 0) {
+				if (strcmp(skiller_if_->exclusive_controller(), "") == 0) {
 					std::string sender = m->sender_thread_name();
 					if (sender == "Unknown") {
 						sender = "Remote";
@@ -131,7 +131,7 @@ SkillerSimulatorExecutionThread::loop()
 		} else if (skiller_if_->msgq_first_is<SkillerInterface::StopExecMessage>()) {
 			SkillerInterface::StopExecMessage *m =
 			  skiller_if_->msgq_first<SkillerInterface::StopExecMessage>();
-			if (skiller_if_->exclusive_controller() == m->source_id()) {
+			if (skiller_if_->exclusive_controller() == m->source_id().get_string()) {
 				logger->log_debug(name(),
 				                  "Stopping execution of '%s' on request",
 				                  skiller_if_->skill_string());

--- a/src/tools/skillgui/skillgui.cpp
+++ b/src/tools/skillgui/skillgui.cpp
@@ -288,12 +288,12 @@ void
 SkillGuiGtkWindow::on_controller_clicked()
 {
 	if (skiller_if_ && skiller_if_->is_valid() && skiller_if_->has_writer()
-	    && skiller_if_->exclusive_controller() == skiller_if_->serial()) {
+	    && skiller_if_->exclusive_controller() == skiller_if_->serial().get_string()) {
 		// we are exclusive controller, release control
 		SkillerInterface::ReleaseControlMessage *rcm = new SkillerInterface::ReleaseControlMessage();
 		skiller_if_->msgq_enqueue(rcm);
 	} else if (skiller_if_ && skiller_if_->is_valid() && skiller_if_->has_writer()
-	           && skiller_if_->exclusive_controller() == 0) {
+	           && strcmp(skiller_if_->exclusive_controller(), "") == 0) {
 		// there is no exclusive controller, try to acquire control
 		SkillerInterface::AcquireControlMessage *acm = new SkillerInterface::AcquireControlMessage();
 		skiller_if_->msgq_enqueue(acm);
@@ -330,7 +330,7 @@ SkillGuiGtkWindow::close_bb()
 		delete skdbg_ifd_;
 		delete agdbg_ifd_;
 		if (skiller_if_ && skiller_if_->is_valid() && skiller_if_->has_writer()
-		    && (skiller_if_->exclusive_controller() == skiller_if_->serial())) {
+		    && skiller_if_->exclusive_controller() == skiller_if_->serial().get_string()) {
 			SkillerInterface::ReleaseControlMessage *rcm = new SkillerInterface::ReleaseControlMessage();
 			skiller_if_->msgq_enqueue(rcm);
 		}
@@ -375,7 +375,7 @@ SkillGuiGtkWindow::on_connect()
 			// always try to acquire control on connect, this may well fail, for
 			// example if agent is running, but we don't care
 			skiller_if_->read();
-			if (skiller_if_->has_writer() && skiller_if_->exclusive_controller() == 0) {
+			if (skiller_if_->has_writer() && strcmp(skiller_if_->exclusive_controller(), "") == 0) {
 				SkillerInterface::AcquireControlMessage *aqm =
 				  new SkillerInterface::AcquireControlMessage();
 				skiller_if_->msgq_enqueue(aqm);
@@ -452,7 +452,7 @@ SkillGuiGtkWindow::on_exec_clicked()
 #endif
 
 		if (skiller_if_ && skiller_if_->is_valid() && skiller_if_->has_writer()
-		    && skiller_if_->exclusive_controller() == skiller_if_->serial()) {
+		    && skiller_if_->exclusive_controller() == skiller_if_->serial().get_string()) {
 			SkillerInterface::ExecSkillMessage *esm = new SkillerInterface::ExecSkillMessage(sks.c_str());
 			skiller_if_->msgq_enqueue(esm);
 
@@ -543,7 +543,7 @@ SkillGuiGtkWindow::on_skiller_data_changed()
 #endif
 		lab_alive->set_text(skiller_if_->has_writer() ? "Yes" : "No");
 
-		if (skiller_if_->exclusive_controller() == skiller_if_->serial()) {
+		if (skiller_if_->exclusive_controller() == skiller_if_->serial().get_string()) {
 			if (tb_controller->get_stock_id() == Gtk::Stock::NO.id) {
 				tb_controller->set_stock_id(Gtk::Stock::YES);
 #if GTKMM_MAJOR_VERSION > 2 || (GTKMM_MAJOR_VERSION == 2 && GTKMM_MINOR_VERSION >= 12)


### PR DESCRIPTION
When comparing the exclusive controller of the skiller with an interface, always explicitly compare strings. In particular:
* Remove any comparisons to ints, which was just broken
* Do not do an implicit conversion to UUID, as this may fail if the UUID is empty

Fixes #284 