### PR TITLE
clips-executive: release lock if we suddenly become the owner

### DIFF
--- a/src/plugins/clips-executive/clips/coordination-mutex.clp
+++ b/src/plugins/clips-executive/clips/coordination-mutex.clp
@@ -443,11 +443,11 @@
 		(do-for-fact ((?m mutex)) (eq ?m:name ?id)
       (if ?locked then
         (if (eq ?locked-by (cx-identity)) then
-          (if (or (eq ?m:request LOCK) (eq ?m:request RENEW-LOCK)) then
+          (if (or (eq ?m:request LOCK) (and (eq ?m:request RENEW-LOCK) (eq ?locked-by ?m:locked-by))) then
             ; Mutex is locked by us and we requested it, all good.
             (modify ?m (response ACQUIRED))
            else
-             (if (eq ?m:state OPEN) then
+             (if (or (eq ?m:state OPEN) (neq ?locked-by ?m:locked-by))  then
                ; Mutex is newly locked by us but we never requested it.
                (printout error "Acquired a mutex without a request,"
                                " releasing the mutex again!" crlf)


### PR DESCRIPTION
We encountered a case, where the local mutex fact was saying that
another robot held the lock, hence the own mutex request was rejected.
After the rejection went through we finally got the update about the
request that was sent asynchronously (prior to the requection).
Hence the mutex fact changed from
(mutex (state LOCKED) (locked-by "other") (request NONE)
to
(mutex (state LOCKED) (locked-by "us") (request NONE)
which is of course not wanted.

```
 14:02:48.340853 CLIPS (executive): FIRE   25 mutex-trigger-event: f-1906,f-65681,*
D 14:02:48.340873 CLIPS (executive): Trigger: { "_id" : { "_data" : "8262459867000000252B022C0100296E5A100490B566345E5A4E9EB31BF9DC848E6F9A463C5F6964003C7265736F757263652D50524F4D4953452D432D5253312D4F5554505554000004" }, "operationType" : "update", "clusterTime" : { "$timestamp" : { "t" : 1648728167, "i" : 37 } }, "fullDocument" : { "_id" : "resource-PROMISE-C-RS1-OUTPUT", "locked" : true, "lock-time" : { "$date" : 1648728167656 }, "locked-by" : "Set" }, "ns" : { "db" : "robmem_coordination", "coll" : "mutex" }, "documentKey" : { "_id" : "resource-PROMISE-C-RS1-OUTPUT" }, "updateDescription" : { "updatedFields" : { "locked" : false }, "removedFields" : [ "lock-time", "locked-by" ] } }
D 14:02:48.340906 CLIPS (executive): <== f-63573 (mutex (name resource-PROMISE-C-RS1-OUTPUT) (state LOCKED) (locked-by "Upsilan") (lock-time 1648728167 626000) (request NONE) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 14:02:48.340913 CLIPS (executive): ==> f-65710 (mutex (name resource-PROMISE-C-RS1-OUTPUT) (state LOCKED) (locked-by "Set") (lock-time 1648728167 656000) (request NONE) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))

```