### PR TITLE
Quantified formulas, domain-constants, goal classes

### DIFF
--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -386,15 +386,6 @@
   )
 )
 
-(defrule domain-remove-grounding-for-plan-action-if-precondition-mismatch
-  "sometimes it is useful to switch the params of a plan-action. Remove grounding to
-  trigger the grounding process again in such a case."
-  ?g <- (pddl-grounding (param-values $?param-values) (id ?grounding))
-  (plan-action (precondition ?grounding) (param-values ~$?param-values))
-  =>
-  (retract ?g)
-)
-
 (defrule domain-ground-plan-action-precondition
   "Create a grounding for the precondition of a plan-action if it
   has not been grounded yet and add a reference to the plan-action fact"

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -19,6 +19,13 @@
   (slot type (type SYMBOL) (default object))
 )
 
+(deftemplate domain-constant
+  "A constant in the domain of the given type. The type must refer to
+   the name of an existing type and existing constant value."
+  (slot type (type SYMBOL))
+  (slot value (type SYMBOL))
+)
+
 (deftemplate domain-predicate
 	"Representation of a predicate specification."
   (slot name (type SYMBOL) (default ?NONE))

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -1185,6 +1185,7 @@
                           (action-name ?action-name)
                           (executable FALSE)
                           (precondition nil))
+  (not (pddl-formula (part-of ?action-name)))
 =>
   (modify ?action (executable TRUE))
 )

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -366,9 +366,11 @@
   (declare (salience ?*SALIENCE-DOMAIN-GROUND*))
   ?p <- (plan-action (id ?action-id) (action-name ?operator-id)
                      (param-names $?param-names) (param-values $?param-values)
-                     (precondition nil))
+                     (precondition nil)
+                     (goal-id ?goal-id))
   (domain-operator (name ?operator-id) (param-names $?op-param-names&:(= (length$ ?param-names) (length$ ?op-param-names))))
 	(pddl-formula (part-of ?operator-id))
+  (goal (id ?goal-id) (mode FORMULATED|SELECTED|EXPANDED|COMMITTED|DISPATCHED))
   =>
   ;(bind ?grounding (ground-pddl-formula ?operator-id root ?param-names ?param-values nil 1))
   (bind ?grounding-id (sym-cat "grounding-" ?operator-id "-" (gensym*)))

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -188,7 +188,7 @@
   (slot predicate (type SYMBOL))
 
   (multislot param-names (type SYMBOL))
-  (multislot param-constants (type SYMBOL))
+  (multislot param-constants )
 )
 
 (deftemplate grounded-pddl-predicate
@@ -384,6 +384,8 @@
   (do-for-all-facts ((?predicate grounded-pddl-predicate)) (eq ?predicate:grounding ?grounding-id)
     (retract ?predicate)
   )
+)
+
 (defrule domain-remove-grounding-for-plan-action-if-precondition-mismatch
   "sometimes it is useful to switch the params of a plan-action. Remove grounding to
   trigger the grounding process again in such a case."
@@ -392,6 +394,7 @@
   =>
   (retract ?g)
 )
+
 (defrule domain-ground-plan-action-precondition
   "Create a grounding for the precondition of a plan-action if it
   has not been grounded yet and add a reference to the plan-action fact"

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -264,7 +264,8 @@
 
 (deffunction ground-pddl-formula
   "Ground a PDDL formula recursively based on the given values from a set of param
-  names and param values."
+  names and param values. Ground quantified values by recursively going through the
+  quantified values and assigning each possible combination of fitting values from the domain."
   (?parent-id ?parent-type ?grounded-parent-id ?param-names ?param-values ?grounding-id ?quantifier-index)
 
   ;if this is a quantified subformula, determine the quantified parameters
@@ -340,6 +341,8 @@
 )
 
 (deffunction domain-exists-objects-for-each-quantified-type
+  "Check if an object exists for each quantified type in a formula. Otherwise the formula
+  can not be fulfilled and should not be grounded."
   (?formula-id)
 
   (do-for-fact ((?formula pddl-formula)) (eq ?formula:id ?formula-id)

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -134,6 +134,7 @@
   the relation between the source of the grounding information and the grounded instance
   explicitely."
   (slot id (type SYMBOL) (default ?NONE))
+  (slot formula-root (type SYMBOL))
 
   (multislot param-names (type SYMBOL))
   (multislot param-values (type SYMBOL))
@@ -159,7 +160,9 @@
   (slot id (type SYMBOL) (default ?NONE))
   (slot part-of (type SYMBOL))
 
-  (slot type (type SYMBOL) (allowed-values conjunction disjunction negation atom))
+  (slot type (type SYMBOL) (allowed-values conjunction disjunction negation atom forall exists))
+  (multislot quantified-names (type SYMBOL))
+  (multislot quantified-types (type SYMBOL))
 )
 
 (deftemplate grounded-pddl-formula
@@ -169,6 +172,7 @@
   (slot id (type SYMBOL) (default ?NONE))
   (slot formula-id (type SYMBOL)); reference to ungrounded base version
   (slot grounding (type SYMBOL))
+  (multislot quantified-values (type SYMBOL))
 
   (slot is-satisfied (type SYMBOL) (allowed-values TRUE FALSE) (default FALSE))
 )
@@ -184,7 +188,7 @@
   (slot predicate (type SYMBOL))
 
   (multislot param-names (type SYMBOL))
-  (multislot param-constants)
+  (multislot param-constants (type SYMBOL))
 )
 
 (deftemplate grounded-pddl-predicate
@@ -192,7 +196,9 @@
   each parameter slot and are part of a grounded formula."
   (slot id (type SYMBOL) (default ?NONE))
   (slot predicate-id (type SYMBOL)) ; reference to ungrounded base version
+  (slot parent-formula (type SYMBOL)) ; reference to the parent atomic formula
   (slot grounding (type SYMBOL))
+  (multislot param-values (type SYMBOL))
 
   (slot is-satisfied (type SYMBOL) (allowed-values TRUE FALSE) (default FALSE))
 )

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -203,10 +203,37 @@
   (slot is-satisfied (type SYMBOL) (allowed-values TRUE FALSE) (default FALSE))
 )
 
+(deffunction domain-build-ground-parameter-list
+  "For multislot of parameter names, build a corresponding multislot of grounded
+  parameter values and - if available - constants."
+  (?names ?constants ?grounded-names ?grounded-values)
+
+  (bind ?values (create$))
+  (foreach ?param ?names
+    (if (neq (nth$ ?param-index ?constants) nil) then
+      (bind ?values
+        (insert$ ?values ?param-index (nth$ ?param-index ?constants)))
+    else
+      (bind ?index (member$ ?param ?grounded-names))
+      (if (not ?index) then
+        (assert (domain-error (error-type unknown-parameter) (error-msg
+          (str-cat "PDDL Predicate has unknown parameter " ?param)))
+        )
+        (return FALSE)
+      else
+        (bind ?values
+          (insert$ ?values ?param-index (nth$ ?index ?grounded-values)))
+      )
+    )
+  )
+
+  (return ?values)
+)
+
 (deffunction ground-pddl-predicate
   "Ground a PDDL predicate based on the given parameter values from a set of param names
   and param values."
-  (?parent-id ?param-names ?param-values ?grounding-id)
+  (?parent-id ?param-names ?param-values ?grounding-id ?parent-atomic-formula)
 
   (do-for-all-facts ((?predicate pddl-predicate))
         (eq ?parent-id ?predicate:part-of)
@@ -214,7 +241,14 @@
     (assert (grounded-pddl-predicate
           (id (sym-cat "grounded-" ?predicate:id "-" ?grounding-id))
           (predicate-id ?predicate:id)
-          (grounding ?grounding-id))
+          (grounding ?grounding-id)
+          (param-values (domain-build-ground-parameter-list ?predicate:param-names
+                                                            ?predicate:param-constants
+                                                            ?param-names
+                                                            ?param-values)
+          )
+          (parent-formula ?parent-atomic-formula)
+      )
     )
   )
 )
@@ -222,15 +256,37 @@
 (deffunction ground-pddl-formula
   "Ground a PDDL formula recursively based on the given values from a set of param
   names and param values."
-  (?parent-id ?param-names ?param-values ?grounding-id)
+  (?parent-id ?parent-type ?param-names ?param-values ?grounding-id ?quantifier-index)
 
+  ;if this is a quantified subformula, determine the quantified parameters
+  (bind ?param-quantified (create$))
+  (bind ?types-quantified (create$))
+  (if (or (eq ?parent-type forall) (eq ?parent-type exists))
+    then
+    (do-for-fact ((?parent pddl-formula)) (eq ?parent-id ?parent:id)
+      (bind ?param-quantified ?parent:quantified-names)
+      (bind ?types-quantified ?parent:quantified-types)
+    )
+  )
+
+  (if (>= (length$ ?param-quantified) ?quantifier-index)
+    then
+    ;recursively ground each of the quantified parameters and insert into values before continuing
+    (do-for-all-facts ((?object domain-object))
+          (eq ?object:type (nth$ ?quantifier-index ?types-quantified))
+      (bind ?index (member$ (nth$ ?quantifier-index ?param-quantified) ?param-names))
+      (bind ?param-values-new (replace$ ?param-values ?index ?index ?object:name))
+      (ground-pddl-formula ?parent-id ?parent-type ?param-names ?param-values-new ?grounding-id (+ 1 ?quantifier-index))
+    )
+    else
   (do-for-all-facts ((?formula pddl-formula)) (eq ?parent-id ?formula:part-of)
-    ;if no grounding fact created yet, create one
-    (if (eq ?grounding-id nil) then
-      (bind ?grounding (assert (pddl-grounding (id (sym-cat "grounding-" ?formula:id "-" (gensym*)))
-                                               (param-names ?param-names)
-                                               (param-values ?param-values))))
-      (bind ?grounding-id (fact-slot-value ?grounding id))
+      ;if we are quantified, get the quantified values
+      (bind ?values-quantified (create$))
+      (if (> (length$ ?param-quantified) 0)
+        then
+        (foreach ?param ?param-quantified
+          (bind ?values-quantified (create$ ?values-quantified (nth$ (member$ ?param ?param-names) ?param-values)))
+        )
     )
 
     ;recursively ground subformulas
@@ -238,11 +294,14 @@
 
     (assert (grounded-pddl-formula (formula-id ?formula:id)
                                    (id ?grounded-id)
-                                   (grounding ?grounding-id)))
+                                    (grounding ?grounding-id)
+                                    (quantified-values ?values-quantified)))
 
-    (ground-pddl-formula ?formula:id ?param-names ?param-values ?grounding-id)
-    (ground-pddl-predicate ?formula:id ?param-names ?param-values ?grounding-id)
+      (ground-pddl-formula ?formula:id ?formula:type ?param-names ?param-values ?grounding-id 1)
+      (ground-pddl-predicate ?formula:id ?param-names ?param-values ?grounding-id ?grounded-id)
   )
+  )
+
   (return ?grounding-id)
 )
 
@@ -311,7 +370,7 @@
   (grounded-pddl-predicate (predicate-id ?child-base)
                            (grounding ?grounding-id)
                            (is-satisfied TRUE)
-                           (parent ?id))
+                           (parent-formula ?id))
   =>
   (modify ?parent (is-satisfied TRUE))
 )
@@ -331,7 +390,7 @@
   (grounded-pddl-predicate (predicate-id ?child-base)
                            (grounding ?grounding-id)
                            (is-satisfied FALSE)
-                           (parent ?id))
+                           (parent-formula ?id))
   =>
   (modify ?parent (is-satisfied FALSE))
 )
@@ -464,61 +523,93 @@
   (modify ?parent (is-satisfied FALSE))
 )
 
-(deffunction domain-build-ground-parameter-list
-  "For multislot of parameter names, build a corresponding multislot of grounded
-  parameter values and - if available - constants."
-  (?names ?constants ?grounded-names ?grounded-values)
 
-  (bind ?values (create$))
-  (foreach ?param ?names
-    (if (neq (nth$ ?param-index ?constants) nil) then
-      (bind ?values
-        (insert$ ?values ?param-index (nth$ ?param-index ?constants)))
-    else
-      (bind ?index (member$ ?param ?grounded-names))
-      (if (not ?index) then
-        (assert (domain-error (error-type unknown-parameter) (error-msg
-          (str-cat "PDDL Predicate has unknown parameter " ?param)))
+(defrule domain-check-if-forall-is-satisfied
+  (declare (salience ?*SALIENCE-DOMAIN-CHECK*))
+
+  (pddl-grounding (id ?grounding-id))
+  (pddl-formula (id ?parent-base) (type forall))
+  ?parent <- (grounded-pddl-formula (id ?id)
+                                    (formula-id ?parent-base)
+                                    (is-satisfied FALSE)
+                                    (grounding ?grounding-id))
+ ; the formula is satisfied when there is no unsatisifed child
+  (not
+    (and
+      (pddl-formula (part-of ?parent-base) (id ?child-base))
+      (grounded-pddl-formula (formula-id ?child-base)
+                             (grounding ?grounding-id)
+                             (is-satisfied FALSE)
         )
-        (return FALSE)
-      else
-        (bind ?values
-          (insert$ ?values ?param-index (nth$ ?index ?grounded-values)))
       )
     )
+=>
+  (modify ?parent (is-satisfied TRUE))
   )
 
-  (return ?values)
+(defrule domain-check-if-forall-is-unsatisfied
+  (declare (salience ?*SALIENCE-DOMAIN-CHECK*))
+
+  (pddl-grounding (id ?grounding-id))
+  (pddl-formula (id ?parent-base) (type forall))
+  ?parent <- (grounded-pddl-formula (id ?id)
+                                    (formula-id ?parent-base)
+                                    (is-satisfied TRUE)
+                                    (grounding ?grounding-id))
+
+   ; the formula is unsatisfied when there is an unsatisifed child
+  (pddl-formula (part-of ?parent-base) (id ?child-base))
+  (grounded-pddl-formula (formula-id ?child-base)
+                         (grounding ?grounding-id)
+                         (is-satisfied FALSE)
+  )
+=>
+  (modify ?parent (is-satisfied FALSE))
 )
 
-(deffunction domain-check-grounding-match
-  "check if a multislot of values matches a the expected values for a multislot
-  of parameter names"
-  (?param-names ?domain-values ?predicate-constants ?grounded-params ?grounded-values)
+(defrule domain-check-if-exists-is-satisfied
+  (declare (salience ?*SALIENCE-DOMAIN-CHECK*))
 
-  (bind ?values (domain-build-ground-parameter-list ?param-names
-                                                   ?predicate-constants
-                                                   ?grounded-params
-                                                   ?grounded-values))
+  (pddl-grounding (id ?grounding-id))
 
-  (if (eq ?domain-values ?values) then
-    (return TRUE)
+  (pddl-formula (id ?parent-base) (type exists))
+  ?parent <- (grounded-pddl-formula (id ?id)
+                                    (formula-id ?parent-base)
+                                    (is-satisfied FALSE)
+                                    (grounding ?grounding-id))
+
+  ; the formula is satisfied when there is a satisifed child
+  (pddl-formula (part-of ?parent-base) (id ?child-base))
+  (grounded-pddl-formula (formula-id ?child-base)
+                         (grounding ?grounding-id)
+                         (is-satisfied TRUE)
   )
-  (return FALSE)
+ =>
+  (modify ?parent (is-satisfied TRUE))
 )
 
-(deffunction domain-check-grounded-equality
-  (?param-names ?predicate-constants ?grounded-params ?grounded-values)
+(defrule domain-check-if-exists-is-unsatisfied
+  (declare (salience ?*SALIENCE-DOMAIN-CHECK*))
 
-  (bind ?values (domain-build-ground-parameter-list ?param-names
-                                                   ?predicate-constants
-                                                   ?grounded-params
-                                                   ?grounded-values))
+  (pddl-grounding (id ?grounding-id))
+  (pddl-formula (id ?parent-base) (type exists))
+  ?parent <- (grounded-pddl-formula (id ?id)
+                                    (formula-id ?parent-base)
+                                    (is-satisfied TRUE)
+                                    (grounding ?grounding-id))
 
-  (if (eq (length ?values) 2) then
-    (return (eq (nth$ 1 ?values) (nth$ 2 ?values)))
+  ; the formula is unsatisfied when there is no satisifed child
+  (not
+    (and
+      (pddl-formula (part-of ?parent-base) (id ?child-base))
+      (grounded-pddl-formula (formula-id ?child-base)
+                              (grounding ?grounding-id)
+                              (is-satisfied TRUE)
   )
-  (return FALSE)
+    )
+  )
+=>
+  (modify ?parent (is-satisfied FALSE))
 )
 
 (defrule domain-check-grounded-predicate
@@ -532,17 +623,14 @@
   ?base-predicate <- (pddl-predicate (id ?id)
                                      (predicate ?pred&~EQUALITY)
                                      (param-names $?param-names)
-                                     (param-constants $?predicate-constants))
+                                     (param-constants $?predicate-constants)
+                     )
   ?predicate <- (grounded-pddl-predicate (predicate-id ?id)
                                          (grounding ?grounding-id)
-                                         (is-satisfied FALSE))
+                                         (is-satisfied FALSE)
+                                         (param-values $?param-values))
 
-  (domain-fact (name ?pred)
-               (param-values $?domain-values&:(domain-check-grounding-match ?param-names
-                                                                            ?domain-values
-                                                                            ?predicate-constants
-                                                                            ?grounded-params
-                                                                            ?grounded-values)))
+  (domain-fact (name ?pred) (param-values $?param-values))
 =>
   (modify ?predicate (is-satisfied TRUE))
 )
@@ -556,17 +644,14 @@
   ?base-predicate <- (pddl-predicate (id ?id)
                                      (predicate ?pred&~EQUALITY)
                                      (param-names $?param-names)
-                                     (param-constants $?predicate-constants))
+                                     (param-constants $?predicate-constants)
+                     )
   ?predicate <- (grounded-pddl-predicate (predicate-id ?id)
                                          (grounding ?grounding-id)
-                                         (is-satisfied TRUE))
+                                         (is-satisfied TRUE)
+                                         (param-values $?param-values))
 
-  (not (domain-fact (name ?pred)
-                    (param-values $?domain-values&:(domain-check-grounding-match ?param-names
-                                                                                 ?domain-values
-                                                                                 ?predicate-constants
-                                                                                 ?grounded-params
-                                                                                 ?grounded-values))))
+  (not (domain-fact (name ?pred) (param-values $?param-values)))
 =>
   (modify ?predicate (is-satisfied FALSE))
 )
@@ -575,20 +660,13 @@
 (defrule domain-check-if-predicate-equality-is-satisfied
   (declare (salience ?*SALIENCE-DOMAIN-CHECK*))
 
-  (pddl-grounding (id ?grounding-id)
-                  (param-names $?grounded-params)
-                  (param-values $?grounded-values))
   ?predicate <- (grounded-pddl-predicate (predicate-id ?id)
                                          (grounding ?grounding-id)
-                                         (is-satisfied FALSE))
+                                         (is-satisfied FALSE)
+                                         (param-values $?param-values&:(and (eq (length ?param-values) 2)
+                                                                            (eq (nth$ 1 ?param-values) (nth$ 2 ?param-values)))))
   ?base-predicate <- (pddl-predicate (id ?id)
-                                     (predicate EQUALITY)
-                                     (param-constants $?predicate-constants)
-                                     (param-names $?param-names&:
-                                                  (domain-check-grounded-equality ?param-names
-                                                                                  ?predicate-constants
-                                                                                  ?grounded-params
-                                                                                  ?grounded-values)))
+                                     (predicate EQUALITY))
 =>
   (modify ?predicate (is-satisfied TRUE))
 )
@@ -596,20 +674,13 @@
 (defrule domain-check-if-predicate-equality-is-unsatisfied
   (declare (salience ?*SALIENCE-DOMAIN-CHECK*))
 
-  (pddl-grounding (id ?grounding-id)
-                  (param-names $?grounded-params)
-                  (param-values $?grounded-values))
   ?predicate <- (grounded-pddl-predicate (predicate-id ?id)
                                          (grounding ?grounding-id)
-                                         (is-satisfied TRUE))
+                                         (is-satisfied TRUE)
+                                         (param-values $?param-values&:(not (and (eq (length ?param-values) 2)
+                                                                                 (eq (nth$ 1 ?param-values) (nth$ 2 ?param-values))))))
   ?base-predicate <- (pddl-predicate (id ?id)
-                                     (predicate EQUALITY)
-                                     (param-constants $?predicate-constants)
-                                     (param-names $?param-names&:
-                                                  (not (domain-check-grounded-equality ?param-names
-                                                                                  ?predicate-constants
-                                                                                  ?grounded-params
-                                                                                  ?grounded-values))))
+                                     (predicate EQUALITY))
 =>
   (modify ?predicate (is-satisfied FALSE))
  )
@@ -833,8 +904,15 @@
   (domain-effect (name ?effect-name) (part-of ?op))
   ?precond <- (pddl-formula (id ?precond-id) (part-of ?effect-name))
 =>
-  (bind ?grounding (ground-pddl-formula ?effect-name ?param-names ?param-values nil))
-  (modify ?pa (precondition ?grounding))
+  ;(bind ?grounding (ground-pddl-formula ?effect-name root ?param-names ?param-values nil 1))
+  (bind ?grounding-id (sym-cat "grounding-" ?effect-name "-" (gensym*)))
+  (assert (pddl-grounding (param-names ?param-names)
+                          (param-values ?param-values)
+                          (formula-root ?effect-name)
+                          (id ?grounding-id)
+          )
+  )
+  (modify ?pa (precondition ?grounding-id))
 )
 
 (deffunction intersect

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -1163,19 +1163,23 @@
 (defrule domain-action-final
   "After the effects of an action have been applied, change it to FINAL."
   (declare (salience ?*SALIENCE-DOMAIN-APPLY*))
-  ?a <- (plan-action (id ?action-id) (state EFFECTS-APPLIED))
+  ?a <- (plan-action (id ?action-id) (state EFFECTS-APPLIED) (precondition ?grounding-id))
+  ?g <- (pddl-grounding (id ?grounding-id))
   =>
-  (modify ?a (state FINAL))
-  (domain-retract-grounding)
+  (modify ?a (state FINAL) (precondition nil))
+  ;(domain-retract-grounding)
+  (retract ?g)
 )
 
 (defrule domain-action-failed
   "An action has failed."
   (declare (salience ?*SALIENCE-DOMAIN-APPLY*))
-  ?a <- (plan-action (id ?action-id) (state EXECUTION-FAILED))
+  ?a <- (plan-action (id ?action-id) (state EXECUTION-FAILED) (precondition ?grounding-id))
+  ?g <- (pddl-grounding (id ?grounding-id))
   =>
-  (modify ?a (state FAILED))
-  (domain-retract-grounding)
+  (modify ?a (state FAILED) (precondition nil))
+  ;(domain-retract-grounding)
+  (retract ?g)
 )
 
 (defrule domain-check-if-action-is-executable-without-precondition

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -502,7 +502,8 @@
   (pddl-formula (part-of ?parent-base) (id ?child-base))
   (grounded-pddl-formula (formula-id ?child-base)
                          (grounding ?grounding-id)
-                         (is-satisfied FALSE))
+                         (is-satisfied FALSE)
+                         (grounded-parent ?id))
 =>
   (modify ?parent (is-satisfied TRUE))
 )
@@ -522,7 +523,8 @@
   (grounded-pddl-formula (formula-id ?child-base)
                          (grounding ?grounding-id)
                          (id ~nil)
-                         (is-satisfied TRUE))
+                         (is-satisfied TRUE)
+                         (grounded-parent ?id))
 =>
   (modify ?parent (is-satisfied FALSE))
 )
@@ -543,6 +545,7 @@
       (grounded-pddl-formula (formula-id ?child-base)
                              (grounding ?grounding-id)
                              (is-satisfied FALSE)
+                             (grounded-parent ?id)
       )
     )
   )
@@ -565,6 +568,7 @@
   (grounded-pddl-formula (formula-id ?child-base)
                          (grounding ?grounding-id)
                          (is-satisfied FALSE)
+                         (grounded-parent ?id)
   )
 =>
   (modify ?parent (is-satisfied FALSE))
@@ -586,6 +590,7 @@
   (grounded-pddl-formula (formula-id ?child-base)
                          (grounding ?grounding-id)
                          (is-satisfied TRUE)
+                         (grounded-parent ?id)
   )
  =>
   (modify ?parent (is-satisfied TRUE))
@@ -608,6 +613,7 @@
       (grounded-pddl-formula (formula-id ?child-base)
                               (grounding ?grounding-id)
                               (is-satisfied TRUE)
+                              (grounded-parent ?id)
       )
     )
   )
@@ -632,6 +638,7 @@
       (grounded-pddl-formula (formula-id ?child-base)
                              (grounding ?grounding-id)
                              (is-satisfied FALSE)
+                             (grounded-parent ?id)
         )
       )
     )
@@ -654,6 +661,7 @@
   (grounded-pddl-formula (formula-id ?child-base)
                          (grounding ?grounding-id)
                          (is-satisfied FALSE)
+                         (grounded-parent ?id)
   )
 =>
   (modify ?parent (is-satisfied FALSE))
@@ -675,6 +683,7 @@
   (grounded-pddl-formula (formula-id ?child-base)
                          (grounding ?grounding-id)
                          (is-satisfied TRUE)
+                         (grounded-parent ?id)
   )
  =>
   (modify ?parent (is-satisfied TRUE))
@@ -697,6 +706,7 @@
       (grounded-pddl-formula (formula-id ?child-base)
                               (grounding ?grounding-id)
                               (is-satisfied TRUE)
+                              (grounded-parent ?id)
   )
     )
   )

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -331,6 +331,14 @@
   (ground-pddl-formula ?parent root ?param-names ?param-values ?grounding-id 1)
 )
 
+(defrule domain-remove-grounding-for-plan-action-if-precondition-mismatch
+  "sometimes it is useful to switch the params of a plan-action. Remove grounding to
+  trigger the grounding process again in such a case."
+  ?g <- (pddl-grounding (param-values $?param-values) (id ?grounding))
+  (plan-action (precondition ?grounding) (param-values ~$?param-values))
+  =>
+  (retract ?g)
+)
 (defrule domain-ground-plan-action-precondition
   "Create a grounding for the precondition of a plan-action if it
   has not been grounded yet and add a reference to the plan-action fact"

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -286,7 +286,13 @@
           (eq ?object:type (nth$ ?quantifier-index ?types-quantified))
       (bind ?index (member$ (nth$ ?quantifier-index ?param-quantified) ?param-names))
       (bind ?param-values-new (replace$ ?param-values ?index ?index ?object:name))
-      (ground-pddl-formula ?parent-id ?parent-type ?grounded-parent-id ?param-names ?param-values-new ?grounding-id (+ 1 ?quantifier-index))
+      (ground-pddl-formula ?parent-id
+                           ?parent-type
+                           ?grounded-parent-id
+                           ?param-names
+                           ?param-values-new
+                           ?grounding-id
+                           (+ 1 ?quantifier-index))
     )
     else
     (do-for-all-facts ((?formula pddl-formula)) (eq ?parent-id ?formula:part-of)
@@ -295,7 +301,8 @@
       (if (> (length$ ?param-quantified) 0)
         then
         (foreach ?param ?param-quantified
-          (bind ?values-quantified (create$ ?values-quantified (nth$ (member$ ?param ?param-names) ?param-values)))
+          (bind ?values-quantified (create$ ?values-quantified
+                                            (nth$ (member$ ?param ?param-names) ?param-values)))
         )
       )
 
@@ -365,7 +372,10 @@
 (defrule domain-add-formula-for-grounding
   "Add a grounded formula for a grounding without formula."
   (declare (salience ?*SALIENCE-DOMAIN-GROUND*))
-  (pddl-grounding (id ?grounding-id) (formula-root ?parent) (param-values $?param-values) (param-names $?param-names))
+  (pddl-grounding (id ?grounding-id)
+                  (formula-root ?parent)
+                  (param-values $?param-values)
+                  (param-names $?param-names))
   (pddl-formula (part-of ?parent) (id ?formula-id))
   (not (grounded-pddl-formula (grounding ?grounding-id) (formula-id ?formula-id)))
   (test (domain-exists-objects-for-each-quantified-type ?formula-id))
@@ -376,10 +386,18 @@
 (defrule domain-retract-quantified-subtree-if-object-is-removed
   "If a formula is grounded with a certain value for a certain type but the corresponding
   object does not exist (anymore), retract the formula to trigger a new grounding of it."
-  (pddl-formula (id ?parent) (quantified-types $?quantified-types&:( > (length$ ?quantified-types) 0)) (type forall|exists))
+  (pddl-formula (id ?parent)
+                (quantified-types $?quantified-types&:(> (length$ ?quantified-types) 0))
+                (type forall|exists))
   (pddl-formula (id ?formula) (part-of ?parent))
-  ?g <- (grounded-pddl-formula (quantified-values $?quantified-values&:( > (length$ ?quantified-values) 0)) (formula-id ?formula) (grounding ?grounding-id))
-  (not (domain-object (type ?object-type) (name ?object-name&:(and (member$ ?object-name ?quantified-values) (eq (member$ ?object-name ?quantified-values) (member$ ?object-type ?quantified-types))))))
+  ?g <- (grounded-pddl-formula (quantified-values $?quantified-values&:
+                               (> (length$ ?quantified-values) 0))
+                               (formula-id ?formula)
+                               (grounding ?grounding-id))
+  (not (domain-object (type ?object-type)
+                      (name ?object-name&:(and (member$ ?object-name ?quantified-values)
+                                               (eq (member$ ?object-name ?quantified-values)
+                                                   (member$ ?object-type ?quantified-types))))))
   =>
   (retract ?g)
 )
@@ -389,16 +407,30 @@
   a quantifier in a formula, add the quantified subformulas containing it as grounding. "
   (domain-object (type ?object-type) (name ?object-name))
   (pddl-grounding (id ?grounding-id) (param-names $?param-names) (param-values $?param-values))
-  (pddl-formula (id ?parent) (quantified-types $?types&:(member$ ?object-type ?types)) (quantified-names $?names) (type ?parent-type&forall|exists))
-  (grounded-pddl-formula (formula-id ?parent) (grounding ?grounding-id) (id ?grounded-parent-id))
+  (pddl-formula (id ?parent)
+                (quantified-types $?types&:(member$ ?object-type ?types))
+                (quantified-names $?names)
+                (type ?parent-type&forall|exists))
+  (grounded-pddl-formula (formula-id ?parent)
+                         (grounding ?grounding-id)
+                         (id ?grounded-parent-id))
   (pddl-formula (id ?formula) (part-of ?parent))
-  (not (grounded-pddl-formula (quantified-values $?values&:(eq (member$ ?object-type ?types) (member$ ?object-name ?values))) (formula-id ?id) (grounding ?grounding-id)))
+  (not (grounded-pddl-formula (quantified-values $?values&:(eq (member$ ?object-type ?types)
+                                                               (member$ ?object-name ?values)))
+                               (formula-id ?id)
+                               (grounding ?grounding-id)))
 
   ;use existing grounding as basis
   (domain-object (type ?object-type) (name ?ex-object-name))
-  (grounded-pddl-formula (quantified-values $?ex-objects&:(eq (member$ ?object-type ?types) (member$ ?ex-object-name ?ex-objects))) (formula-id ?id) (grounding ?grounding-id))
+  (grounded-pddl-formula (quantified-values $?ex-objects&:(eq (member$ ?object-type ?types)
+                                                              (member$ ?ex-object-name ?ex-objects)))
+                         (formula-id ?id)
+                         (grounding ?grounding-id))
   =>
-  (do-for-all-facts ((?q-sf grounded-pddl-formula)) (and (eq ?q-sf:formula-id ?id) (eq ?q-sf:grounding ?grounding-id) (eq (member$ ?object-type ?types) (member$ ?ex-object-name ?q-sf:quantified-values)))
+  (do-for-all-facts ((?q-sf grounded-pddl-formula)) (and (eq ?q-sf:formula-id ?id)
+                                                         (eq ?q-sf:grounding ?grounding-id)
+                                                         (eq (member$ ?object-type ?types)
+                                                             (member$ ?ex-object-name ?q-sf:quantified-values)))
     (bind ?new-param-values ?param-values)
     (loop-for-count (?cnt 1 (length$ ?param-names)) do
       (bind ?index (member$ (nth$ ?cnt ?param-names) ?names))
@@ -410,7 +442,13 @@
         )
       )
     )
-    (ground-pddl-formula ?parent ?parent-type ?grounded-parent-id ?param-names ?new-param-values ?grounding-id (+ (length$ ?param-names) 1))
+    (ground-pddl-formula ?parent
+                         ?parent-type
+                         ?grounded-parent-id
+                         ?param-names
+                         ?new-param-values
+                         ?grounding-id
+                         (+ (length$ ?param-names) 1))
   )
 )
 
@@ -422,7 +460,8 @@
                      (param-names $?param-names) (param-values $?param-values)
                      (precondition nil)
                      (goal-id ?goal-id))
-  (domain-operator (name ?operator-id) (param-names $?op-param-names&:(= (length$ ?param-names) (length$ ?op-param-names))))
+  (domain-operator (name ?operator-id)
+                   (param-names $?op-param-names&:(= (length$ ?param-names) (length$ ?op-param-names))))
 	(pddl-formula (part-of ?operator-id))
   (goal (id ?goal-id) (mode FORMULATED|SELECTED|EXPANDED|COMMITTED|DISPATCHED))
   =>
@@ -792,7 +831,8 @@
                                          (grounding ?grounding-id)
                                          (is-satisfied FALSE)
                                          (param-values $?param-values&:(and (eq (length ?param-values) 2)
-                                                                            (eq (nth$ 1 ?param-values) (nth$ 2 ?param-values)))))
+                                                                            (eq (nth$ 1 ?param-values)
+                                                                                (nth$ 2 ?param-values)))))
   ?base-predicate <- (pddl-predicate (id ?id)
                                      (predicate EQUALITY))
 =>
@@ -806,7 +846,8 @@
                                          (grounding ?grounding-id)
                                          (is-satisfied TRUE)
                                          (param-values $?param-values&:(not (and (eq (length ?param-values) 2)
-                                                                                 (eq (nth$ 1 ?param-values) (nth$ 2 ?param-values))))))
+                                                                                 (eq (nth$ 1 ?param-values)
+                                                                                     (nth$ 2 ?param-values))))))
   ?base-predicate <- (pddl-predicate (id ?id)
                                      (predicate EQUALITY))
 =>

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -301,11 +301,11 @@
                                     (is-satisfied FALSE)
                                     (grounding ?grounding-id))
 
-  (and (pddl-predicate (part-of ?parent-base) (id ?child-base))
-        (grounded-pddl-predicate (predicate-id ?child-base)
-                                (grounding ?grounding-id)
-                                (is-satisfied TRUE))
-  )
+  (pddl-predicate (part-of ?parent-base) (id ?child-base))
+  (grounded-pddl-predicate (predicate-id ?child-base)
+                           (grounding ?grounding-id)
+                           (is-satisfied TRUE)
+                           (parent ?id))
   =>
   (modify ?parent (is-satisfied TRUE))
 )
@@ -321,11 +321,11 @@
                                     (is-satisfied TRUE)
                                     (grounding ?grounding-id))
 
-  (and (pddl-predicate (part-of ?parent-base) (id ?child-base))
-        (grounded-pddl-predicate (predicate-id ?child-base)
-                                (grounding ?grounding-id)
-                                (is-satisfied FALSE))
-  )
+  (pddl-predicate (part-of ?parent-base) (id ?child-base))
+  (grounded-pddl-predicate (predicate-id ?child-base)
+                           (grounding ?grounding-id)
+                           (is-satisfied FALSE)
+                           (parent ?id))
   =>
   (modify ?parent (is-satisfied FALSE))
 )

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -214,7 +214,7 @@
 (deffunction domain-build-ground-parameter-list
   "For multislot of parameter names, build a corresponding multislot of grounded
   parameter values and - if available - constants."
-  (?names ?constants ?grounded-names ?grounded-values)
+  (?names ?constants ?grounded-names ?grounded-values ?predicate-id)
 
   (bind ?values (create$))
   (foreach ?param ?names
@@ -225,7 +225,7 @@
       (bind ?index (member$ ?param ?grounded-names))
       (if (not ?index) then
         (assert (domain-error (error-type unknown-parameter) (error-msg
-          (str-cat "PDDL Predicate has unknown parameter " ?param)))
+          (str-cat "PDDL predicate " ?predicate-id " has unknown parameter " ?param)))
         )
         (return FALSE)
       else
@@ -253,7 +253,8 @@
           (param-values (domain-build-ground-parameter-list ?predicate:param-names
                                                             ?predicate:param-constants
                                                             ?param-names
-                                                            ?param-values)
+                                                            ?param-values
+                                                            ?predicate:id)
           )
           (parent-formula ?parent-atomic-formula)
       )
@@ -1351,7 +1352,8 @@
                     (not (= (length$ (domain-build-ground-parameter-list ?param-names
                                                                          ?param-constants
                                                                          ?grounding-names
-                                                                         ?grounding-values))
+                                                                         ?grounding-values
+                                                                         ?pid))
                                       2)))
   )
   =>

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -279,27 +279,27 @@
       (ground-pddl-formula ?parent-id ?parent-type ?param-names ?param-values-new ?grounding-id (+ 1 ?quantifier-index))
     )
     else
-  (do-for-all-facts ((?formula pddl-formula)) (eq ?parent-id ?formula:part-of)
-      ;if we are quantified, get the quantified values
-      (bind ?values-quantified (create$))
-      (if (> (length$ ?param-quantified) 0)
-        then
-        (foreach ?param ?param-quantified
-          (bind ?values-quantified (create$ ?values-quantified (nth$ (member$ ?param ?param-names) ?param-values)))
-        )
+    (do-for-all-facts ((?formula pddl-formula)) (eq ?parent-id ?formula:part-of)
+        ;if we are quantified, get the quantified values
+        (bind ?values-quantified (create$))
+        (if (> (length$ ?param-quantified) 0)
+          then
+          (foreach ?param ?param-quantified
+            (bind ?values-quantified (create$ ?values-quantified (nth$ (member$ ?param ?param-names) ?param-values)))
+          )
+      )
+
+      ;recursively ground subformulas
+      (bind ?grounded-id (sym-cat "grounded-" ?formula:id "-" (gensym*)))
+
+      (assert (grounded-pddl-formula (formula-id ?formula:id)
+                                    (id ?grounded-id)
+                                      (grounding ?grounding-id)
+                                      (quantified-values ?values-quantified)))
+
+        (ground-pddl-formula ?formula:id ?formula:type ?param-names ?param-values ?grounding-id 1)
+        (ground-pddl-predicate ?formula:id ?param-names ?param-values ?grounding-id ?grounded-id)
     )
-
-    ;recursively ground subformulas
-    (bind ?grounded-id (sym-cat "grounded-" ?formula:id "-" (gensym*)))
-
-    (assert (grounded-pddl-formula (formula-id ?formula:id)
-                                   (id ?grounded-id)
-                                    (grounding ?grounding-id)
-                                    (quantified-values ?values-quantified)))
-
-      (ground-pddl-formula ?formula:id ?formula:type ?param-names ?param-values ?grounding-id 1)
-      (ground-pddl-predicate ?formula:id ?param-names ?param-values ?grounding-id ?grounded-id)
-  )
   )
 
   (return ?grounding-id)

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -29,6 +29,12 @@
 )
 
 (deffunction goal-class-create-grounding
+    "Go through the list of parameters and build up a grounding. For values that have an
+    entry that is not nil in param-constants, assign that value. For values that are quantified
+    leave them empty, as they will be quantified in the formula. For values that are neither
+    quantified nor constnats, assign the value based on the entry in the type field by
+    creating one grounding for each possible value or constant of that type in the current
+    world. "
     (?goal-class-id ?param-types ?param-names ?param-names-left ?param-constants ?param-quantified ?param-values)
 
     (if (> (length$ ?param-types) 0)

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -29,7 +29,6 @@
 (deffunction goal-class-create-grounding
     (?goal-class ?param-types ?param-names ?param-names-left ?param-constants ?param-quantified ?param-values)
 
-
     (if (> (length$ ?param-types) 0)
         then
         (if (neq (nth$ 1 ?param-constants) nil)
@@ -101,4 +100,22 @@
     )
     =>
     (goal-class-create-grounding ?class-id ?param-types ?param-names ?param-names ?param-constants ?param-quantified (create$ ))
+)
+
+(defrule goal-class-retract-unbased-grounding
+    "If there is a grounding of a goal class using a value that does not exist anymore,
+    retract the grounding to trigger the removal of the formula. "
+    (goal-class (class ?class-id)
+                (param-names $?param-names)
+                (param-constants $?param-constants)
+                (param-types $?param-types)
+                (param-quantified $?param-quantified)
+    )
+    (pddl-formula (part-of ?class-id) (id ?formula-id))
+    ?g <- (pddl-grounding (id ?grounding-id) (param-values $? ?value&~nil $?))
+    (grounded-pddl-formula (formula-id ?formula-id) (grounding ?grounding-id))
+    (not (domain-object (name ?value)))
+    =>
+    (printout t ?value crlf)
+    (retract ?g)
 )

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -128,3 +128,12 @@
     (printout t "Retracting grounding" ?grounding-id " because value " ?value " is " crlf)
     (retract ?g)
 )
+
+(defrule goal-class-assert-precondition-formula-for-class
+    "If there is a goal class that doesn't have its precondition formula
+    translated to a set of PDDL formula facts yet, parse its formula string."
+    (goal-class (class ?cid) (preconditions ?prec))
+    (not (pddl-formula (part-of ?cid)))
+    =>
+    (parse-pddl-formula ?prec (str-cat ?cid))
+)

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -42,27 +42,52 @@
         (if (neq (nth$ 1 ?param-constants) nil)
             then
                 (bind ?param-values-new (insert$ ?param-values (+ 1 (length$ ?param-values)) (nth$ 1 ?param-constants)))
-                (goal-class-create-grounding ?goal-class-id (delete$ ?param-types 1 1) (delete$ ?param-names 1 1) ?param-names-left  (delete$ ?param-constants 1 1) ?param-quantified ?param-values-new)
+                (goal-class-create-grounding ?goal-class-id
+                                             (delete$ ?param-types 1 1)
+                                             (delete$ ?param-names 1 1)
+                                             ?param-names-left
+                                             (delete$ ?param-constants 1 1)
+                                             ?param-quantified
+                                             ?param-values-new)
             else
             (if (not (member$ (nth$ 1 ?param-names) ?param-quantified))
                 then
                     ;ground by domain objects
                     (do-for-all-facts ((?object domain-object)) (eq ?object:type (nth$ 1 ?param-types))
                         (bind ?param-values-new (insert$ ?param-values (+ 1 (length$ ?param-values)) ?object:name))
-                        (goal-class-create-grounding ?goal-class-id (delete$ ?param-types 1 1) (delete$ ?param-names 1 1) ?param-names-left (delete$ ?param-constants 1 1) ?param-quantified ?param-values-new)
+                        (goal-class-create-grounding ?goal-class-id
+                                                     (delete$ ?param-types 1 1)
+                                                     (delete$ ?param-names 1 1)
+                                                     ?param-names-left
+                                                     (delete$ ?param-constants 1 1)
+                                                     ?param-quantified
+                                                      ?param-values-new)
                     )
                     ;ground by domain constants
                     (do-for-all-facts ((?constant domain-constant)) (eq ?constant:type (nth$ 1 ?param-types))
                         (bind ?param-values-new (insert$ ?param-values (+ 1 (length$ ?param-values)) ?constant:value))
-                        (goal-class-create-grounding ?goal-class-id (delete$ ?param-types 1 1) (delete$ ?param-names 1 1) ?param-names-left (delete$ ?param-constants 1 1) ?param-quantified ?param-values-new)
+                        (goal-class-create-grounding ?goal-class-id
+                                                     (delete$ ?param-types 1 1)
+                                                     (delete$ ?param-names 1 1)
+                                                     ?param-names-left
+                                                     (delete$ ?param-constants 1 1)
+                                                     ?param-quantified
+                                                     ?param-values-new)
                     )
                 else
                     (bind ?param-values-new (insert$ ?param-values (+ 1 (length$ ?param-values)) nil))
-                    (goal-class-create-grounding ?goal-class-id (delete$ ?param-types 1 1) (delete$ ?param-names 1 1) ?param-names-left (delete$ ?param-constants 1 1) ?param-quantified ?param-values-new)
+                    (goal-class-create-grounding ?goal-class-id
+                                                 (delete$ ?param-types 1 1)
+                                                 (delete$ ?param-names 1 1)
+                                                 ?param-names-left
+                                                 (delete$ ?param-constants 1 1)
+                                                 ?param-quantified
+                                                 ?param-values-new)
             )
         )
         else
-        (if (not (any-factp ((?grounding pddl-grounding)) (and (eq ?grounding:formula-root ?goal-class-id) (eq ?grounding:param-values ?param-values))))
+        (if (not (any-factp ((?grounding pddl-grounding)) (and (eq ?grounding:formula-root ?goal-class-id)
+                                                               (eq ?grounding:param-values ?param-values))))
             then
                 (printout t "Adding new Groundings: " ?param-values " for " ?goal-class-id crlf)
                 (bind ?grounding-id (sym-cat "grounding-" ?goal-class-id "-" (gensym*)))
@@ -102,7 +127,10 @@
 
             (not
                 (and
-                    (pddl-grounding (id ?grounding-id) (formula-root ?formula-id) (param-names $?param-names) (param-values $? ?object $?))
+                    (pddl-grounding (id ?grounding-id)
+                                    (formula-root ?formula-id)
+                                    (param-names $?param-names)
+                                    (param-values $? ?object $?))
                 )
             )
         )
@@ -113,7 +141,13 @@
         )
     )
     =>
-    (goal-class-create-grounding ?class-id ?param-types ?param-names ?param-names ?param-constants ?param-quantified (create$ ))
+    (goal-class-create-grounding ?class-id
+                                 ?param-types
+                                 ?param-names
+                                 ?param-names
+                                 ?param-constants
+                                 ?param-quantified
+                                 (create$ ))
 )
 
 (defrule goal-class-retract-unbased-grounding

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -1,0 +1,28 @@
+;---------------------------------------------------------------------------
+;  goal-class.clp - CLIPS executive - goal class representation
+;
+;  Created: Sun Sep 12 20:44:00 2021
+;  Copyright  2021  Daniel Swoboda <swoboda@kbsg.rwth-aachen.de>
+;  Licensed under GPLv2+ license, cf. LICENSE file
+;---------------------------------------------------------------------------
+
+(deftemplate goal-class
+    "
+    A description of the properties of a goal class specifying its
+    preconditions, effects, parameters and types.
+    In the goal lifecycle, goal classes are used to specify the preconditions
+    for formulation of goals in a general way. These preconditions are grounded
+    automatically similarly to plan actions and subsequently checked for
+    satisfcation.
+    "
+    (slot class (type SYMBOL))
+    (slot type (type SYMBOL) (allowed-values ACHIEVE MAINTAIN) (default ACHIEVE))
+    (slot sub-type (type SYMBOL))
+    (multislot param-names)
+    (multislot param-constants)
+    (multislot param-quantified)
+    (multislot param-types)
+    (slot preconditions (type STRING))
+    (slot effects (type STRING))
+)
+

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -18,6 +18,7 @@
     (slot class (type SYMBOL))
     (slot type (type SYMBOL) (allowed-values ACHIEVE MAINTAIN) (default ACHIEVE))
     (slot sub-type (type SYMBOL))
+    (multislot meta)
     (multislot param-names)
     (multislot param-constants)
     (multislot param-quantified)

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -63,6 +63,9 @@
 )
 
 (defrule goal-class-grounding
+    "If there is a domain-object matching the type of a parameter of a goal class, or if
+    no grounding exists for the goal class at all (e.g. for fully quantified formulas)
+    generate the possible groundings that do not exist yet. "
     (domain-facts-loaded)
     (goal-class (class ?class-id)
                 (param-names $?param-names)

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -93,15 +93,13 @@
 
             (not
                 (and
-                    (pddl-grounding (id ?grounding-id) (param-names $?param-names) (param-values $? ?object $?))
-                    (grounded-pddl-formula (formula-id ?formula-id) (grounding ?grounding-id))
+                    (pddl-grounding (id ?grounding-id) (formula-root ?formula-id) (param-names $?param-names) (param-values $? ?object $?))
                 )
             )
         )
         (not
             (and
-                (pddl-grounding (id ?grounding-id))
-                (grounded-pddl-formula (formula-id ?formula-id) (grounding ?grounding-id))
+                (pddl-grounding (id ?grounding-id) (formula-root ?formula-id))
             )
         )
     )

--- a/src/plugins/clips-executive/clips/goal-class.clp
+++ b/src/plugins/clips-executive/clips/goal-class.clp
@@ -26,3 +26,76 @@
     (slot effects (type STRING))
 )
 
+(deffunction goal-class-create-grounding
+    (?goal-class ?param-types ?param-names ?param-names-left ?param-constants ?param-quantified ?param-values)
+
+
+    (if (> (length$ ?param-types) 0)
+        then
+        (if (neq (nth$ 1 ?param-constants) nil)
+            then
+                (bind ?param-values-new (insert$ ?param-values (+ 1 (length$ ?param-values)) (nth$ 1 ?param-constants)))
+                (goal-class-create-grounding ?goal-class (delete$ ?param-types 1 1) (delete$ ?param-names 1 1) ?param-names-left  (delete$ ?param-constants 1 1) ?param-quantified ?param-values-new)
+            else
+            (if (not (member$ (nth$ 1 ?param-names) ?param-quantified))
+                then
+                (do-for-all-facts ((?object domain-object)) (eq ?object:type (nth$ 1 ?param-types))
+                    (bind ?param-values-new (insert$ ?param-values (+ 1 (length$ ?param-values)) ?object:name))
+                    (goal-class-create-grounding ?goal-class (delete$ ?param-types 1 1) (delete$ ?param-names 1 1) ?param-names-left (delete$ ?param-constants 1 1) ?param-quantified ?param-values-new)
+                )
+                else
+                (bind ?param-values-new (insert$ ?param-values (+ 1 (length$ ?param-values)) nil))
+                (goal-class-create-grounding ?goal-class (delete$ ?param-types 1 1) (delete$ ?param-names 1 1) ?param-names-left (delete$ ?param-constants 1 1) ?param-quantified ?param-values-new)
+            )
+        )
+        else
+        (if (not (any-factp ((?grounding pddl-grounding)) (and (eq ?grounding:formula-root ?goal-class) (eq ?grounding:param-values ?param-values))))
+            then
+            (bind ?grounding-id (sym-cat "grounding-" ?goal-class "-" (gensym*)))
+            (assert (pddl-grounding (param-names ?param-names-left)
+                                    (param-values ?param-values)
+                                    (formula-root ?goal-class)
+                                    (id ?grounding-id)
+                    )
+            )
+        )
+    )
+)
+
+(defrule goal-class-grounding
+    (domain-facts-loaded)
+    (goal-class (class ?class-id)
+                (param-names $?param-names)
+                (param-constants $?param-constants)
+                (param-types $?param-types)
+                (param-quantified $?param-quantified)
+    )
+
+    (pddl-formula (part-of ?class-id) (id ?formula-id))
+
+    (or
+        (and
+            (domain-object (name ?object) (type ?type&:
+                        (and
+                            (member$ ?type ?param-types)
+                            (eq (nth$ (member$ ?type ?param-types) ?param-constants) nil)
+                        ))
+            )
+
+            (not
+                (and
+                    (pddl-grounding (id ?grounding-id) (param-names $?param-names) (param-values $? ?object $?))
+                    (grounded-pddl-formula (formula-id ?formula-id) (grounding ?grounding-id))
+                )
+            )
+        )
+        (not
+            (and
+                (pddl-grounding (id ?grounding-id))
+                (grounded-pddl-formula (formula-id ?formula-id) (grounding ?grounding-id))
+            )
+        )
+    )
+    =>
+    (goal-class-create-grounding ?class-id ?param-types ?param-names ?param-names ?param-constants ?param-quantified (create$ ))
+)

--- a/src/plugins/clips-executive/clips/init.clp
+++ b/src/plugins/clips-executive/clips/init.clp
@@ -11,7 +11,7 @@
   ?*CONFIG_PREFIX* = "/clips-executive"
   ?*AGENT_PREFIX* = "/fawkes/agent"
 	?*INIT-STAGES* = (create$ STAGE-1 STAGE-2 STAGE-3)
-	?*CX-STAGE2-FILES* = (create$ "plan.clp" "goal.clp" "domain.clp"
+	?*CX-STAGE2-FILES* = (create$ "plan.clp" "goal.clp" "domain.clp" "goal-class.clp"
 	                              "worldmodel.clp" "cx-identity.clp"  "wm-domain-sync.clp"
 	                              "wm-config.clp" "BATCH|skills.clp")
 	?*CX-USER-INIT-OFFSET* = 10

--- a/src/plugins/clips-executive/clips/wm-domain-sync.clp
+++ b/src/plugins/clips-executive/clips/wm-domain-sync.clp
@@ -455,6 +455,20 @@
 	)
 )
 
+(defrule wm-sync-domain-reference-updated
+	"If the wm-fact is newer than the reference in the sync-map entry, but no object
+	of the specified type exists, update the reference. This inconsistency is caused
+	by a robmem update to the wm-fact that does not change its contents. "
+	(declare (salience ?*SALIENCE-WM-SYNC-ADD*))
+	?wm <- (wm-sync-map-object-type (wm-fact-id ?id) (wm-fact-idx ?wf-idx)
+																	(domain-object-type ?type))
+	?wf <- (wm-fact (id ?id) (type SYMBOL) (is-list TRUE) (values ))
+	(not (domain-object (name ?name) (type ?type)))
+	(test (> (fact-index ?wf) ?wf-idx))
+	=>
+	(modify ?wm (wm-fact-idx (fact-index ?wf)))
+)
+
 (defrule wm-sync-domain-object-added
 	"For a recently added domain objects, add a wm-fact."
   (declare (salience ?*SALIENCE-WM-SYNC-ADD*))

--- a/src/plugins/clips-pddl-parser/clips_pddl_parser_feature.cpp
+++ b/src/plugins/clips-pddl-parser/clips_pddl_parser_feature.cpp
@@ -133,12 +133,8 @@ PDDLCLIPSFeature::parse_domain(std::string env_name, std::string domain_file)
 		                  ")");
 	}
 	for (auto &constant : domain.constants) {
-		string type_string = "";
-		for (auto &param : constant.second) {
-			type_string += param;
-		}
 		for (auto &param : constant.first) {
-			env.assert_fact("(domain-constant (value " + param + ") (type " + type_string + "))");
+			env.assert_fact("(domain-constant (value " + param + ") (type " + constant.second + "))");
 		}
 	}
 

--- a/src/plugins/clips-pddl-parser/clips_pddl_parser_feature.cpp
+++ b/src/plugins/clips-pddl-parser/clips_pddl_parser_feature.cpp
@@ -132,6 +132,15 @@ PDDLCLIPSFeature::parse_domain(std::string env_name, std::string domain_file)
 		                + ")"
 		                  ")");
 	}
+	for (auto &constant : domain.constants) {
+		string type_string = "";
+		for (auto &param : constant.second) {
+			type_string += param;
+		}
+		for (auto &param : constant.first) {
+			env.assert_fact("(domain-constant (value " + param + ") (type " + type_string + "))");
+		}
+	}
 
 	for (auto &action : domain.actions) {
 		string params_string = "(param-names";

--- a/src/plugins/clips-pddl-parser/precondition_visitor.cpp
+++ b/src/plugins/clips-pddl-parser/precondition_visitor.cpp
@@ -56,25 +56,34 @@ PreconditionToCLIPSFactVisitor::operator()(pddl_parser::QuantifiedFormula &q) co
 	std::stringstream        typestream;
 	std::stringstream        namestream;
 
-	std::stringstream        identifierstream;
+	std::stringstream identifierstream;
 	identifierstream << parent_ << sub_counter_;
 	std::string id = identifierstream.str();
 
-	for(const auto& value:q.args) {
+	for (const auto &value : q.args) {
 		typestream << value.second << " ";
 		namestream << value.first << " ";
 	}
 	res.push_back(std::string("(pddl-formula "
-								" (id " + id +") "
-								" (part-of " + parent_ +") "
-								" (type " + q.quantifier  + ") "
-								"(quantified-names "+namestream.str()+") "
-								"(quantified-types "+typestream.str()+"))"
+	                          " (id "
+	                          + id
+	                          + ") "
+	                            " (part-of "
+	                          + parent_
+	                          + ") "
+	                            " (type "
+	                          + q.quantifier
+	                          + ") "
+	                            "(quantified-names "
+	                          + namestream.str()
+	                          + ") "
+	                            "(quantified-types "
+	                          + typestream.str() + "))"
 
-	));
+	                          ));
 
 	std::vector<std::string> args =
-		boost::apply_visitor(PreconditionToCLIPSFactVisitor(id, 1), q.sub_expr.expression);
+	  boost::apply_visitor(PreconditionToCLIPSFactVisitor(id, 1), q.sub_expr.expression);
 	res.insert(res.end(), args.begin(), args.end());
 
 	return res;

--- a/src/plugins/clips-pddl-parser/precondition_visitor.cpp
+++ b/src/plugins/clips-pddl-parser/precondition_visitor.cpp
@@ -52,8 +52,32 @@ PreconditionToCLIPSFactVisitor::PreconditionToCLIPSFactVisitor(const std::string
 std::vector<std::string>
 PreconditionToCLIPSFactVisitor::operator()(pddl_parser::QuantifiedFormula &q) const
 {
-	throw pddl_parser::PddlParserException("QuantifiedFormulas are not supported in CLIPS yet.");
-	return {};
+	std::vector<std::string> res;
+	std::stringstream        typestream;
+	std::stringstream        namestream;
+
+	std::stringstream        identifierstream;
+	identifierstream << parent_ << sub_counter_;
+	std::string id = identifierstream.str();
+
+	for(const auto& value:q.args) {
+		typestream << value.second << " ";
+		namestream << value.first << " ";
+	}
+	res.push_back(std::string("(pddl-formula "
+								" (id " + id +") "
+								" (part-of " + parent_ +") "
+								" (type " + q.quantifier  + ") "
+								"(quantified-names "+namestream.str()+") "
+								"(quantified-types "+typestream.str()+"))"
+
+	));
+
+	std::vector<std::string> args =
+		boost::apply_visitor(PreconditionToCLIPSFactVisitor(id, 1), q.sub_expr.expression);
+	res.insert(res.end(), args.begin(), args.end());
+
+	return res;
 }
 
 /** Translate an Atom into a vector of strings.


### PR DESCRIPTION
This PR introduces/extends three concepts in the CX: quantified formulas, PDDL constants, goal-classes.

The first two extensions cover functionality related to the handling of PDDL domains in the CX:
- **Quantified formulas** (as defined in the ADL subset of PDDL) are now supported in the `clips-pddl-parser`-plugin. Quantifiers are treated as nodes in the formula tree. They operate over the current world, i.e. a quantified variable is always grounded against the entire set of `domain-objects` of its type.  When a formula contains a quantifier and is grounded, the subtree under the quantifier is duplicated for each possible assignment of a value from the current state of the domain. This is required to evaluate a grounded subtree against only one common variable assignment. The existing set of subtrees under a quantifier is watched for changes in the domain. Should an object be added, new copies of the subtree are created. When an object is removed, the corresponding subtrees are removed as well. The quantifier `forall` is evaluated like a conjunction, when all grounded subtrees are satisfied, the node representing the quantifier is satisfied. Similarly, the quantifier `exists` is handled like a disjunction of the grounded subtrees. 
- **PDDL constants** are now supported in the CX. In a PDDL domain description, a set of constants of certain types can be defined. However, these were not parsed into the CLIPS domain even though they are interested int he context of quantifiers and free variables to handle special instances of certain types. A new deftemplate `domain-constant` is therefore added, which is similar to `domain-object`. The clips-pddl-parser`-plugin is also updated accordingly. 

The third addition -- which required both of the above extensions in practical application -- is the **goal-class** fact template. To enable proper support for more kinds of reasoning (e.g. promises), it was deemed necessary to formulate the preconditions for goal-formulation -- at least in parts -- in PDDL. This new template is meant to represent an ungrounded instance of a goal as an object in the world instead of just a rule in CLIPS. It contains slots for meta information necessary for goal creation (type, sub-type), slots for defining its effects and precondition in PDDL, and slots to define parameters. A simple goal-class might look like this:
```
(goal-class (class CLEAR-MPS)
            (id CLEAR-MPS)
            (type ACHIEVE)
            (sub-type SIMPLE)
            (param-names     robot  rs  wp)
            (param-constants ?robot nil nil)
            (param-types     robot  rs  workpiece)
            (param-quantified)
            (preconditions "
                (and
                    (can-hold ?robot)
                    (not (mps-state ?rs BROKEN))
                    (wp-at ?wp ?rs OUTPUT)
                    (wp-cap-color ?wp CAP_NONE)
                    (wp-for-order ?wp ?order)
                    (order-out-of-delivery ?order)
                )
            ")
            (effects "")
)
```
Here a goal-class fact for the `CLEAR-MPS` class is created. The precondition is formulated in PDDL and contains the variables `?robot` (of type robot), `?rs` (of type rs), and `?wp` (of type workpiece). The formula is grounded against all free variables. A variable is a free variable if its corresponding slot in param-constants is `nil` and if it is not quantified in the formula. For the variable robot, you can see that a CLIPS variable is used to define it as a constant, but in the context of a certain environment. In the case of the decentralized agent, `?robot` might be bound to the instance of the self fact. This use of parameterizable constants allows for a reduction of the grounding space and thus performance improvements. Through it, we can also omit grounding of variables for which we only care about certain instances (e.g. orders, workpieces, or robots as above). Additionally, constants within the PDDL formula can be used as normal. 
