### PR TITLE
REST-API: catch non-existing precondition fact pointers

### DIFF
--- a/src/plugins/clips-executive/rest-api/clips-executive-rest-api.cpp
+++ b/src/plugins/clips-executive/rest-api/clips-executive-rest-api.cpp
@@ -840,35 +840,50 @@ ClipsExecutiveRestApi::gen_plan(const PlanKey &            plan_key,
 
 			// preconditions
 			if (get_value<std::string>(pai, "precondition") != "") {
-				pa->set_precondition(gen_pddl_grounding(pgm[get_value<std::string>(pai, "precondition")]));
-
-				std::string        grnd_name = *(pa->precondition()->id());
-				std::string        op_name   = *(pa->operator_name());
-				PDDLFormulaTreeMap grounded_parent_map;
-
-				for (const auto &p : gpfm[grnd_name]) {
-					PDDLFormulaTreeNode node =
-					  std::make_tuple(pfm[get_value<std::string>(p, "formula-id")], p);
-					grounded_parent_map[get_value<std::string>(pfm[get_value<std::string>(p, "formula-id")],
-					                                           "part-of")]
-					  .push_back(node);
+				bool                 exists = false;
+				CLIPS::Fact::pointer fact   = clips_->get_facts();
+				while (fact) {
+					CLIPS::Template::pointer tmpl = fact->get_template();
+					if (tmpl->name() == "pddl-grounding"
+					    && get_value<std::string>(fact, "id")
+					         == get_value<std::string>(pai, "precondition")) {
+						exists = true;
+						break;
+					}
+					fact = fact->next();
 				}
-				for (const auto &p : gppm[grnd_name]) {
-					PDDLFormulaTreeNode node =
-					  std::make_tuple(ppm[get_value<std::string>(p, "predicate-id")], p);
-					grounded_parent_map[get_value<std::string>(ppm[get_value<std::string>(p, "predicate-id")],
-					                                           "part-of")]
-					  .push_back(node);
-				}
+				if (exists) {
+					pa->set_precondition(
+					  gen_pddl_grounding(pgm[get_value<std::string>(pai, "precondition")]));
 
-				//get root node
-				for (const auto &rnode : grounded_parent_map[op_name]) {
-					CLIPS::Fact::pointer root_fp = std::get<0>(rnode);
-					std::string          root    = get_value<std::string>(root_fp, "id");
+					std::string        grnd_name = *(pa->precondition()->id());
+					std::string        op_name   = *(pa->operator_name());
+					PDDLFormulaTreeMap grounded_parent_map;
 
-					//recursively compute the tree and set the preconditions
-					pa->set_preconditions(std::make_shared<GroundedFormula>(
-					  gen_plan_compute_precons(rnode, grounded_parent_map, pgm)));
+					for (const auto &p : gpfm[grnd_name]) {
+						PDDLFormulaTreeNode node =
+						  std::make_tuple(pfm[get_value<std::string>(p, "formula-id")], p);
+						grounded_parent_map[get_value<std::string>(pfm[get_value<std::string>(p, "formula-id")],
+						                                           "part-of")]
+						  .push_back(node);
+					}
+					for (const auto &p : gppm[grnd_name]) {
+						PDDLFormulaTreeNode node =
+						  std::make_tuple(ppm[get_value<std::string>(p, "predicate-id")], p);
+						grounded_parent_map[get_value<std::string>(
+						                      ppm[get_value<std::string>(p, "predicate-id")], "part-of")]
+						  .push_back(node);
+					}
+
+					//get root node
+					for (const auto &rnode : grounded_parent_map[op_name]) {
+						CLIPS::Fact::pointer root_fp = std::get<0>(rnode);
+						std::string          root    = get_value<std::string>(root_fp, "id");
+
+						//recursively compute the tree and set the preconditions
+						pa->set_preconditions(std::make_shared<GroundedFormula>(
+						  gen_plan_compute_precons(rnode, grounded_parent_map, pgm)));
+					}
 				}
 			}
 


### PR DESCRIPTION
If a precondition fact for a plan-action might not exist (e.g. when only a partial view of the world-model is restored), the rest-api
can cause segfaults, as it tries to access a fact that does not exist. To prevent this, the existence of the precondition fact is checked first.