### PR TITLE
realsense: Switch from point cloud and to only rgb

### DIFF
--- a/cfg/conf.d/realsense2.yaml
+++ b/cfg/conf.d/realsense2.yaml
@@ -11,7 +11,7 @@ realsense2:
   pcl_id: "/camera/depth/points"
 
   # Shared Image Buffer ID
-  shm_image_id: "rgb_id"
+  shm_image_id: "realsense_rgb"
 
   # If true, the camera will be enabled/disabled on incoming Enable/Disable
   # messages. If false, switch messages will be ignored.

--- a/cfg/conf.d/realsense2.yaml
+++ b/cfg/conf.d/realsense2.yaml
@@ -7,8 +7,8 @@ realsense2:
   # Frame ID of the PointCloud
   frame_id: "cam_conveyor"
 
-  # ID of the PointCloud
-  pcl_id: "/camera/depth/points"
+  # Path to save images to
+  rgb_path: "/tmp/realsense_images/"
 
   # Shared Image Buffer ID
   shm_image_id: "realsense_rgb"
@@ -20,6 +20,8 @@ realsense2:
   # Desired Frame rate. Device will try deliver new frames in time.
   # 0 for don't care
   frame_rate: 30
+  rgb_width: 640
+  rgb_height: 480
 
   # Number of retries after unsuccessful polling before restarting the camera
   restart_after_num_errors: 50

--- a/cfg/conf.d/realsense2.yaml
+++ b/cfg/conf.d/realsense2.yaml
@@ -10,6 +10,9 @@ realsense2:
   # ID of the PointCloud
   pcl_id: "/camera/depth/points"
 
+  # Shared Image Buffer ID
+  shm_image_id: "rgb_id"
+
   # If true, the camera will be enabled/disabled on incoming Enable/Disable
   # messages. If false, switch messages will be ignored.
   use_switch: true

--- a/src/plugins/realsense2/Makefile
+++ b/src/plugins/realsense2/Makefile
@@ -25,7 +25,7 @@ CFLAGS  +=  $(CFLAGS_TF) $(CFLAGS_PCL) $(CFFLAGS_conveyor_pose)
 LDFLAGS +=  $(LDFLAGS_TF) $(LDFLAGS_PCL)
 
 LIBS_realsense2 = m fawkescore fawkesutils fawkesaspects fawkesbaseapp \
-                      fawkesblackboard fawkesinterface \
+                      fawkesblackboard fawkesinterface fvutils \
                       fawkespcl_utils SwitchInterface
 
 OBJS_realsense2 = realsense2_plugin.o realsense2_thread.o 

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -57,8 +57,8 @@ Realsense2Thread::init()
 	cfg_use_switch_ = config->get_bool_or_default((cfg_prefix + "use_switch").c_str(), true);
 
 	//rgb image path
-	rgb_path_ = config->get_string_or_default((cfg_prefix + "rgb_path").c_str(),
-	                                          "/tmp/realsense_images/");
+	rgb_path_ =
+	  config->get_string_or_default((cfg_prefix + "rgb_path").c_str(), "/tmp/realsense_images/");
 	//rgb camera resolution/frame rate
 	//rgb_width_      = config->get_int_or_default((cfg_prefix + "rgb_width").c_str(), 1920);
 	//rgb_height_     = config->get_int_or_default((cfg_prefix + "rgb_height").c_str(), 1080);
@@ -109,35 +109,34 @@ Realsense2Thread::loop()
 		if (rs_rgb_pipe_->poll_for_frames(&rs_rgb_data_)) {
 			error_counter_               = 0;
 			rs2::video_frame color_frame = rs_rgb_data_.first(RS2_STREAM_COLOR, RS2_FORMAT_RGB8);
-//			image_name_ =
-//			  rgb_path_ + std::to_string(name_it_) + color_frame.get_profile().stream_name() + ".png";
-//			png_writer_.set_filename(image_name_.c_str());
-//			png_writer_.set_dimensions(color_frame.get_width(), color_frame.get_height());
-//			png_writer_.set_buffer(firevision::RGB, (unsigned char *)color_frame.get_data());
-//			png_writer_.write();
+			//			image_name_ =
+			//			  rgb_path_ + std::to_string(name_it_) + color_frame.get_profile().stream_name() + ".png";
+			//			png_writer_.set_filename(image_name_.c_str());
+			//			png_writer_.set_dimensions(color_frame.get_width(), color_frame.get_height());
+			//			png_writer_.set_buffer(firevision::RGB, (unsigned char *)color_frame.get_data());
+			//			png_writer_.write();
 
-      //firevision::convert(fv_cam_->colorspace(),
-      //                    firevision::YUV422_PLANAR,
-      //                    fv_cam_->buffer(),
-      //                    image_buffer_,
-      //                    this->img_width_,
-      //                    this->img_height_);
-      //fv_cam_->dispose_buffer();
-      // convert img
-      firevision::convert(firevision::BGR,
-                          firevision::BGR,
-                          (unsigned char *)color_frame.get_data(),
-                          shm_buffer_->buffer(),
-                          rgb_width_,
-                          rgb_height_);
+			//firevision::convert(fv_cam_->colorspace(),
+			//                    firevision::YUV422_PLANAR,
+			//                    fv_cam_->buffer(),
+			//                    image_buffer_,
+			//                    this->img_width_,
+			//                    this->img_height_);
+			//fv_cam_->dispose_buffer();
+			// convert img
+			firevision::convert(firevision::RGB,
+			                    firevision::BGR,
+			                    (unsigned char *)color_frame.get_data(),
+			                    shm_buffer_->buffer(),
+			                    rgb_width_,
+			                    rgb_height_);
 
-//      firevision::CvMatAdapter::convert_image_bgr((unsigned char *)color_frame.get_data(), ipl_image_);
+			//      firevision::CvMatAdapter::convert_image_bgr((unsigned char *)color_frame.get_data(), ipl_image_);
 
-//			logger->log_info(name(), "Saving image to %s", image_name_.c_str());
+			//			logger->log_info(name(), "Saving image to %s", image_name_.c_str());
 			name_it_++;
 		} else {
 			error_counter_++;
-			logger->log_warn(name(), "Poll for rgb frames not successful ()");
 			if (error_counter_ >= restart_after_num_errors_) {
 				logger->log_warn(name(), "Polling failed, restarting device");
 				error_counter_ = 0;
@@ -252,10 +251,11 @@ Realsense2Thread::start_camera()
 		rgb_intrinsics_              = rgb_stream.get_intrinsics();
 		rs2::color_sensor rgb_sensor = rs_device_.first<rs2::color_sensor>();
 		logger->log_info(name(),
-		                 "RGB Height: %d RGB Width: %d FPS: %d PPX: %f PPY: %f FX: %f FY: %f MODEL: %i COEFFS: %f %f %f %f %f",
+		                 "RGB Height: %d RGB Width: %d FPS: %d PPX: %f PPY: %f FX: %f FY: %f MODEL: %i "
+		                 "COEFFS: %f %f %f %f %f",
 		                 rgb_intrinsics_.height,
 		                 rgb_intrinsics_.width,
-                     rgb_frame_rate_,
+		                 rgb_frame_rate_,
 		                 rgb_intrinsics_.ppx,
 		                 rgb_intrinsics_.ppy,
 		                 rgb_intrinsics_.fx,
@@ -266,10 +266,10 @@ Realsense2Thread::start_camera()
 		                 rgb_intrinsics_.coeffs[2],
 		                 rgb_intrinsics_.coeffs[3],
 		                 rgb_intrinsics_.coeffs[4]);
-    shm_buffer_ = new firevision::SharedMemoryImageBuffer(shm_id_.c_str(),
-                                                          firevision::RGB,
-                                                          rgb_width_,
-                                                          rgb_height_);
+		shm_buffer_ = new firevision::SharedMemoryImageBuffer(shm_id_.c_str(),
+		                                                      firevision::BGR,
+		                                                      rgb_width_,
+		                                                      rgb_height_);
 
 		return true;
 

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -45,14 +45,11 @@ Realsense2Thread::init()
 {
 	// set config values
 	const std::string cfg_prefix = "/realsense2/";
-	frame_id_ = config->get_string_or_default((cfg_prefix + "frame_id").c_str(), "cam_conveyor");
-	pcl_id_ = config->get_string_or_default((cfg_prefix + "pcl_id").c_str(), "/camera/depth/points");
 	switch_if_name_ =
 	  config->get_string_or_default((cfg_prefix + "switch_if_name").c_str(), "realsense2");
 	restart_after_num_errors_ =
 	  config->get_uint_or_default((cfg_prefix + "restart_after_num_errors").c_str(), 50);
 	frame_rate_  = config->get_uint_or_default((cfg_prefix + "frame_rate").c_str(), 30);
-	laser_power_ = config->get_float_or_default((cfg_prefix + "laser_power").c_str(), -1);
 
 	cfg_use_switch_ = config->get_bool_or_default((cfg_prefix + "use_switch").c_str(), true);
 
@@ -77,7 +74,6 @@ Realsense2Thread::init()
 
 	shm_id_ = config->get_string((cfg_prefix + "shm_image_id").c_str());
 
-	camera_scale_ = 1;
 	rs_context_   = new rs2::context();
 	rs_pipe_      = new rs2::pipeline();
 
@@ -118,6 +114,8 @@ Realsense2Thread::loop()
 			                    shm_buffer_->buffer(),
 			                    image_width_,
 			                    image_height_);
+			fawkes::Time now(0,0);
+			shm_buffer_->set_capture_time(&now);
 		} else {
 			error_counter_++;
 			if (error_counter_ >= restart_after_num_errors_) {

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -100,14 +100,17 @@ Realsense2Thread::loop()
 		camera_running_ = start_camera();
 		return;
 	}
+	if (cfg_use_switch_) {
+		read_switch();
+	}
 
 	// take picture
 	if (enable_camera_) {
 		if (rs_rgb_pipe_->poll_for_frames(&rs_rgb_data_)) {
 			error_counter_               = 0;
 			rs2::video_frame color_frame = rs_rgb_data_.first(RS2_STREAM_COLOR, RS2_FORMAT_RGB8);
-			image_name_ =
-			  rgb_path_ + std::to_string(name_it_) + color_frame.get_profile().stream_name() + ".png";
+//			image_name_ =
+//			  rgb_path_ + std::to_string(name_it_) + color_frame.get_profile().stream_name() + ".png";
 //			png_writer_.set_filename(image_name_.c_str());
 //			png_writer_.set_dimensions(color_frame.get_width(), color_frame.get_height());
 //			png_writer_.set_buffer(firevision::RGB, (unsigned char *)color_frame.get_data());

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -5,6 +5,7 @@
  *  Plugin created: Wed May 22 10:09:22 2019
  *
  *  Copyright  2019 Christoph Gollok
+ *             2022 Matteo Tschesche
  *
  ****************************************************************************/
 
@@ -45,11 +46,14 @@ Realsense2Thread::init()
 {
 	// set config values
 	const std::string cfg_prefix = "/realsense2/";
+	frame_id_ = config->get_string_or_default((cfg_prefix + "frame_id").c_str(), "cam_conveyor");
+	pcl_id_ = config->get_string_or_default((cfg_prefix + "pcl_id").c_str(), "/camera/depth/points");
 	switch_if_name_ =
 	  config->get_string_or_default((cfg_prefix + "switch_if_name").c_str(), "realsense2");
 	restart_after_num_errors_ =
 	  config->get_uint_or_default((cfg_prefix + "restart_after_num_errors").c_str(), 50);
-	frame_rate_ = config->get_uint_or_default((cfg_prefix + "frame_rate").c_str(), 30);
+	frame_rate_  = config->get_uint_or_default((cfg_prefix + "frame_rate").c_str(), 30);
+	laser_power_ = config->get_float_or_default((cfg_prefix + "laser_power").c_str(), -1);
 
 	cfg_use_switch_ = config->get_bool_or_default((cfg_prefix + "use_switch").c_str(), true);
 
@@ -57,10 +61,10 @@ Realsense2Thread::init()
 	rgb_path_ =
 	  config->get_string_or_default((cfg_prefix + "rgb_path").c_str(), "/tmp/realsense_images/");
 	//rgb camera resolution/frame rate
-	image_width_  = config->get_int_or_default((cfg_prefix + "rgb_width").c_str(), 640);
-	image_height_ = config->get_int_or_default((cfg_prefix + "rgb_height").c_str(), 480);
-	frame_rate_   = config->get_int_or_default((cfg_prefix + "frame_rate").c_str(), 30);
-	save_images_  = config->get_bool_or_default((cfg_prefix + "save_images").c_str(), false);
+	image_width_    = config->get_int_or_default((cfg_prefix + "rgb_width").c_str(), 640);
+	image_height_   = config->get_int_or_default((cfg_prefix + "rgb_height").c_str(), 480);
+	rgb_frame_rate_ = config->get_int_or_default((cfg_prefix + "frame_rate").c_str(), 30);
+	save_images_    = config->get_bool_or_default((cfg_prefix + "save_images").c_str(), false);
 
 	if (cfg_use_switch_) {
 		logger->log_info(name(), "Switch enabled");
@@ -72,10 +76,22 @@ Realsense2Thread::init()
 	switch_if_->set_enabled(true);
 	switch_if_->write();
 
+	camera_scale_ = 1;
+	// initalize pointcloud
+	realsense_depth_refptr_           = new Cloud();
+	realsense_depth_                  = pcl_utils::cloudptr_from_refptr(realsense_depth_refptr_);
+	realsense_depth_->header.frame_id = frame_id_;
+	realsense_depth_->width           = 0;
+	realsense_depth_->height          = 0;
+	realsense_depth_->resize(0);
+	pcl_manager->add_pointcloud(pcl_id_.c_str(), realsense_depth_refptr_);
+
+	rs_pipe_    = new rs2::pipeline();
+	rs_context_ = new rs2::context();
+
 	shm_id_ = config->get_string((cfg_prefix + "shm_image_id").c_str());
 
-	rs_context_ = new rs2::context();
-	rs_pipe_    = new rs2::pipeline();
+	rgb_rs_pipe_ = new rs2::pipeline();
 
 	name_it_ = 0;
 }
@@ -93,9 +109,9 @@ Realsense2Thread::loop()
 
 	// take picture
 	if (enable_camera_) {
-		if (rs_pipe_->poll_for_frames(&rs_data_)) {
-			error_counter_               = 0;
-			rs2::video_frame color_frame = rs_data_.first(RS2_STREAM_COLOR, RS2_FORMAT_RGB8);
+		if (rgb_rs_pipe_->poll_for_frames(&rgb_rs_data_)) {
+			rgb_error_counter_           = 0;
+			rs2::video_frame color_frame = rgb_rs_data_.first(RS2_STREAM_COLOR, RS2_FORMAT_RGB8);
 			fawkes::Time     now(clock);
 
 			// set image in shared memory
@@ -117,13 +133,56 @@ Realsense2Thread::loop()
 				name_it_++;
 			}
 		} else {
-			error_counter_++;
-			if (error_counter_ >= restart_after_num_errors_) {
+			rgb_error_counter_++;
+			if (rgb_error_counter_ >= restart_after_num_errors_) {
 				logger->log_warn(name(), "Polling failed, restarting device");
-				error_counter_ = 0;
+				rgb_error_counter_ = 0;
 				stop_camera();
 				start_camera();
 			}
+		}
+	}
+
+	if (cfg_use_switch_) {
+		read_switch();
+	}
+
+	if (enable_camera_ && !depth_enabled_) {
+		enable_depth_stream();
+		return;
+	} else if (!enable_camera_ && depth_enabled_) {
+		disable_depth_stream();
+		return;
+	} else if (!depth_enabled_) {
+		return;
+	}
+	if (rs_pipe_->poll_for_frames(&rs_data_)) {
+		rs2::frame depth_frame = rs_data_.first(RS2_STREAM_DEPTH);
+		error_counter_         = 0;
+		const uint16_t *image  = reinterpret_cast<const uint16_t *>(depth_frame.get_data());
+		Cloud::iterator it     = realsense_depth_->begin();
+		for (int y = 0; y < intrinsics_.height; y++) {
+			for (int x = 0; x < intrinsics_.width; x++) {
+				float scaled_depth = camera_scale_ * (static_cast<float>(*image));
+				float depth_point[3];
+				float depth_pixel[2] = {static_cast<float>(x), static_cast<float>(y)};
+				rs2_deproject_pixel_to_point(depth_point, &intrinsics_, depth_pixel, scaled_depth);
+				it->x = depth_point[0];
+				it->y = depth_point[1];
+				it->z = depth_point[2];
+				++image;
+				++it;
+			}
+		}
+		pcl_utils::set_time(realsense_depth_refptr_, fawkes::Time(clock));
+	} else {
+		error_counter_++;
+		logger->log_warn(name(), "Poll for frames not successful ()");
+		if (error_counter_ >= restart_after_num_errors_) {
+			logger->log_warn(name(), "Polling failed, restarting device");
+			error_counter_ = 0;
+			stop_camera();
+			start_camera();
 		}
 	}
 }
@@ -132,8 +191,11 @@ void
 Realsense2Thread::finalize()
 {
 	stop_camera();
-	delete rs_context_;
+	delete rgb_rs_pipe_;
 	delete rs_pipe_;
+	delete rs_context_;
+	realsense_depth_refptr_.reset();
+	pcl_manager->remove_pointcloud(pcl_id_.c_str());
 	blackboard->close(switch_if_);
 }
 
@@ -147,19 +209,40 @@ Realsense2Thread::start_camera()
 		rs_pipe_->stop();
 	} catch (const std::exception &e) {
 	}
+	try {
+		rgb_rs_pipe_->stop();
+	} catch (const std::exception &e) {
+	}
 
 	try {
 		if (!get_camera(rs_device_)) {
 			return false;
 		}
+		rs2::config config;
+		config.enable_stream(RS2_STREAM_DEPTH, RS2_FORMAT_Z16, frame_rate_);
+		rs2::pipeline_profile rs_pipeline_profile_ = rs_pipe_->start(config);
+		auto                  depth_stream =
+		  rs_pipeline_profile_.get_stream(RS2_STREAM_DEPTH).as<rs2::video_stream_profile>();
+		intrinsics_              = depth_stream.get_intrinsics();
+		realsense_depth_->width  = intrinsics_.width;
+		realsense_depth_->height = intrinsics_.height;
+		realsense_depth_->resize(intrinsics_.width * intrinsics_.height);
+		rs2::depth_sensor sensor = rs_device_.first<rs2::depth_sensor>();
+		camera_scale_            = sensor.get_depth_scale();
+		logger->log_info(name(),
+		                 "Height: %d Width: %d Scale: %f FPS: %d",
+		                 intrinsics_.height,
+		                 intrinsics_.width,
+		                 camera_scale_,
+		                 frame_rate_);
 
-		rs2::config rs_config;
-		rs_config.enable_stream(
-		  RS2_STREAM_COLOR, image_width_, image_height_, RS2_FORMAT_RGB8, frame_rate_);
-		rs2::pipeline_profile rs_pipeline_profile_ = rs_pipe_->start(rs_config);
+		rs2::config rgb_rs_config;
+		rgb_rs_config.enable_stream(
+		  RS2_STREAM_COLOR, image_width_, image_height_, RS2_FORMAT_RGB8, rgb_frame_rate_);
+		rs2::pipeline_profile rgb_rs_pipeline_profile_ = rgb_rs_pipe_->start(rgb_rs_config);
 		auto                  rgb_stream =
-		  rs_pipeline_profile_.get_stream(RS2_STREAM_COLOR).as<rs2::video_stream_profile>();
-		intrinsics_                  = rgb_stream.get_intrinsics();
+		  rgb_rs_pipeline_profile_.get_stream(RS2_STREAM_COLOR).as<rs2::video_stream_profile>();
+		rgb_intrinsics_              = rgb_stream.get_intrinsics();
 		rs2::color_sensor rgb_sensor = rs_device_.first<rs2::color_sensor>();
 		logger->log_info(name(),
 		                 "RGB Height: %d RGB Width: %d FPS: %d PPX: %f PPY: %f FX: %f FY: %f MODEL: %i "
@@ -247,12 +330,86 @@ Realsense2Thread::get_camera(rs2::device &dev)
 }
 
 /*
+ * Enable the depth stream from rs_device
+ */
+void
+Realsense2Thread::enable_depth_stream()
+{
+	logger->log_info(name(), "Enable depth Stream");
+
+	try {
+		rs2::depth_sensor depth_sensor = rs_device_.first<rs2::depth_sensor>();
+		if (depth_sensor.supports(RS2_OPTION_EMITTER_ENABLED)) {
+			depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED,
+			                        1.f); // Enable emitter
+			depth_enabled_ = true;
+		} else if (depth_sensor.supports(RS2_OPTION_LASER_POWER)) {
+			if (laser_power_ == -1) {
+				rs2::option_range range = depth_sensor.get_option_range(RS2_OPTION_LASER_POWER);
+				laser_power_            = range.max;
+			}
+			logger->log_info(name(), "Enable depth stream with Laser Power: %f", laser_power_);
+			depth_sensor.set_option(RS2_OPTION_LASER_POWER, laser_power_); // Set max power
+			depth_enabled_ = true;
+		} else {
+			logger->log_warn(name(), "Enable depth stream not supported on device");
+		}
+
+	} catch (const rs2::error &e) {
+		logger->log_error(name(),
+		                  "RealSense error calling %s ( %s ):\n    %s",
+		                  e.get_failed_function().c_str(),
+		                  e.get_failed_args().c_str(),
+		                  e.what());
+		return;
+	} catch (const std::exception &e) {
+		logger->log_error(name(), "%s", e.what());
+		return;
+	}
+}
+
+/*
+ * Disable the depth stream from rs_device
+ */
+void
+Realsense2Thread::disable_depth_stream()
+{
+	logger->log_info(name(), "Disable Depth Stream");
+
+	try {
+		rs2::depth_sensor depth_sensor = rs_device_.first<rs2::depth_sensor>();
+		if (depth_sensor.supports(RS2_OPTION_EMITTER_ENABLED)) {
+			depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED,
+			                        0.f); // Disable emitter
+			depth_enabled_ = false;
+		} else if (depth_sensor.supports(RS2_OPTION_LASER_POWER)) {
+			rs2::option_range range = depth_sensor.get_option_range(RS2_OPTION_LASER_POWER);
+			depth_sensor.set_option(RS2_OPTION_LASER_POWER, range.min); // Set max power
+			depth_enabled_ = false;
+		} else {
+			logger->log_warn(name(), "Disable depth stream not supported on device");
+		}
+	} catch (const rs2::error &e) {
+		logger->log_error(name(),
+		                  "RealSense error calling %s ( %s ):\n    %s",
+		                  e.get_failed_function().c_str(),
+		                  e.get_failed_args().c_str(),
+		                  e.what());
+		return;
+	} catch (const std::exception &e) {
+		logger->log_error(name(), "%s", e.what());
+		return;
+	}
+}
+
+/*
  * Stop the device and delete the context properly
  */
 void
 Realsense2Thread::stop_camera()
 {
 	camera_running_ = false;
+	depth_enabled_  = false;
 	try {
 		rs_pipe_->stop();
 	} catch (const std::exception &e) {

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -113,7 +113,7 @@ Realsense2Thread::loop()
 
 			// set image in shared memory
 			firevision::convert(firevision::RGB,
-			                    firevision::BGR,
+			                    firevision::RGB,
 			                    (unsigned char *)color_frame.get_data(),
 			                    shm_buffer_->buffer(),
 			                    image_width_,
@@ -180,7 +180,7 @@ Realsense2Thread::start_camera()
 		                 intrinsics_.coeffs[3],
 		                 intrinsics_.coeffs[4]);
 		shm_buffer_ = new firevision::SharedMemoryImageBuffer(shm_id_.c_str(),
-		                                                      firevision::BGR,
+		                                                      firevision::RGB,
 		                                                      image_width_,
 		                                                      image_height_);
 

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -31,6 +31,7 @@
 #include <aspect/logging.h>
 #include <aspect/pointcloud.h>
 #include <core/threading/thread.h>
+#include <fvutils/writers/png.h>
 #include <librealsense2/rsutil.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -87,6 +88,8 @@ private:
 	typedef Cloud::Ptr      CloudPtr;
 	typedef Cloud::ConstPtr CloudConstPtr;
 
+	firevision::PNGWriter png_writer_;
+
 	fawkes::RefPtr<Cloud> realsense_depth_refptr_;
 	CloudPtr              realsense_depth_;
 
@@ -94,13 +97,22 @@ private:
 	rs2::context * rs_context_;
 	rs2::device    rs_device_;
 	rs2::frameset  rs_data_;
+	rs2::pipeline *rs_rgb_pipe_;
+	rs2::frameset  rs_rgb_data_;
 	rs2_intrinsics intrinsics_;
+	rs2_intrinsics rgb_intrinsics_;
 
 	float       camera_scale_;
 	std::string frame_id_;
 	std::string pcl_id_;
 	std::string switch_if_name_;
+	std::string rgb_path_;
+	std::string image_name_;
 	uint        frame_rate_;
+	int         rgb_frame_rate_;
+	int         rgb_width_;
+	int         rgb_height_;
+	int         name_it_;
 	float       laser_power_;
 	bool        camera_running_ = false;
 	bool        enable_camera_  = true;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -92,13 +92,9 @@ private:
 
 	/// firevision image buffer
 	firevision::SharedMemoryImageBuffer *shm_buffer_;
-	unsigned char *                      image_buffer_;
 	/// Image Buffer Id
 	std::string shm_id_;
 
-	float       camera_scale_;
-	std::string frame_id_;
-	std::string pcl_id_;
 	std::string switch_if_name_;
 	std::string rgb_path_;
 	std::string image_name_;
@@ -107,7 +103,6 @@ private:
 	int         image_height_;
 	bool        save_images_;
 	size_t      name_it_;
-	float       laser_power_;
 	bool        camera_running_ = false;
 	bool        enable_camera_  = true;
 	uint        restart_after_num_errors_;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -65,8 +65,6 @@ public:
 private:
 	bool start_camera();
 	bool get_camera(rs2::device &dev);
-	void enable_depth_stream();
-	void disable_depth_stream();
 	void stop_camera();
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
@@ -84,25 +82,13 @@ private:
 	fawkes::SwitchInterface *switch_if_;
 	bool                     cfg_use_switch_;
 
-	typedef pcl::PointXYZ              PointType;
-	typedef pcl::PointCloud<PointType> Cloud;
-
-	typedef Cloud::Ptr      CloudPtr;
-	typedef Cloud::ConstPtr CloudConstPtr;
-
 	firevision::PNGWriter png_writer_;
-
-	fawkes::RefPtr<Cloud> realsense_depth_refptr_;
-	CloudPtr              realsense_depth_;
 
 	rs2::pipeline *rs_pipe_;
 	rs2::context * rs_context_;
 	rs2::device    rs_device_;
 	rs2::frameset  rs_data_;
-	rs2::pipeline *rs_rgb_pipe_;
-	rs2::frameset  rs_rgb_data_;
 	rs2_intrinsics intrinsics_;
-	rs2_intrinsics rgb_intrinsics_;
 
 	/// firevision image buffer
 	firevision::SharedMemoryImageBuffer *shm_buffer_;
@@ -116,15 +102,14 @@ private:
 	std::string switch_if_name_;
 	std::string rgb_path_;
 	std::string image_name_;
-	uint        frame_rate_;
-	int         rgb_frame_rate_;
-	int         rgb_width_;
-	int         rgb_height_;
+	int         frame_rate_;
+	int         image_width_;
+	int         image_height_;
+	bool        save_images;
 	size_t      name_it_;
 	float       laser_power_;
 	bool        camera_running_ = false;
 	bool        enable_camera_  = true;
-	bool        depth_enabled_  = false;
 	uint        restart_after_num_errors_;
 	uint        error_counter_ = 0;
 };

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -35,6 +35,9 @@
 #include <librealsense2/rsutil.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
+#include <fvutils/ipc/shm_image.h>
+#include <fvutils/color/conversions.h>
+
 
 #include <librealsense2/rs.hpp>
 #include <librealsense2/rs_advanced_mode.hpp>
@@ -101,6 +104,12 @@ private:
 	rs2::frameset  rs_rgb_data_;
 	rs2_intrinsics intrinsics_;
 	rs2_intrinsics rgb_intrinsics_;
+
+  /// firevision image buffer
+  firevision::SharedMemoryImageBuffer *shm_buffer_;
+  unsigned char *                      image_buffer_;
+  /// Image Buffer Id
+  std::string shm_id_;
 
 	float       camera_scale_;
 	std::string frame_id_;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -105,7 +105,7 @@ private:
 	int         frame_rate_;
 	int         image_width_;
 	int         image_height_;
-	bool        save_images;
+	bool        save_images_;
 	size_t      name_it_;
 	float       laser_power_;
 	bool        camera_running_ = false;

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -65,6 +65,8 @@ public:
 private:
 	bool start_camera();
 	bool get_camera(rs2::device &dev);
+	void enable_depth_stream();
+	void disable_depth_stream();
 	void stop_camera();
 
 	/** Stub to see name in backtrace for easier debugging. @see Thread::run() */
@@ -82,7 +84,20 @@ private:
 	fawkes::SwitchInterface *switch_if_;
 	bool                     cfg_use_switch_;
 
+	typedef pcl::PointXYZ              PointType;
+	typedef pcl::PointCloud<PointType> Cloud;
+
+	typedef Cloud::Ptr      CloudPtr;
+	typedef Cloud::ConstPtr CloudConstPtr;
+
+	fawkes::RefPtr<Cloud> realsense_depth_refptr_;
+	CloudPtr              realsense_depth_;
+
 	firevision::PNGWriter png_writer_;
+
+	rs2::pipeline *rgb_rs_pipe_;
+	rs2::frameset  rgb_rs_data_;
+	rs2_intrinsics rgb_intrinsics_;
 
 	rs2::pipeline *rs_pipe_;
 	rs2::context * rs_context_;
@@ -90,23 +105,31 @@ private:
 	rs2::frameset  rs_data_;
 	rs2_intrinsics intrinsics_;
 
+	float       camera_scale_;
+	std::string frame_id_;
+	std::string pcl_id_;
+	std::string switch_if_name_;
+	uint        frame_rate_;
+	float       laser_power_;
+	bool        camera_running_ = false;
+	bool        enable_camera_  = true;
+	bool        depth_enabled_  = false;
+	uint        restart_after_num_errors_;
+	uint        error_counter_ = 0;
+
 	/// firevision image buffer
 	firevision::SharedMemoryImageBuffer *shm_buffer_;
 	/// Image Buffer Id
 	std::string shm_id_;
 
-	std::string switch_if_name_;
+	uint        rgb_frame_rate_;
 	std::string rgb_path_;
 	std::string image_name_;
-	int         frame_rate_;
 	int         image_width_;
 	int         image_height_;
 	bool        save_images_;
 	size_t      name_it_;
-	bool        camera_running_ = false;
-	bool        enable_camera_  = true;
-	uint        restart_after_num_errors_;
-	uint        error_counter_ = 0;
+	uint        rgb_error_counter_ = 0;
 };
 
 #endif

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -31,13 +31,12 @@
 #include <aspect/logging.h>
 #include <aspect/pointcloud.h>
 #include <core/threading/thread.h>
+#include <fvutils/color/conversions.h>
+#include <fvutils/ipc/shm_image.h>
 #include <fvutils/writers/png.h>
 #include <librealsense2/rsutil.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <fvutils/ipc/shm_image.h>
-#include <fvutils/color/conversions.h>
-
 
 #include <librealsense2/rs.hpp>
 #include <librealsense2/rs_advanced_mode.hpp>
@@ -105,11 +104,11 @@ private:
 	rs2_intrinsics intrinsics_;
 	rs2_intrinsics rgb_intrinsics_;
 
-  /// firevision image buffer
-  firevision::SharedMemoryImageBuffer *shm_buffer_;
-  unsigned char *                      image_buffer_;
-  /// Image Buffer Id
-  std::string shm_id_;
+	/// firevision image buffer
+	firevision::SharedMemoryImageBuffer *shm_buffer_;
+	unsigned char *                      image_buffer_;
+	/// Image Buffer Id
+	std::string shm_id_;
 
 	float       camera_scale_;
 	std::string frame_id_;
@@ -121,7 +120,7 @@ private:
 	int         rgb_frame_rate_;
 	int         rgb_width_;
 	int         rgb_height_;
-	int         name_it_;
+	size_t      name_it_;
 	float       laser_power_;
 	bool        camera_running_ = false;
 	bool        enable_camera_  = true;


### PR DESCRIPTION
This PR creates a shared memory buffer for the rgb images from the realsense and allows to save images.

Important details:
- The visual servoing approach requires these commits for its object detector to work.
- Visual servoing is unstable when using the save_images feature and will often drive into MPS's. If images should be captured while using visual servoing, save them in the object-tracking plugin.