### PR TITLE
clips-executive: remove executability check from action selection

### DIFF
--- a/src/plugins/clips-executive/clips/action-selection/sequential.clp
+++ b/src/plugins/clips-executive/clips/action-selection/sequential.clp
@@ -11,7 +11,7 @@
   (goal (id ?goal-id) (mode DISPATCHED) (committed-to ?plan-id))
   (plan (id ?plan-id) (goal-id ?goal-id) (type SEQUENTIAL))
   ?pa <- (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (id ?id)
-                      (state FORMULATED) (executable TRUE))
+                      (state FORMULATED))
   (not (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (state ~FORMULATED&~FINAL)))
   (not (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (state FORMULATED) (id ?oid&:(< ?oid ?id))))
  =>

--- a/src/plugins/clips-executive/clips/action-selection/temporal.clp
+++ b/src/plugins/clips-executive/clips/action-selection/temporal.clp
@@ -19,7 +19,7 @@
   (goal (id ?goal-id) (mode DISPATCHED) (committed-to ?plan-id))
   (plan (id ?plan-id) (goal-id ?goal-id) (type TEMPORAL) (start-time $?start-time))
   ?pa <- (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (id ?id)
-                      (state FORMULATED) (executable TRUE)
+                      (state FORMULATED)
                       (dispatch-time ?dt&:(timeout ?now ?start-time ?dt)))
  =>
   (modify ?pa (state PENDING) (start-time ?now))


### PR DESCRIPTION
The executability check takes places after the selection, when an action is PENDING.