### PR TITLE
Reduce timeout for buildtests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
       - .buildkite/annotate
     artifact_paths:
       - tests.out.d/**/*
-    timeout_in_minutes: 45
+    timeout_in_minutes: 20
     plugins:
       - *merged-pr-plugin
       - compono/podman#main:


### PR DESCRIPTION
This PR relies on carologistics/fawkes-robotino#583 which, among other things, uses speed up simulation for speed tests.

Buildtests will run in under 15 minutes testing a pre-configured test-game for both the central and decentral agent. Thus a timeout of 20 minutes should be sufficient to detect failing/stuck tests. 