### PR TITLE
fix resource locks interfering with different goals

### DIFF
--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -132,6 +132,8 @@
               (required-resources $?req)
               (acquired-resources $?acq
                 &:(member$ (mutex-to-resource ?n) (set-diff ?req ?acq))))
+  (resource-request (resource ?resource&:(eq ?resource (mutex-to-resource ?n)))
+                    (goal ?goal-id))
   ; We cannot abort a pending request. Thus, we first need to wait to get
   ; responses for all requested locks.
   (not (mutex (name ?on&:(member$ (mutex-to-resource ?on) ?req))

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -57,7 +57,7 @@
       (printout warn "Locking resource " ?res crlf)
     )
     (mutex-try-lock-async (resource-to-mutex ?res))
-		(assert (resource-request (goal ?goal-id) (resource ?res)))
+    (assert (resource-request (goal ?goal-id) (resource ?res)))
   )
 )
 
@@ -110,7 +110,7 @@
 )
 
 (defrule resource-locks-lock-acquired
-	(resource-request (resource ?res) (goal ?goal-id))
+  (resource-request (resource ?res) (goal ?goal-id))
   ?m <- (mutex (name ?n&:(eq ?n (resource-to-mutex ?res)))
                (request LOCK) (response ACQUIRED))
   ?g <- (goal (mode COMMITTED) (id ?goal-id)
@@ -172,7 +172,7 @@
          (eq ?request:goal ?goal-id)
          (eq ?request:resource (mutex-to-resource ?om:name)))
     (modify ?om (request NONE) (response NONE) (error-msg ""))
-		(retract ?request)
+    (retract ?request)
   )
 )
 

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -75,8 +75,12 @@
   ; it was either locked by someone else or for a different goal.
   (mutex (name ?n&:(member$ (mutex-to-resource ?n) ?req))
          (state LOCKED) (request NONE) (locked-by ?locker&~?identity))
-  (not (mutex (name ?n1&:(member$ (mutex-to-resource ?n1) ?req))
-              (request ~NONE)))
+  (not (and (mutex (name ?n1&:(member$ (mutex-to-resource ?n1) ?req))
+              (request ~NONE))
+            (resource-request (goal ?goal-id) (resource ?resource&:
+                              (eq ?resource (mutex-to-resource ?n1))))
+       )
+  )
   =>
   (if (neq ?verbosity QUIET) then
     (printout warn "Rejecting goal " ?goal-id ", " (mutex-to-resource ?n)

--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -169,6 +169,7 @@
   (delayed-do-for-all-facts
     ((?om mutex) (?request resource-request))
     (and (or (eq ?om:response REJECTED) (eq ?om:response ERROR))
+         (eq ?request:goal ?goal-id)
          (eq ?request:resource (mutex-to-resource ?om:name)))
     (modify ?om (request NONE) (response NONE) (error-msg ""))
 		(retract ?request)


### PR DESCRIPTION
This PR addresses an issue that arises, when multiple goals have overlapping required resources.
In particular, one must take care when rejecting and cleaning up goals in that scenario, so that all COMMITTED goals are properly processed.
A problem this PR fixes follows the following pattern:
1. Goal A and B are `COMMITTED`, both require resource R
2. A requests resource R and asserts corrsponding `resource-request`
3. Request of A fails
4. B reacts on failed lock-request of A, gets rejected and cleans up mutex of R (despite not being the issuer of the `resource-request`)
5. A still has not processed the request, therefore it gets stuck