### PR TITLE
clips-pddl-parser: add primitive support for durative actions

### DIFF
--- a/src/plugins/clips-pddl-parser/precondition_visitor.cpp
+++ b/src/plugins/clips-pddl-parser/precondition_visitor.cpp
@@ -20,6 +20,8 @@
 
 #include "precondition_visitor.h"
 
+#include "core/exception.h"
+
 #include <pddl_parser/pddl_exception.h>
 
 /** @class PreconditionToCLIPSFactVisitor "precondition_visitor.h"
@@ -111,6 +113,18 @@ PreconditionToCLIPSFactVisitor::operator()(pddl_parser::Predicate &p) const
 			res.insert(res.end(), args.begin(), args.end());
 		}
 		return res;
+	} else if (p.function == "at start" || p.function == "over all" || p.function == "at end") {
+		// This is a temporal condition. We ignore the temporal aspect for now and just use the sub-expression.
+		if (p.arguments.size() != 1) {
+			throw fawkes::Exception(
+			  "Unexpected number of sub-formulas (%zu) of temporal formula, expected exactly 1",
+			  p.arguments.size());
+		}
+
+		auto sub_expr = boost::apply_visitor(PreconditionToCLIPSFactVisitor(parent_, sub_counter_),
+		                                     p.arguments[0].expression);
+		res.insert(res.end(), sub_expr.begin(), sub_expr.end());
+		return res;
 	} else {
 		// We expect p.function to be a predicate name.
 		std::string new_parent;
@@ -138,11 +152,16 @@ PreconditionToCLIPSFactVisitor::operator()(pddl_parser::Predicate &p) const
 		}
 		std::string params    = "";
 		std::string constants = "";
-		for (auto &p : p.arguments) {
+		for (auto &arg : p.arguments) {
 			std::vector<std::string> p_strings =
-			  boost::apply_visitor(PreconditionToCLIPSFactVisitor(name, 0), p.expression);
+			  boost::apply_visitor(PreconditionToCLIPSFactVisitor(name, 0), arg.expression);
 			if (p_strings.size() != 1) {
-				throw pddl_parser::PddlParserException("Unexpected parameter length, expected exactly one");
+				throw fawkes::Exception(
+				  "Parser error: Unexpected parameter length (%zu) while parsing predicate parameter in "
+				  "precondition %s, expected exactly one parameter. Is '%s' really a domain predicate?",
+				  p_strings.size(),
+				  name.c_str(),
+				  p.function.c_str());
 			}
 			std::string p_string = p_strings[0];
 			if (p_string[0] == '?') {


### PR DESCRIPTION
As we do not actually have support for durative actions yet, ignore the
temporal aspects of the action's preconditions and effects, and instead
just parse them the same way as primitive actions. In particular, this
means that we ignore the temporal operators 'at start', 'over all', and
'at end'.