### PR TITLE
Switch the buildkite podman plugin to supported plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,7 @@ podman-plugin-base: &podman-plugin-base
   image: quay.io/fawkesrobotics/fawkes-builder:fedora33-noetic
   always-pull: true
   debug: true
+  privileged: true
   environment: ["BUILDKITE", "BUILDKITE_LABEL"]
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
     command: .buildkite/lint
     plugins:
       - *merged-pr-plugin
-      - kennasecurity/podman#master:
+      - compono/podman#main:
           <<: *podman-plugin-base
           environment:
             - BUILDKITE
@@ -41,7 +41,7 @@ steps:
     timeout_in_minutes: 45
     plugins:
       - *merged-pr-plugin
-      - kennasecurity/podman#master:
+      - compono/podman#main:
           <<: *podman-plugin-base
           volumes:
             - /var/lib/buildkite-agent/ccache_fedora:/var/cache/ccache


### PR DESCRIPTION
The old plugin is no longer available, switch to the podman plugin provided by
https://github.com/compono/podman-buildkite-plugin.