### PR TITLE
Add optional transformation of laserlines

### DIFF
--- a/cfg/conf.d/laser-lines.yaml
+++ b/cfg/conf.d/laser-lines.yaml
@@ -57,3 +57,7 @@ laser-lines:
   moving_avg_enabled: true
   # The size (number of elements) of the moving average window
   moving_avg_window_size: 10
+
+  # Create additional LaserLineInterfaces transformed to a custom frame.
+  transform_to_frame_enabled: false
+  transform_to_frame_id: "map"

--- a/src/plugins/laser-lines/laser-lines-thread.cpp
+++ b/src/plugins/laser-lines/laser-lines-thread.cpp
@@ -86,6 +86,9 @@ LaserLinesThread::init()
 		if (cfg_moving_avg_enabled_) {
 			line_avg_ifs_.resize(cfg_max_num_lines_, NULL);
 		}
+		if (cfg_transform_to_frame_enabled_) {
+			line_transformed_ifs_.resize(cfg_max_num_lines_, NULL);
+		}
 		//2.2:open interfaces for writing
 		for (unsigned int i = 0; i < cfg_max_num_lines_; ++i) {
 			//2.2.1:create id name /laser-lines/(i+1)
@@ -100,6 +103,10 @@ LaserLinesThread::init()
 				if (cfg_moving_avg_enabled_) {
 					line_avg_ifs_[i] =
 					  blackboard->open_for_writing<LaserLineInterface>((id + "/moving_avg").c_str());
+				}
+				if (cfg_transform_to_frame_enabled_) {
+					line_transformed_ifs_[i] =
+					  blackboard->open_for_writing<LaserLineInterface>((id + "/to_" + cfg_transform_to_frame_id_).c_str());
 				}
 			}
 		}
@@ -121,6 +128,9 @@ LaserLinesThread::init()
 			blackboard->close(line_ifs_[i]);
 			if (cfg_moving_avg_enabled_) {
 				blackboard->close(line_avg_ifs_[i]);
+			}
+			if (cfg_transform_to_frame_enabled_) {
+				blackboard->close(line_transformed_ifs_[i]);
 			}
 		}
 		blackboard->close(switch_if_);
@@ -167,6 +177,9 @@ LaserLinesThread::finalize()
 		blackboard->close(line_ifs_[i]);
 		if (cfg_moving_avg_enabled_) {
 			blackboard->close(line_avg_ifs_[i]);
+		}
+		if (cfg_transform_to_frame_enabled_) {
+			blackboard->close(line_transformed_ifs_[i]);
 		}
 	}
 	blackboard->close(switch_if_);
@@ -250,16 +263,18 @@ LaserLinesThread::read_config()
 	cfg_segm_max_iterations_ = config->get_uint(CFG_PREFIX "line_segmentation_max_iterations");
 	cfg_segm_distance_threshold_ =
 	  config->get_float(CFG_PREFIX "line_segmentation_distance_threshold");
-	cfg_segm_sample_max_dist_   = config->get_float(CFG_PREFIX "line_segmentation_sample_max_dist");
-	cfg_segm_min_inliers_       = config->get_uint(CFG_PREFIX "line_segmentation_min_inliers");
-	cfg_min_length_             = config->get_float(CFG_PREFIX "line_min_length");
-	cfg_max_length_             = config->get_float(CFG_PREFIX "line_max_length");
-	cfg_min_dist_               = config->get_float(CFG_PREFIX "line_min_distance");
-	cfg_max_dist_               = config->get_float(CFG_PREFIX "line_max_distance");
-	cfg_cluster_tolerance_      = config->get_float(CFG_PREFIX "line_cluster_tolerance");
-	cfg_cluster_quota_          = config->get_float(CFG_PREFIX "line_cluster_quota");
-	cfg_moving_avg_enabled_     = config->get_bool(CFG_PREFIX "moving_avg_enabled");
-	cfg_moving_avg_window_size_ = config->get_uint(CFG_PREFIX "moving_avg_window_size");
+	cfg_segm_sample_max_dist_       = config->get_float(CFG_PREFIX "line_segmentation_sample_max_dist");
+	cfg_segm_min_inliers_           = config->get_uint(CFG_PREFIX "line_segmentation_min_inliers");
+	cfg_min_length_                 = config->get_float(CFG_PREFIX "line_min_length");
+	cfg_max_length_                 = config->get_float(CFG_PREFIX "line_max_length");
+	cfg_min_dist_                   = config->get_float(CFG_PREFIX "line_min_distance");
+	cfg_max_dist_                   = config->get_float(CFG_PREFIX "line_max_distance");
+	cfg_cluster_tolerance_          = config->get_float(CFG_PREFIX "line_cluster_tolerance");
+	cfg_cluster_quota_              = config->get_float(CFG_PREFIX "line_cluster_quota");
+	cfg_moving_avg_enabled_         = config->get_bool(CFG_PREFIX "moving_avg_enabled");
+	cfg_moving_avg_window_size_     = config->get_uint(CFG_PREFIX "moving_avg_window_size");
+	cfg_transform_to_frame_enabled_ = config->get_bool(CFG_PREFIX "transform_to_frame_enabled");
+	cfg_transform_to_frame_id_      = config->get_string(CFG_PREFIX "transform_to_frame_id");
 
 	cfg_switch_tolerance_ = config->get_float(CFG_PREFIX "switch_tolerance");
 
@@ -310,11 +325,14 @@ LaserLinesThread::update_lines(std::vector<LineInfo> &linfos)
 		TrackedLineInfo tl(tf_listener,
 		                   finput_->header.frame_id,
 		                   cfg_tracking_frame_id_,
+		                   cfg_transform_to_frame_id_,
+		                   cfg_transform_to_frame_enabled_,
 		                   cfg_switch_tolerance_,
 		                   cfg_moving_avg_enabled_ ? cfg_moving_avg_window_size_ : 0,
 		                   logger,
 		                   name());
 		tl.update(l);
+
 		known_lines_.push_back(tl);
 	}
 
@@ -387,13 +405,20 @@ LaserLinesThread::publish_known_lines()
 			if (cfg_moving_avg_enabled_) {
 				set_empty_interface(line_avg_ifs_[line_if_idx]);
 			}
+			if (cfg_transform_to_frame_enabled_) {
+				set_empty_interface(line_transformed_ifs_[line_if_idx]);
+			}
 		} else {
 			known_lines_[known_line_idx].interface_idx = line_if_idx;
 			const TrackedLineInfo &info                = known_lines_[known_line_idx];
-			set_interface(line_if_idx, line_ifs_[line_if_idx], false, info, finput_->header.frame_id);
+			set_interface(line_if_idx, line_ifs_[line_if_idx], false, false, info, finput_->header.frame_id);
 			if (cfg_moving_avg_enabled_) {
 				set_interface(
-				  line_if_idx, line_avg_ifs_[line_if_idx], true, info, finput_->header.frame_id);
+				  line_if_idx, line_avg_ifs_[line_if_idx], true, false, info, finput_->header.frame_id);
+			}
+			if (cfg_transform_to_frame_enabled_) {
+				set_interface(
+				  line_if_idx, line_transformed_ifs_[line_if_idx], false, true, info, cfg_transform_to_frame_id_.c_str());
 			}
 		}
 	}
@@ -424,10 +449,11 @@ void
 LaserLinesThread::set_interface(unsigned int                idx,
                                 fawkes::LaserLineInterface *iface,
                                 bool                        moving_average,
+                                bool                        to_frame,
                                 const TrackedLineInfo &     tinfo,
                                 const std::string &         frame_id)
 {
-	const LineInfo &info = moving_average ? tinfo.smooth : tinfo.raw;
+  const LineInfo &info = moving_average ? tinfo.smooth : to_frame ? tinfo.transformed : tinfo.raw;
 
 	iface->set_visibility_history(tinfo.visibility_history);
 
@@ -452,11 +478,12 @@ LaserLinesThread::set_interface(unsigned int                idx,
 	std::string  frame_name_1, frame_name_2;
 	char *       tmp;
 	std::string  avg = moving_average ? "avg_" : "";
-	if (asprintf(&tmp, "laser_line_%s%u_e1", avg.c_str(), idx + 1) != -1) {
+	std::string  transformed = to_frame ? "transformed_" : "";
+	if (asprintf(&tmp, "laser_line_%s%s%u_e1", avg.c_str(), transformed.c_str(), idx + 1) != -1) {
 		frame_name_1 = tmp;
 		free(tmp);
 	}
-	if (asprintf(&tmp, "laser_line_%s%u_e2", avg.c_str(), idx + 1) != -1) {
+	if (asprintf(&tmp, "laser_line_%s%s%u_e2", avg.c_str(), transformed.c_str(), idx + 1) != -1) {
 		frame_name_2 = tmp;
 		free(tmp);
 	}

--- a/src/plugins/laser-lines/laser-lines-thread.h
+++ b/src/plugins/laser-lines/laser-lines-thread.h
@@ -126,6 +126,7 @@ private:
 	void set_interface(unsigned int                idx,
 	                   fawkes::LaserLineInterface *iface,
 	                   bool                        moving_average,
+	                   bool                        transformed,
 	                   const TrackedLineInfo &     tinfo,
 	                   const std::string &         frame_id = "");
 
@@ -152,6 +153,7 @@ private:
 
 	std::vector<fawkes::LaserLineInterface *> line_ifs_;
 	std::vector<fawkes::LaserLineInterface *> line_avg_ifs_;
+	std::vector<fawkes::LaserLineInterface *> line_transformed_ifs_;
 	std::vector<TrackedLineInfo>              known_lines_;
 
 	fawkes::SwitchInterface *switch_if_;
@@ -173,6 +175,8 @@ private:
 	float        cfg_max_dist_;
 	bool         cfg_moving_avg_enabled_;
 	unsigned int cfg_moving_avg_window_size_;
+	bool         cfg_transform_to_frame_enabled_;
+  std::string  cfg_transform_to_frame_id_;
 	std::string  cfg_tracking_frame_id_;
 
 	unsigned int loop_count_;

--- a/src/plugins/laser-lines/line_info.cpp
+++ b/src/plugins/laser-lines/line_info.cpp
@@ -40,6 +40,8 @@ using namespace std;
 TrackedLineInfo::TrackedLineInfo(fawkes::tf::Transformer *tfer,
                                  const string &           input_frame_id,
                                  const string &           tracking_frame_id,
+                                 const string &           fixed_frame_id,
+                                 bool                     transform_to_fixed_frame,
                                  float                    cfg_switch_tolerance,
                                  unsigned int             cfg_moving_avg_len,
                                  fawkes::Logger *         logger,
@@ -48,6 +50,8 @@ TrackedLineInfo::TrackedLineInfo(fawkes::tf::Transformer *tfer,
   visibility_history(0),
   transformer(tfer),
   input_frame_id(input_frame_id),
+  fixed_frame_id(fixed_frame_id),
+  transform_to_fixed_frame(transform_to_fixed_frame),
   tracking_frame_id(tracking_frame_id),
   cfg_switch_tolerance(cfg_switch_tolerance),
   history(cfg_moving_avg_len),
@@ -146,6 +150,15 @@ TrackedLineInfo::update(LineInfo &linfo)
 	this->smooth.line_direction = line_direction_sum / sz;
 	this->smooth.point_on_line  = point_on_line_sum / sz;
 
+
+  if (transform_to_fixed_frame == true)
+  {
+    transform_point_to_frame(linfo.base_point, this->transformed.base_point, input_frame_id, fixed_frame_id);
+    transform_point_to_frame(linfo.line_direction, this->transformed.line_direction, input_frame_id, fixed_frame_id);
+    transform_point_to_frame(linfo.end_point_1, this->transformed.end_point_1, input_frame_id, fixed_frame_id);
+    transform_point_to_frame(linfo.end_point_2, this->transformed.end_point_2, input_frame_id, fixed_frame_id);
+  }
+
 	Eigen::Vector3f x_axis(1, 0, 0);
 
 	Eigen::Vector3f ld_unit    = this->smooth.line_direction / this->smooth.line_direction.norm();
@@ -162,3 +175,34 @@ TrackedLineInfo::update(LineInfo &linfo)
 	if (l_ctr[1] < 0)
 		this->bearing_center = std::abs(this->bearing_center) * -1.;
 }
+
+/** Transform a point with an origin in a particular frame to another frame
+ * @param point the point to be transformed
+ * @param from_frame frame_id of the point's origin
+ * @param to_frame frame_id of the target coordinate system
+ */
+bool
+TrackedLineInfo::transform_point_to_frame(const Eigen::Vector3f& in_point, Eigen::Vector3f& out_point, const std::string from_frame, const std::string to_frame)
+{
+	fawkes::tf::Stamped<fawkes::tf::Point> transformed_point(fawkes::tf::Point(in_point[0],
+	                                                                           in_point[1],
+	                                                                           in_point[2]),
+	                                                         fawkes::Time(0, 0),
+	                                                         from_frame);
+
+	try {
+		transformer->transform_point(fixed_frame_id, transformed_point, transformed_point);
+
+    out_point[0] = transformed_point[0];
+    out_point[1] = transformed_point[1];
+    out_point[2] = transformed_point[2];
+
+	} catch (fawkes::tf::TransformException &e) {
+		logger->log_warn(plugin_name.c_str(),
+		                 "Can't transform to %s.",
+		                 fixed_frame_id.c_str());
+    return false;
+	}
+  return true;
+}
+

--- a/src/plugins/laser-lines/line_info.h
+++ b/src/plugins/laser-lines/line_info.h
@@ -63,11 +63,16 @@ public:
 	int visibility_history; ///< visibility history of this line, negative for "no sighting"
 	LineInfo raw;           ///< the latest geometry of this line, i.e. unfiltered
 	LineInfo smooth;        ///< moving-average geometry of this line (cf. length of history buffer)
+	LineInfo transformed;   ///< the latest geometry of this line, i.e. unfiltered - in fixed frame (i.e. map)
 	fawkes::tf::Stamped<fawkes::tf::Point>
 	  base_point_odom; ///< last reference point (in odom frame) for line tracking
+	fawkes::tf::Stamped<fawkes::tf::Point>
+	  base_point_fixed; ///< last reference point (in odom frame) for line tracking
 	fawkes::tf::Transformer
 	  *         transformer;    ///< Transformer used to transform from input_frame_id_to odom
 	std::string input_frame_id; ///< Input frame ID of raw line infos (base_laser usually)
+	std::string fixed_frame_id; ///< Input frame ID of raw line infos (base_laser usually)
+  bool transform_to_fixed_frame; ///< Whether to transform the line to the fixed_frame
 	std::string
 	  tracking_frame_id; ///< Track lines relative to this frame (e.g. odom helps compensate movement)
 	float cfg_switch_tolerance; ///< Configured line jitter threshold
@@ -81,6 +86,8 @@ public:
 	TrackedLineInfo(fawkes::tf::Transformer *tfer,
 	                const std::string &      input_frame_id,
 	                const std::string &      tracking_frame_id,
+	                const std::string &      fixed_frame_id,
+	                bool                     transform_to_fixed_frame,
 	                float                    cfg_switch_tolerance,
 	                unsigned int             cfg_moving_avg_len,
 	                fawkes::Logger *         logger,
@@ -89,6 +96,10 @@ public:
 	btScalar distance(const LineInfo &linfo) const;
 	void     update(LineInfo &new_linfo);
 	void     not_visible_update();
+	bool     transform_point_to_frame(const Eigen::Vector3f& in_point,
+                                    Eigen::Vector3f& out_point,
+                                    const std::string from_frame,
+                                    const std::string to_frame);
 };
 
 #endif


### PR DESCRIPTION
In case a plugin wishes to transform a laser-line which accesses the `LaserLineInterface`s that are synchronized via `bbsync` it has to synchronize the complete necessary transform tree as well.
This change addresses this by optionally adding another set of laser-lines that are already transformed to the desired frame.

--------------
Note that this is a refactored version of what was used at RoboCup 2021 so it's necessary to test this before merging.