### PR TITLE
clips-pddl-parser: add CLIPS function to parse a formula

### DIFF
--- a/src/plugins/clips-pddl-parser/clips_pddl_parser_feature.h
+++ b/src/plugins/clips-pddl-parser/clips_pddl_parser_feature.h
@@ -46,6 +46,7 @@ public:
 
 private:
 	void parse_domain(std::string env_name, std::string domain_file);
+	void parse_formula(std::string env_name, std::string pddl_formula, std::string output_id);
 
 private:
 	fawkes::Logger *                                           logger_;


### PR DESCRIPTION
The function expects a PDDL string and an output ID and parses it into
the CLIPS representation of a formula with the given output ID.

As an example, adding the following code into the test scenario:
```
(defrule goal-reasoner-parse-formula
  (domain-loaded)
 =>
  (bind ?formula  "(and (p) (q))")
  (printout t "Parsing formula " ?formula crlf)
  (parse-pddl-formula ?formula "test-formula")
  (printout t "Parsed formula" crlf)
)
```

Results in the following output (debug log):
```
11:01:18.996084 CLIPS (executive): Parsing formula (and (p) (q))
11:01:18.996143 CLIPS (executive): ==> f-254   (pddl-formula (id test-formula1) (part-of test-formula) (type conjunction))
11:01:18.996162 CLIPS (executive): ==> f-255   (pddl-formula (id test-formula11) (part-of test-formula1) (type atom))
11:01:18.996186 CLIPS (executive): ==> f-256   (pddl-predicate (id test-formula11-atom) (part-of test-formula11) (predicate p) (param-names) (param-constants))
11:01:18.996200 CLIPS (executive): ==> f-257   (pddl-formula (id test-formula12) (part-of test-formula1) (type atom))
11:01:18.996221 CLIPS (executive): ==> f-258   (pddl-predicate (id test-formula12-atom) (part-of test-formula12) (predicate q) (param-names) (param-constants))
11:01:18.996229 CLIPS (executive): Parsed formula
```

Open questions:
* Does it make sense to store the ID in `part-of`? We could also adapt this so the root formula would have `id test-formula` and `part-of nil` instead. @snoato What have you been working with so far?
* We could also auto-generate the ID and return it instead, but giving the ID explicitly allows having named formulas 