### PR TITLE
buildkite: use builder image from quay.io instead of docker.io

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ merged-pr-plugin: &merged-pr-plugin
     mode: checkout
 
 podman-plugin-base: &podman-plugin-base
-  image: docker.io/fawkesrobotics/fawkes-builder:fedora33-noetic
+  image: quay.io/fawkesrobotics/fawkes-builder:fedora33-noetic
   always-pull: true
   debug: true
   environment: ["BUILDKITE", "BUILDKITE_LABEL"]


### PR DESCRIPTION
Docker Hub no longer supports autobuilds, thus switch to Quay.