### PR TITLE
Fix finding of shared memory buffers

### DIFF
--- a/src/libs/utils/ipc/shm_registry.h
+++ b/src/libs/utils/ipc/shm_registry.h
@@ -27,7 +27,7 @@
 #include <list>
 #include <semaphore.h>
 
-#define MAGIC_TOKEN_SIZE 16
+#define MAGIC_TOKEN_SIZE 32
 #define MAXNUM_SHM_SEGMS 64
 #define DEFAULT_SHM_NAME "/fawkes-shmem-registry"
 #define USER_SHM_NAME "/fawkes-shmem-registry-%s"


### PR DESCRIPTION
Tools like `fvshmem` and the `webview` plugin were unable to receive lists of actual SharedMemoryImageBuffers.
The `MAGIC_TOKEN_SIZE` defines the length of the character array `FIREVISION_SHM_IMAGE_MAGIC_TOKEN` which in turn is used to locate the respective shared memory buffers. However the length of 16 renders the actual string `FireVision Image` to be cropped by its null termination.

I have set a value of 32 to allow further extension of the name or adding other shared memory buffers.