### PR TITLE
Make custom query work on LGTM again

### DIFF
--- a/.lgtm/cpp-queries/resource-not-released.ql
+++ b/.lgtm/cpp-queries/resource-not-released.ql
@@ -18,7 +18,165 @@
  *       external/cwe/cwe-404
  */
 import cpp
-import Critical.NewDelete
+
+/**
+ * Provides predicates for associating new/malloc calls with delete/free.
+ *
+ * This is a local copy of Critical/NewDelete.qll.
+ */
+module NewDelete_copy {
+  import semmle.code.cpp.controlflow.SSA
+  import semmle.code.cpp.dataflow.DataFlow
+
+  /**
+   * Holds if `alloc` is a use of `malloc` or `new`.  `kind` is
+   * a string describing the type of the allocation.
+   */
+  predicate allocExpr(Expr alloc, string kind) {
+    (
+      exists(Function target |
+        alloc.(AllocationExpr).(FunctionCall).getTarget() = target and
+        (
+          target.getName() = "operator new" and
+          kind = "new" and
+          // exclude placement new and custom overloads as they
+          // may not conform to assumptions
+          not target.getNumberOfParameters() > 1
+          or
+          target.getName() = "operator new[]" and
+          kind = "new[]" and
+          // exclude placement new and custom overloads as they
+          // may not conform to assumptions
+          not target.getNumberOfParameters() > 1
+          or
+          not target instanceof OperatorNewAllocationFunction and
+          kind = "malloc"
+        )
+      )
+      or
+      alloc instanceof NewExpr and
+      kind = "new" and
+      // exclude placement new and custom overloads as they
+      // may not conform to assumptions
+      not alloc.(NewExpr).getAllocatorCall().getTarget().getNumberOfParameters() > 1
+      or
+      alloc instanceof NewArrayExpr and
+      kind = "new[]" and
+      // exclude placement new and custom overloads as they
+      // may not conform to assumptions
+      not alloc.(NewArrayExpr).getAllocatorCall().getTarget().getNumberOfParameters() > 1
+    ) and
+    not alloc.isFromUninstantiatedTemplate(_)
+  }
+
+  /**
+   * Holds if `alloc` is a use of `malloc` or `new`, or a function
+   * wrapping one of those.  `kind` is a string describing the type
+   * of the allocation.
+   */
+  predicate allocExprOrIndirect(Expr alloc, string kind) {
+    // direct alloc
+    allocExpr(alloc, kind)
+    or
+    exists(ReturnStmt rtn |
+      // indirect alloc via function call
+      alloc.(FunctionCall).getTarget() = rtn.getEnclosingFunction() and
+      (
+        allocExprOrIndirect(rtn.getExpr(), kind)
+        or
+        exists(Expr e |
+          allocExprOrIndirect(e, kind) and
+          DataFlow::localExprFlow(e, rtn.getExpr())
+        )
+      )
+    )
+  }
+
+  /**
+   * Holds if `v` is a non-local variable which is assigned with allocations of
+   * type `kind`.
+   */
+  pragma[nomagic]
+  private predicate allocReachesVariable(Variable v, Expr alloc, string kind) {
+    exists(Expr mid |
+      not v instanceof StackVariable and
+      v.getAnAssignedValue() = mid and
+      allocReaches0(mid, alloc, kind)
+    )
+  }
+
+  /**
+   * Holds if `e` is an expression which may evaluate to the
+   * result of a previous memory allocation `alloc`.  `kind` is a
+   * string describing the type of that allocation.
+   */
+  private predicate allocReaches0(Expr e, Expr alloc, string kind) {
+    // alloc
+    allocExprOrIndirect(alloc, kind) and
+    e = alloc
+    or
+    exists(SsaDefinition def, StackVariable v |
+      // alloc via SSA
+      allocReaches0(def.getAnUltimateDefiningValue(v), alloc, kind) and
+      e = def.getAUse(v)
+    )
+    or
+    exists(Variable v |
+      // alloc via a global
+      allocReachesVariable(v, alloc, kind) and
+      strictcount(VariableAccess va | va.getTarget() = v) <= 50 and // avoid very expensive cases
+      e.(VariableAccess).getTarget() = v
+    )
+  }
+
+  /**
+   * Holds if `free` is a use of free or delete.  `freed` is the
+   * expression that is freed / deleted and `kind` is a string
+   * describing the type of that free or delete.
+   */
+  predicate freeExpr(Expr free, Expr freed, string kind) {
+    exists(Function target |
+      freed = free.(DeallocationExpr).getFreedExpr() and
+      free.(FunctionCall).getTarget() = target and
+      (
+        target.getName() = "operator delete" and
+        kind = "delete"
+        or
+        target.getName() = "operator delete[]" and
+        kind = "delete[]"
+        or
+        not target instanceof OperatorDeleteDeallocationFunction and
+        kind = "free"
+      )
+    )
+    or
+    free.(DeleteExpr).getExpr() = freed and
+    kind = "delete"
+    or
+    free.(DeleteArrayExpr).getExpr() = freed and
+    kind = "delete[]"
+  }
+
+  /**
+   * Holds if `free` is a use of free or delete, or a function
+   * wrapping one of those.  `freed` is the expression that is
+   * freed / deleted and `kind` is a string describing the type
+   * of that free or delete.
+   */
+  predicate freeExprOrIndirect(Expr free, Expr freed, string kind) {
+    // direct free
+    freeExpr(free, freed, kind)
+    or
+    // indirect free via function call
+    exists(Expr internalFree, Expr internalFreed, int arg |
+      freeExprOrIndirect(internalFree, internalFreed, kind) and
+      free.(FunctionCall).getTarget().getParameter(arg) = internalFreed.(VariableAccess).getTarget() and
+      free.(FunctionCall).getArgument(arg) = freed
+    )
+  }
+}
+
+import NewDelete_copy
 
 /**
  * An expression that acquires a resource, and the kind of resource that is acquired.  The


### PR DESCRIPTION
The CodeQL query engine on lgtm.com no longer allows importing query-internal libraries such as `Critical.NewDelete`. This means that the customized query used by the Fawkes project cannot run. To fix it, I've copied the contents of the current version of the library into the query.