### PR TITLE
Switch to most recent clips 6.3 update

### DIFF
--- a/src/plugins/clips/aspect/clips_env_manager.cpp
+++ b/src/plugins/clips/aspect/clips_env_manager.cpp
@@ -105,7 +105,7 @@ public:
 };
 
 static int
-log_router_query(void *env, char *logical_name)
+log_router_query(void *env, const char *logical_name)
 {
 	if (strcmp(logical_name, "l") == 0)
 		return TRUE;
@@ -141,7 +141,7 @@ log_router_query(void *env, char *logical_name)
 }
 
 static int
-log_router_print(void *env, char *logical_name, char *str)
+log_router_print(void *env, const char *logical_name, const char *str)
 {
 	void        *rc     = GetEnvironmentRouterContext(env);
 	CLIPSLogger *logger = static_cast<CLIPSLogger *>(rc);

--- a/src/plugins/clips/feature_redefine_warning.cpp
+++ b/src/plugins/clips/feature_redefine_warning.cpp
@@ -102,7 +102,7 @@ private:
 };
 
 static int
-redefine_warning_router_query(void *env, char *logical_name)
+redefine_warning_router_query(void *env, const char *logical_name)
 {
 	if (strcmp(logical_name, WDIALOG) == 0)
 		return TRUE;
@@ -112,7 +112,7 @@ redefine_warning_router_query(void *env, char *logical_name)
 }
 
 static int
-redefine_warning_router_print(void *env, char *logical_name, char *str)
+redefine_warning_router_print(void *env, const char *logical_name, const char *str)
 {
 	void                       *rc     = GetEnvironmentRouterContext(env);
 	CLIPSRedefineWarningLogger *logger = static_cast<CLIPSRedefineWarningLogger *>(rc);

--- a/src/plugins/clips/rest-api/clips-rest-api.cpp
+++ b/src/plugins/clips/rest-api/clips-rest-api.cpp
@@ -20,8 +20,9 @@
  */
 
 #include "clips-rest-api.h"
-
+extern "C" {
 #include <clips/clips.h>
+}
 #include <core/threading/mutex_locker.h>
 #include <webview/rest_api_manager.h>
 


### PR DESCRIPTION
This PR addresses smaller changes necessary in order to utilize the updated clips and clipsmm packages from https://copr.fedorainfracloud.org/coprs/thofmann/clips-6.31.
Also, as the function `set_slot` is more strict in newer versions when it comes to type restrictions and the intended usage (building facts that do not exist in working memory as opposed to modifying existing facts), this PR adds some sanity checks across to detect potential misuse.