### PR TITLE
gazsim-comm: link against protobuf_comm

### DIFF
--- a/src/plugins/gazebo/gazsim-comm/Makefile
+++ b/src/plugins/gazebo/gazsim-comm/Makefile
@@ -35,9 +35,9 @@ REQ_BOOST_LIBS = system
 HAVE_BOOST_LIBS = $(call boost-have-libs,$(REQ_BOOST_LIBS))
 
 ifeq ($(HAVE_GAZEBO)$(HAVE_PROTOBUF)$(HAVE_PROTOBUF_COMM)$(HAVE_BOOST_LIBS),1111)
-  CFLAGS  += $(CFLAGS_PROTOBUF) \
+  CFLAGS  += $(CFLAGS_PROTOBUF) $(CFLAGS_PROTOBUF_COMM) \
 	     $(call boost-libs-cflags,$(REQ_BOOST_LIBS))
-  LDFLAGS += $(LDFLAGS_PROTOBUF) \
+  LDFLAGS += $(LDFLAGS_PROTOBUF) $(LDFLAGS_PROTOBUF_COMM) \
 	     $(call boost-libs-ldflags,$(REQ_BOOST_LIBS))
 
   PLUGINS_build = $(PLUGINS_all)


### PR DESCRIPTION
We already check that we have it available, but we also need to use its
compile and link flags.

This fixes an abort due to an undefined symbol.