### PR TITLE
Properly clean up writer notifier when destructing a SyncInterface

### DIFF
--- a/src/plugins/bbsync/sync_listener.cpp
+++ b/src/plugins/bbsync/sync_listener.cpp
@@ -71,6 +71,9 @@ SyncInterfaceListener::SyncInterfaceListener(fawkes::Logger     *logger,
 SyncInterfaceListener::~SyncInterfaceListener()
 {
 	reader_bb_->unregister_listener(this);
+	// The listener needs an update in order to restore its bbil_maps, which
+	// is necessary in order to clean up the notifier of the second bb
+	writer_bb_->update_listener(this, BlackBoard::BBIL_FLAG_ALL);
 	writer_bb_->unregister_listener(this);
 }
 


### PR DESCRIPTION
When unregistering the sync listener for the first time, the bbil_maps
of it are cleared and an update is necessary to fill them again before
unregistering it again. Otherwise, the notifier of the second blackboard
is not properly unregistering the listener.