### PR TITLE
buildsys: fix erroneous override of format targets in submodule topdir

### DIFF
--- a/etc/buildsys/rules.mk
+++ b/etc/buildsys/rules.mk
@@ -327,7 +327,7 @@ $(LIBDIR)/%.so: $$(OBJS_$$(call nametr,$$*))
 include $(BUILDSYSDIR)/stats.mk
 
 ### Include formatting targets
-ifneq ($(subst $(abspath $(TOP_BASEDIR)),,$(PWD)),)
+ifneq ($(subst $(abspath $(BASEDIR)),,$(PWD)),)
   include $(BUILDSYSDIR)/format.mk
 endif
 


### PR DESCRIPTION
If we are in the submodule's topdir, we should use the format target for
the root directory, not the sub-directory format target. This should be
done not only in TOP_BASEDIR (e.g.,  fawkes-robotino), but also if we
are in the submodule BASEDIR (i.e., fawkes-robotino/fawkes).