### PR TITLE
clips-executive: wait for pending mutex requests before aborting goals

### DIFF
--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -160,6 +160,8 @@
   ; We also need to release all acquired mutexes before rejecting the goal.
   (not (mutex (name ?ores&:(member$ (mutex-to-resource ?ores) ?req))
               (response PENDING|ACQUIRED)))
+  (not (mutex (name ?ores&:(member$ (mutex-to-resource ?ores) ?req))
+              (request LOCK)))
   =>
   (if (neq ?verbosity QUIET) then
     (printout warn "Rejecting goal " ?goal-id ", resource lock "


### PR DESCRIPTION
Previously we only waited for responses...

Here is a part of a lock, where we found this problem (notice how `f-86857` still has a lock request at the time the goal is rejected, this leads to a dangling `resource-request` fact):
```
W 13:44:46.983850 CLIPS (executive): Locking resource PROMISE-C-RS2                                                   
D 13:44:46.983870 CLIPS (executive): <== f-82772 (mutex (name resource-PROMISE-C-RS2) (state OPEN) (locked-by "") (lock-time 0 0) (request NONE) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 13:44:46.983878 CLIPS (executive): ==> f-86857 (mutex (name resource-PROMISE-C-RS2) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 13:44:46.983899 CLIPS (executive): ==> f-86858 (resource-request (resource PROMISE-C-RS2) (goal MOUNT-NEXT-RING-gen14427))
W 13:44:46.983919 CLIPS (executive): Locking resource PROMISE-C-RS2-OUTPUT      
D 13:44:46.983944 CLIPS (executive): <== f-86853 (mutex (name resource-PROMISE-C-RS2-OUTPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 13:44:46.983952 CLIPS (executive): ==> f-86859 (mutex (name resource-PROMISE-C-RS2-OUTPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response ERROR) (auto-renew TRUE) (error-msg "Mutex resource-PROMISE-C-RS2-OUTPUT already has pending LOCK request. This may lead to unpredictable behavior on both sides!"))           
D 13:44:46.984001 CLIPS (executive): FIRE  119 mutex-print-error: f-86859                          
W 13:44:46.984008 CLIPS (executive): Mutex resource-PROMISE-C-RS2-OUTPUT (request LOCK, locked by '') reported an error: Mutex resource-PROMISE-C-RS2-OUTPUT already has pending LOCK request. This may lead to unpredictable behavior on both sides!
D 13:44:46.984013 CLIPS (executive): FIRE  120 resource-locks-lock-rejected-release-acquired-resources: f-86859,f-86850,f-86854,*
D 13:44:46.984105 CLIPS (executive): FIRE  121 resource-locks-reject-goal-on-rejected-lock: f-86859,f-86850,*
```
The problem that grew from this was the dangling resource-request fact that prevents future goals from requesting locks.

https://github.com/fawkesrobotics/fawkes/blob/4b5ea7027d30d621b3d9e606f9a874e17376b405/src/plugins/clips-executive/clips/resource-locks.clp#L41-L62