### PR TITLE
Update to Fedora 35

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ merged-pr-plugin: &merged-pr-plugin
     mode: checkout
 
 podman-plugin-base: &podman-plugin-base
-  image: quay.io/fawkesrobotics/fawkes-builder:fedora33-noetic
+  image: quay.io/fawkesrobotics/fawkes-builder:f35
   always-pull: true
   debug: true
   privileged: true

--- a/src/libs/core/tests/test_wait_condition.cpp
+++ b/src/libs/core/tests/test_wait_condition.cpp
@@ -68,7 +68,7 @@ protected:
 			params[i]       = new thread_params();
 			params[i]->cond = cond;
 			pthread_create(&threads[i], NULL, thread_func, params[i]);
-			pthread_yield();
+			sched_yield();
 		}
 
 		usleep(1000);
@@ -99,7 +99,7 @@ start_waiter_thread(void *args)
 void *
 start_abstimed_waiter_thread(void *args)
 {
-	thread_params * params = (thread_params *)args;
+	thread_params  *params = (thread_params *)args;
 	struct timespec ts;
 	EXPECT_NE(-1, clock_gettime(CLOCK_REALTIME, &ts));
 	ts.tv_sec += 5;

--- a/src/libs/syncpoint/tests/test_syncpoint.cpp
+++ b/src/libs/syncpoint/tests/test_syncpoint.cpp
@@ -445,7 +445,7 @@ TEST_F(SyncPointManagerTest, MultipleManagerRequests)
 		params[i]->num_wait_calls = 0;
 		params[i]->sp_identifier  = sp_identifier;
 		pthread_create(&threads[i], &attrs, start_waiter_thread, params[i]);
-		pthread_yield();
+		sched_yield();
 		ASSERT_LE(manager->get_syncpoints().size(), 3u);
 	}
 
@@ -474,7 +474,7 @@ TEST_F(SyncPointManagerTest, ParallelWaitCalls)
 		params[i]->num_wait_calls = num_wait_calls;
 		params[i]->sp_identifier  = sp_identifier;
 		pthread_create(&threads[i], &attrs, start_waiter_thread, params[i]);
-		pthread_yield();
+		sched_yield();
 		ASSERT_LE(manager->get_syncpoints().size(), 3u);
 	}
 
@@ -506,7 +506,7 @@ TEST_F(SyncPointManagerTest, ParallelWaitsReturn)
 		params[i]->num_wait_calls = num_wait_calls;
 		params[i]->sp_identifier  = sp_identifier;
 		pthread_create(&threads[i], &attrs, start_waiter_thread, params[i]);
-		pthread_yield();
+		sched_yield();
 	}
 
 	for (uint i = 0; i < num_threads; i++) {
@@ -835,7 +835,7 @@ TEST_F(SyncBarrierTest, SyncBarrierHierarchy)
 	uint                  num_threads = identifiers.size();
 	pthread_t             threads[num_threads];
 	waiter_thread_params *params[num_threads];
-	Barrier *             barrier = new Barrier(num_threads + 1);
+	Barrier              *barrier = new Barrier(num_threads + 1);
 	for (uint i = 0; i < num_threads; i++) {
 		params[i]                 = new waiter_thread_params();
 		params[i]->component      = "component " + to_string(i);
@@ -1272,7 +1272,7 @@ TEST_F(SyncPointManagerTest, WaitForOneSeparateTimeoutTest)
 	sp->register_emitter("emitter1");
 	string               sp_identifier = "/test";
 	uint                 num_threads   = 2;
-	Barrier *            barrier       = new Barrier(num_threads + 2);
+	Barrier             *barrier       = new Barrier(num_threads + 2);
 	pthread_t            wait_for_one_thread;
 	waiter_thread_params wait_for_one_params;
 	wait_for_one_params.component      = "wait_for_one";

--- a/src/plugins/navgraph/rospub_thread.cpp
+++ b/src/plugins/navgraph/rospub_thread.cpp
@@ -94,7 +94,7 @@ NavGraphROSPubThread::graph_changed() noexcept
 
 void
 NavGraphROSPubThread::convert_nodes(const std::vector<fawkes::NavGraphNode> &nodes,
-                                    std::vector<fawkes_msgs::NavGraphNode> & out)
+                                    std::vector<fawkes_msgs::NavGraphNode>  &out)
 {
 	for (const NavGraphNode &node : nodes) {
 		fawkes_msgs::NavGraphNode ngn;
@@ -107,7 +107,7 @@ NavGraphROSPubThread::convert_nodes(const std::vector<fawkes::NavGraphNode> &nod
 		}
 		ngn.unconnected                                 = node.unconnected();
 		const std::map<std::string, std::string> &props = node.properties();
-		for (const auto p : props) {
+		for (const auto &p : props) {
 			fawkes_msgs::NavGraphProperty ngp;
 			ngp.key   = p.first;
 			ngp.value = p.second;
@@ -134,7 +134,7 @@ NavGraphROSPubThread::publish_graph()
 		nge.to_node                                     = edge.to();
 		nge.directed                                    = edge.is_directed();
 		const std::map<std::string, std::string> &props = edge.properties();
-		for (const auto p : props) {
+		for (const auto &p : props) {
 			fawkes_msgs::NavGraphProperty ngp;
 			ngp.key   = p.first;
 			ngp.value = p.second;
@@ -147,7 +147,7 @@ NavGraphROSPubThread::publish_graph()
 }
 
 bool
-NavGraphROSPubThread::svs_search_path_cb(fawkes_msgs::NavGraphSearchPath::Request & req,
+NavGraphROSPubThread::svs_search_path_cb(fawkes_msgs::NavGraphSearchPath::Request  &req,
                                          fawkes_msgs::NavGraphSearchPath::Response &res)
 {
 	NavGraphNode from, to;
@@ -210,7 +210,7 @@ NavGraphROSPubThread::svs_search_path_cb(fawkes_msgs::NavGraphSearchPath::Reques
 }
 
 bool
-NavGraphROSPubThread::svs_get_pwcosts_cb(fawkes_msgs::NavGraphGetPairwiseCosts::Request & req,
+NavGraphROSPubThread::svs_get_pwcosts_cb(fawkes_msgs::NavGraphGetPairwiseCosts::Request  &req,
                                          fawkes_msgs::NavGraphGetPairwiseCosts::Response &res)
 {
 	for (unsigned int i = 0; i < req.nodes.size(); ++i) {


### PR DESCRIPTION
Update buildkite to Fedora 35 and fix some remaining build issues that have not been fixed in #324.

Also switch to the new builder image in https://github.com/fawkesrobotics/docker-fawkes-builder. The old one consisted of three images built on top of each other, this one is built from scratch and makes it easier to maintain. The new images uses the same image registry, but a different tag naming scheme.