### PR TITLE
realsense2: fix for more than one camera

### DIFF
--- a/cfg/conf.d/realsense2.yaml
+++ b/cfg/conf.d/realsense2.yaml
@@ -30,3 +30,7 @@ realsense2:
   device_options:
     # Laser power from 0 - 15 as integer
     laser_power: 15
+
+  # set Serial Number to select device if more than one connected
+  serial_no: ""
+

--- a/cfg/conf.d/realsense2.yaml
+++ b/cfg/conf.d/realsense2.yaml
@@ -33,4 +33,3 @@ realsense2:
 
   # set Serial Number to select device if more than one connected
   serial_no: ""
-

--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -312,8 +312,9 @@ Realsense2Thread::get_camera(rs2::device &dev)
 					logger->log_info(name(), "RS2Option RS2_CAMERA_INFO_NAME not supported %d", 1);
 				}
 
-				std::string dev_sn = "########";
+				
 				if (dev.supports(RS2_CAMERA_INFO_SERIAL_NUMBER)) {
+					std::string dev_sn = "########";
 					dev_sn = std::string("#") + rs_device_.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
 					logger->log_info(name(), "found device with serial number: %s", dev_sn.c_str());
 					if(strcmp(rs_device_.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER), serial_no_.c_str()) == 0){

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -130,6 +130,7 @@ private:
 	bool        save_images_;
 	size_t      name_it_;
 	uint        rgb_error_counter_ = 0;
+	std::string serial_no_;
 };
 
 #endif


### PR DESCRIPTION
This enables the realsense plugin to use a certain camera based on a serial number parameter. If several cameras are connected, one can now choose which one to use.