### PR TITLE
pddl-parser: collapse exception msg before rethrowing

### DIFF
--- a/src/libs/pddl_parser/pddl_parser.cpp
+++ b/src/libs/pddl_parser/pddl_parser.cpp
@@ -96,6 +96,7 @@ PddlParser::parseDomain(const std::string &pddl_domain)
 	} catch (PddlSemanticsException &e) {
 		e.prepend("Semantic Error: ");
 		e.append(getErrorContext(iter, end, e.pos).c_str());
+		e.collapse_msg();
 		throw;
 	}
 


### PR DESCRIPTION
The issue https://github.com/fawkesrobotics/fawkes/issues/297 revealed that the error messages of the new pddl-parser are not working as intended.

This PR fixes this issue. The actual problem of https://github.com/fawkesrobotics/fawkes/issues/297 is that the respective domain.pddl contains errors which are hard to spot when the error messages are not displayed...
