### PR TITLE
clips-executive: Properly clean up mutex responses and requests on fast reject

### DIFF
--- a/src/plugins/clips-executive/clips/resource-locks.clp
+++ b/src/plugins/clips-executive/clips/resource-locks.clp
@@ -168,8 +168,7 @@
   (modify ?g (mode FINISHED) (outcome REJECTED) (message ?err))
   (delayed-do-for-all-facts
     ((?om mutex) (?request resource-request))
-    (and (or (eq ?om:response REJECTED) (eq ?om:response ERROR))
-         (eq ?request:goal ?goal-id)
+    (and (eq ?request:goal ?goal-id)
          (eq ?request:resource (mutex-to-resource ?om:name)))
     (modify ?om (request NONE) (response NONE) (error-msg ""))
     (retract ?request)


### PR DESCRIPTION
The only problematic case that should not be cleaned up is when a mutex
has a pending or acquired response (as then we would need for a trigger). This is
already excluded through the precondition.

In particular, now the rule can clean up mutexes with request LOCK and
response NONE (which therefore did not try to lock asynchronously yet).

The problem can be nicely seen in this log snippet, where first all resource-requests are created, then an immediate response from resource PROMISE-C-RS2-OUTPUT causes the fast rejection to trigger while all other mutexes have request LOCK and response NONE:
```
D 01:21:44.356736 CLIPS (executive): FIRE  813 resource-locks-request-lock: f-43741,*,*,*
W 01:21:44.356750 CLIPS (executive): Locking resource PROMISE-C-RS2-INPUT       
D 01:21:44.356778 CLIPS (executive): <== f-42636 (mutex (name resource-PROMISE-C-RS2-INPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request NONE) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356786 CLIPS (executive): ==> f-43742 (mutex (name resource-PROMISE-C-RS2-INPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356801 CLIPS (executive): ==> f-43743 (resource-request (resource PROMISE-C-RS2-INPUT) (goal MOUNT-NEXT-RING-gen8473))
W 01:21:44.356810 CLIPS (executive): Locking resource PROMISE-C-RS2-OUTPUT      
D 01:21:44.356827 CLIPS (executive): <== f-42632 (mutex (name resource-PROMISE-C-RS2-OUTPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request NONE) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356834 CLIPS (executive): ==> f-43744 (mutex (name resource-PROMISE-C-RS2-OUTPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356843 CLIPS (executive): ==> f-43745 (resource-request (resource PROMISE-C-RS2-OUTPUT) (goal MOUNT-NEXT-RING-gen8473))
W 01:21:44.356852 CLIPS (executive): Locking resource PROMISE-WP-601783484      
D 01:21:44.356869 CLIPS (executive): <== f-42634 (mutex (name resource-PROMISE-WP-601783484) (state OPEN) (locked-by "") (lock-time 0 0) (request NONE) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356876 CLIPS (executive): ==> f-43746 (mutex (name resource-PROMISE-WP-601783484) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356886 CLIPS (executive): ==> f-43747 (resource-request (resource PROMISE-WP-601783484) (goal MOUNT-NEXT-RING-gen8473))
W 01:21:44.356896 CLIPS (executive): Locking resource PROMISE-C-RS2             
D 01:21:44.356913 CLIPS (executive): <== f-42633 (mutex (name resource-PROMISE-C-RS2) (state OPEN) (locked-by "") (lock-time 0 0) (request NONE) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356920 CLIPS (executive): ==> f-43748 (mutex (name resource-PROMISE-C-RS2) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356931 CLIPS (executive): ==> f-43749 (resource-request (resource PROMISE-C-RS2) (goal MOUNT-NEXT-RING-gen8473))
W 01:21:44.356942 CLIPS (executive): Locking resource PROMISE-C-RS2-OUTPUT      
D 01:21:44.356963 CLIPS (executive): <== f-43744 (mutex (name resource-PROMISE-C-RS2-OUTPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.356970 CLIPS (executive): ==> f-43750 (mutex (name resource-PROMISE-C-RS2-OUTPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response ERROR) (auto-renew TRUE) (error-msg "Mutex resource-PROMISE-C-RS2-OUTPUT already has pending LOCK request. This may lead to unpredictable behavior on both sides!"))
D 01:21:44.357011 CLIPS (executive): FIRE  814 mutex-print-error: f-43750       
W 01:21:44.357018 CLIPS (executive): Mutex resource-PROMISE-C-RS2-OUTPUT (request LOCK, locked by '') reported an error: Mutex resource-PROMISE-C-RS2-OUTPUT already has pending LOCK request. This may lead to unpredictable behavior on both sides!
D 01:21:44.357023 CLIPS (executive): FIRE  815 resource-locks-lock-rejected-release-acquired-resources: f-43750,f-43741,f-43745,*
D 01:21:44.357095 CLIPS (executive): FIRE  816 resource-locks-reject-goal-on-rejected-lock: f-43750,f-43741,*
W 01:21:44.357102 CLIPS (executive): Rejecting goal MOUNT-NEXT-RING-gen8473, resource lock PROMISE-C-RS2-OUTPUT was rejected
D 01:21:44.357118 CLIPS (executive): <== f-43741 (goal (id MOUNT-NEXT-RING-gen8473) (class MOUNT-NEXT-RING) (type ACHIEVE) (sub-type SIMPLE) (parent RUN-ONE-INTERMEDEATE-STEPS-gen8446) (mode COMMITTED) (outcome UNKNOWN) (warning) (error) (message "") (priority 94) (params robot Upsilan prev-rs C-RS2 prev-rs-side OUTPUT wp WP-601783484 rs C-RS2 ring1-color RING_ORANGE ring2-color RING_YELLOW ring3-color RING_NONE curr-ring-color RING_YELLOW ring-pos TWO rs-before ZERO rs-after ZERO rs-req ZERO order O3) (meta promised TRUE) (meta-fact 0) (meta-template nil) (required-resources PROMISE-C-RS2-INPUT PROMISE-C-RS2-OUTPUT PROMISE-WP-601783484 PROMISE-C-RS2 PROMISE-C-RS2-OUTPUT) (acquired-resources) (committed-to nil) (verbosity DEFAULT) (is-executable FALSE))
D 01:21:44.357139 CLIPS (executive): ==> f-43751 (goal (id MOUNT-NEXT-RING-gen8473) (class MOUNT-NEXT-RING) (type ACHIEVE) (sub-type SIMPLE) (parent RUN-ONE-INTERMEDEATE-STEPS-gen8446) (mode FINISHED) (outcome REJECTED) (warning) (error) (message "Mutex resource-PROMISE-C-RS2-OUTPUT already has pending LOCK request. This may lead to unpredictable behavior on both sides!") (priority 94) (params robot Upsilan prev-rs C-RS2 prev-rs-side OUTPUT wp WP-601783484 rs C-RS2 ring1-color RING_ORANGE ring2-color RING_YELLOW ring3-color RING_NONE curr-ring-color RING_YELLOW ring-pos TWO rs-before ZERO rs-after ZERO rs-req ZERO order O3) (meta promised TRUE) (meta-fact 0) (meta-template nil) (required-resources PROMISE-C-RS2-INPUT PROMISE-C-RS2-OUTPUT PROMISE-WP-601783484 PROMISE-C-RS2 PROMISE-C-RS2-OUTPUT) (acquired-resources) (committed-to nil) (verbosity DEFAULT) (is-executable FALSE))
D 01:21:44.357244 CLIPS (executive): <== f-43750 (mutex (name resource-PROMISE-C-RS2-OUTPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request LOCK) (pending-requests) (response ERROR) (auto-renew TRUE) (error-msg "Mutex resource-PROMISE-C-RS2-OUTPUT already has pending LOCK request. This may lead to unpredictable behavior on both sides!"))
D 01:21:44.357252 CLIPS (executive): ==> f-43752 (mutex (name resource-PROMISE-C-RS2-OUTPUT) (state OPEN) (locked-by "") (lock-time 0 0) (request NONE) (pending-requests) (response NONE) (auto-renew TRUE) (error-msg ""))
D 01:21:44.357258 CLIPS (executive): <== f-43745 (resource-request (resource PROMISE-C-RS2-OUTPUT) (goal MOUNT-NEXT-RING-gen8473))
```

This actually resolves the problems encountered in https://github.com/fawkesrobotics/fawkes/pull/322