### PR TITLE
pddl-planner: add support for POPF

### DIFF
--- a/src/plugins/pddl-planner/pddl-planner_thread.h
+++ b/src/plugins/pddl-planner/pddl-planner_thread.h
@@ -78,6 +78,7 @@ private:
 	void                     ff_planner();
 	void                     fd_planner();
 	void                     dbmp_planner();
+	void                     popf_planner();
 	bsoncxx::document::value BSONFromActionList();
 	static size_t            find_nth_space(const std::string &s, size_t nth);
 	void                     print_action_list();


### PR DESCRIPTION
Call the PDDL planner POPF and parse its result. Use std::regex to parse
the result to get rid of the action timestamps, which we currently do
not use.