### PR TITLE
cx: world model template fact rework

### DIFF
--- a/src/plugins/clips-executive/clips/test-scenario/worldmodel-facts.clp
+++ b/src/plugins/clips-executive/clips/test-scenario/worldmodel-facts.clp
@@ -63,13 +63,22 @@
   the synchronization procedure between domain facts and world model facts.
 "
   ?g <- (goal (id ?id))
-=>
-  (do-for-fact ((?goal-wm wm-fact)) (wm-key-prefix ?goal-wm:key (create$ template fact goal id ?id))
+  =>
+  (do-for-fact ((?goal-wm wm-fact)) (wm-key-prefix ?goal-wm:key (create$ template fact goal args? id ?id))
     (retract ?goal-wm)
   )
-  (assert (wm-fact (key (template-fact-to-wm-key ?g
-                                               id
-                                               (deftemplate-remaining-slots goal id)))))
+  (assert-template-wm-fact ?g
+                           id
+                           (deftemplate-remaining-slots goal id)
+  )
+)
+
+(defrule goal-remove-wm-fact
+" A goal got deleted, but the wm-fact is still around, delete it. "
+  ?wm <- (wm-fact (key template fact goal args? id ?id))
+  (not (goal (id ?id)))
+  =>
+  (retract ?wm)
 )
 
 (defrule state-robot-location

--- a/src/plugins/clips-executive/clips/wm-template-facts.clp
+++ b/src/plugins/clips-executive/clips/wm-template-facts.clp
@@ -63,7 +63,10 @@
 	; However, if the target type is a STRING, whitespaces may become a problem.
 	(if (and (neq ?type STRING) (eq (type ?value) SYMBOL))  then
 		(bind ?value (string-to-field ?value))
-		(return ?value)
+		(if (eq (type ?value) ?type)
+		 then
+			(return ?value)
+		)
 	)
 
 	(switch ?type

--- a/src/plugins/clips-executive/clips/wm-template-facts.clp
+++ b/src/plugins/clips-executive/clips/wm-template-facts.clp
@@ -20,11 +20,12 @@
 ;
 ; (defrule goal-to-wm-fact
 ;   ?g <- (goal (id ?id))
-;   (not (wm-fact (key template fact goal id ?id $?)))
+;   (not (wm-fact (key template fact goal args? id ?id)))
 ; =>
-;   (assert (wm-fact (key (template-fact-to-wm-key ?g
-;                                                  id
-;                                                  (deftemplate-remaining-slots goal id)))))
+;   (assert-template-wm-fact ?g
+;                            id
+;                            (deftemplate-remaining-slots goal id)
+;   )
 ; )
 
 (deffunction deftemplate-remaining-slots (?template ?slots)
@@ -106,33 +107,35 @@
 	(return ?res)
 )
 
-(deffunction template-fact-to-wm-key (?fact-id ?id-slots ?arg-slots)
-" Encode a fact to a wm-fact key.
+(deffunction template-fact-slots-to-key-vals (?fact-id ?arg-slots)
+" Encode fact slots to key value pairs.
 
   Slots are encoded by <slot-name> <slot-value> and slots are required to have
   a single allowed type.
   Multislots are encoded by <slot-name> [ <slot-value-type> <slot-value> ... ]
   to ensure type safety when converting back via template-fact-str-from-wm-key.
-
-  @param ?fact-id:   id of fact to encode as wm-fact key
-  @param ?id-slots:  slot names that uniquely identify facts of the template
-                     Those will be part of the base ID.
-  @param ?arg-slots: other slot names that should be captured by the wm-fact key
 "
-	(bind ?template (fact-relation ?fact-id))
-	(bind ?key (create$ template fact ?template))
-	(if (neq (type ?id-slots) MULTIFIELD) then (bind ?id-slots (create$ ?id-slots)))
-	(bind ?key (append$ ?key (slots-to-multifield ?fact-id ?id-slots)))
+	(bind ?values (create$ ))
 	(if (neq (type ?arg-slots) MULTIFIELD) then (bind ?arg-slots (create$ ?arg-slots)))
-
 	(if (> (length$ ?arg-slots) 0) then
-		(bind ?key (append$ ?key args?))
-		(bind ?key (append$ ?key (slots-to-multifield ?fact-id ?arg-slots)))
+		(bind ?values (append$ ?values (slots-to-multifield ?fact-id ?arg-slots)))
 	)
-	(return ?key)
+	(return ?values)
 )
 
-(deffunction template-fact-str-from-wm-key (?key)
+(deffunction assert-template-wm-fact (?fact-id ?id-slots ?other-slots)
+" Helper to create a wm-fact from a template fact"
+	(assert (wm-fact (key template fact (fact-relation ?fact-id)
+	                  args? (template-fact-slots-to-key-vals ?fact-id ?id-slots))
+	                 (type SYMBOL)
+	                 (is-list TRUE)
+	                 (values (template-fact-slots-to-key-vals ?fact-id ?other-slots)))
+	)
+)
+
+
+
+(deffunction template-fact-str-from-wm (?key ?values)
 " Build a fact string from a template fact wm-fact key.
 "
 	(if (eq (subseq$ ?key 1 2) (create$ template fact))
@@ -145,6 +148,7 @@
 		(if ?args-pos then
 			(bind ?key (delete$ ?key ?args-pos ?args-pos))
 		)
+		(bind ?key (append$ ?key ?values))
 		; start with the template name ...
 		(bind ?res (str-cat "(" ?template))
 		(bind ?mode SLOT)

--- a/src/plugins/clips-executive/clips/wm-template-facts.clp
+++ b/src/plugins/clips-executive/clips/wm-template-facts.clp
@@ -33,7 +33,7 @@
 	 then
 		(bind ?slots (create$ ?slots))
 	)
-	(bind ?res (deftemplate-slot-names goal))
+	(bind ?res (deftemplate-slot-names ?template))
 	(progn$ (?slot ?slots)
 		(bind ?pos (member$ ?slot ?res))
 		(bind ?res (delete$ ?res ?pos ?pos))

--- a/src/plugins/clips-executive/clips/worldmodel.clp
+++ b/src/plugins/clips-executive/clips/worldmodel.clp
@@ -143,8 +143,13 @@
 		(foreach ?p ?ps
 			(bind ?kv (wm-split-string-sym ?p "="))
 			(if (<> (length$ ?kv) 2) then
-				(printout w "Param '" ?p "' not of format name=value, ignoring" crlf)
-				(bind ?rv (append$ ?rv INVALID (sym-cat ?p)))
+				(if (eq (length$ ?kv) 1)
+				 then
+					(bind ?rv (append$ ?rv (create$ ?kv [ ])))
+				 else
+					(printout warn "Param '" ?p "' not of format name=value, ignoring" crlf)
+					(bind ?rv (append$ ?rv INVALID (sym-cat ?p)))
+				)
 			 else
 				(if (str-index "," (nth$ 2 ?kv)) then
 				 then


### PR DESCRIPTION
This PR is a followup to https://github.com/fawkesrobotics/fawkes/pull/329. When actively using the features introduced there, i realized that the enoding of wm-facts representing templates was slightly off.
Essentially, the wm-key should only contribute template slots that determine the uniqueness of facts from that template.
Other slots can simply be stored in the `values` field.

I also stumbled accross some minor bugs and imroved the code a bit. I leave this as a draft PR for a bit to test this feature more actively in the coming days.