### PR TITLE
CX: Add slots to control suspension of plans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM quay.io/fawkesrobotics/fawkes-builder:f37-ros2
 
 COPY . /workdir
 WORKDIR /workdir/build
-RUN /bin/bash -l -c "cmake ..  ; make -j doxygen ; make -j"
+RUN /bin/bash -l -c "cmake ..  ; make -j doxygen --quiet; make -j$(nproc)"
 WORKDIR /workdir
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ]

--- a/src/plugins/clips-executive/clips/action-selection/sequential.clp
+++ b/src/plugins/clips-executive/clips/action-selection/sequential.clp
@@ -9,7 +9,7 @@
 
 (defrule action-selection-sequential-select
   (goal (id ?goal-id) (mode DISPATCHED) (committed-to ?plan-id))
-  (plan (id ?plan-id) (goal-id ?goal-id) (type SEQUENTIAL))
+  (plan (id ?plan-id) (goal-id ?goal-id) (type SEQUENTIAL) (suspended FALSE))
   ?pa <- (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (id ?id)
                       (state FORMULATED))
   (not (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (state ~FORMULATED&~FINAL)))

--- a/src/plugins/clips-executive/clips/action-selection/temporal.clp
+++ b/src/plugins/clips-executive/clips/action-selection/temporal.clp
@@ -9,7 +9,7 @@
 
 (defrule action-selection-temporal-zerotime
   (goal (id ?goal-id) (mode DISPATCHED) (committed-to ?plan-id))
-  ?p <- (plan (id ?plan-id) (goal-id ?goal-id) (type TEMPORAL) (start-time 0 0))
+  ?p <- (plan (id ?plan-id) (goal-id ?goal-id) (type TEMPORAL) (start-time 0 0) (suspended FALSE))
  =>
   (modify ?p (start-time (now)))
 )
@@ -17,7 +17,7 @@
 (defrule action-selection-temporal-select
   (time $?now)
   (goal (id ?goal-id) (mode DISPATCHED) (committed-to ?plan-id))
-  (plan (id ?plan-id) (goal-id ?goal-id) (type TEMPORAL) (start-time $?start-time))
+  (plan (id ?plan-id) (goal-id ?goal-id) (type TEMPORAL) (start-time $?start-time) (suspended FALSE))
   ?pa <- (plan-action (goal-id ?goal-id) (plan-id ?plan-id) (id ?id)
                       (state FORMULATED)
                       (dispatch-time ?dt&:(timeout ?now ?start-time ?dt)))

--- a/src/plugins/clips-executive/clips/plan.clp
+++ b/src/plugins/clips-executive/clips/plan.clp
@@ -13,6 +13,8 @@
 	(slot cost (type FLOAT))
 	(slot type (type SYMBOL))
 	(multislot start-time (type INTEGER) (cardinality 2 2) (default 0 0))
+	(slot suspended (type SYMBOL) (allowed-values TRUE FALSE) (default FALSE))
+	(slot suspension-reason (type SYMBOL) (default nil))
 )
 
 ; TODO: Rename slots


### PR DESCRIPTION
Some applications of the CX might want to suspend plans during their execution. Here we add two slots to the plan fact template which allows users to implement such suspension mechanisms.