### PR TITLE
buildkite: also use new podman plugin for webview builds

### DIFF
--- a/.buildkite/steps.d/20-webview-frontend.yml
+++ b/.buildkite/steps.d/20-webview-frontend.yml
@@ -6,7 +6,7 @@
       - .buildkite/build-webview-frontend
     plugins:
       - *merged-pr-plugin
-      - kennasecurity/podman#master:
+      - compono/podman#main:
           <<: *podman-plugin-base
           volumes:
             - /var/lib/buildkite-agent/npm_cache:/root/.npm


### PR DESCRIPTION
For the main build, we switched to a different plugin a while ago. Also
switch to the new plugin for the webview build.

This fixes the build failure that occurred after merging #324:
https://buildkite.com/fawkesrobotics/fawkes-build/builds/1788#2009cbba-dca9-495d-bb28-67f286df8cec