### PR TITLE
ir_sensor: added ros2 support for the IR_sensors

### DIFF
--- a/src/plugins/robotino/sensor_thread.cpp
+++ b/src/plugins/robotino/sensor_thread.cpp
@@ -37,7 +37,7 @@ using namespace fawkes;
  */
 
 /// taken from Robotino API2 DistanceSensorImpl.hpp
-const std::vector<std::pair<double, double>> VOLTAGE_TO_DIST_DPS = {{0.3, 1.0},
+const std::vector<std::pair<double, double>> VOLTAGE_TO_DIST_DPS = {{0.0, 1.0},
                                                                     {1.05, 1.0},
                                                                     {1.11, 0.12},
                                                                     {1.3, 0.10},
@@ -45,7 +45,7 @@ const std::vector<std::pair<double, double>> VOLTAGE_TO_DIST_DPS = {{0.3, 1.0},
                                                                     {1.55, 0.08},
                                                                     {1.8, 0.07},
                                                                     {2.35, 0.05},
-                                                                    {2.55, 0.04}};
+                                                                    {10.55, 0.04}};
 
 /** Constructor.
  * @param com_thread communication thread to trigger for writing data
@@ -152,9 +152,8 @@ RobotinoSensorThread::update_distances(float *voltages)
 	const size_t num_dps = VOLTAGE_TO_DIST_DPS.size();
 
 	for (int i = 0; i < NUM_IR_SENSORS; ++i) {
-		dist_m[i] = 0.;
+		dist_m[i] = 1.0;
 		// find the two enclosing data points
-
 		for (size_t j = 0; j < num_dps - 1; ++j) {
 			// This determines two points, l(eft) and r(ight) that are
 			// defined by voltage (x coord) and distance (y coord). We

--- a/src/plugins/robotino/sensor_thread.cpp
+++ b/src/plugins/robotino/sensor_thread.cpp
@@ -37,14 +37,9 @@ using namespace fawkes;
  */
 
 /// taken from Robotino API2 DistanceSensorImpl.hpp
-const std::vector<std::pair<double, double>> VOLTAGE_TO_DIST_DPS = {{0.3, 0.41},
-                                                                    {0.39, 0.35},
-                                                                    {0.41, 0.30},
-                                                                    {0.5, 0.25},
-                                                                    {0.75, 0.18},
-                                                                    {0.8, 0.16},
-                                                                    {0.95, 0.14},
-                                                                    {1.05, 0.12},
+const std::vector<std::pair<double, double>> VOLTAGE_TO_DIST_DPS = {{0.3, 1.0},
+                                                                    {1.05, 1.0},
+                                                                    {1.11, 0.12},
                                                                     {1.3, 0.10},
                                                                     {1.4, 0.09},
                                                                     {1.55, 0.08},

--- a/src/plugins/ros2/CMakeLists.txt
+++ b/src/plugins/ros2/CMakeLists.txt
@@ -35,6 +35,9 @@ set(PLUGIN_ros2-images
 set(PLUGIN_ros2-laserscan
     ON
     CACHE BOOL "Build ros2-laserscan plugin")
+set(PLUGIN_ros2-irscan
+    ON
+    CACHE BOOL "Build ros2-irscan plugin")
 set(PLUGIN_ros2-odometry
     ON
     CACHE BOOL "Build ros2-odometry plugin")
@@ -155,6 +158,25 @@ if(PLUGIN_ros2-laserscan)
     Laser1080Interface)
 else()
   plugin_disabled_message(ros2-laserscan)
+endif()
+
+if(PLUGIN_ros2-irscan)
+  add_library(ros2-irscan MODULE irscan_plugin.cpp irscan_thread.cpp)
+  depend_on_ros2(ros2-irscan)
+  depend_on_ros2_libs(ros2-irscan sensor_msgs)
+  target_link_libraries(
+    ros2-irscan
+    m
+    fawkescore
+    fawkesutils
+    fawkesaspects
+    fawkesblackboard
+    fawkesinterface
+    fawkesros2aspect
+    fvutils
+    RobotinoSensorInterface)
+else()
+  plugin_disabled_message(ros2-irscan)
 endif()
 
 if(PLUGIN_ros2-joint)

--- a/src/plugins/ros2/irscan_plugin.cpp
+++ b/src/plugins/ros2/irscan_plugin.cpp
@@ -1,0 +1,45 @@
+
+/***************************************************************************
+ *  laserscan_plugin.cpp - Exchange laser scans between Fawkes and ROS
+ *
+ *  Created: Tue May 29 19:30:47 2012
+ *  Copyright  2011-2012  Tim Niemueller [www.niemueller.de]
+ *
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "irscan_thread.h"
+
+#include <core/plugin.h>
+
+using namespace fawkes;
+
+/** Plugin exchange laser scans between Fawkes and ROS.
+ * @author Tim Niemueller
+ */
+class Ros2IrScanPlugin : public fawkes::Plugin
+{
+public:
+	/** Constructor.
+   * @param config Fawkes configuration
+   */
+	explicit Ros2IrScanPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new ROS2IrScanThread());
+	}
+};
+
+PLUGIN_DESCRIPTION("ROS IR scan exchange plugin")
+EXPORT_PLUGIN(Ros2IrScanPlugin)

--- a/src/plugins/ros2/irscan_plugin.cpp
+++ b/src/plugins/ros2/irscan_plugin.cpp
@@ -1,10 +1,9 @@
 
 /***************************************************************************
- *  laserscan_plugin.cpp - Exchange laser scans between Fawkes and ROS
+ *  irscan_plugin.cpp - Exchange irsensor data between Fawkes and ROS
  *
- *  Created: Tue May 29 19:30:47 2012
- *  Copyright  2011-2012  Tim Niemueller [www.niemueller.de]
- *
+ *  Created: Mon Jul 03 13:41:18 2012
+ *  Copyright  2023 Saurabh Borse, Tim Wendt
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify

--- a/src/plugins/ros2/irscan_thread.cpp
+++ b/src/plugins/ros2/irscan_thread.cpp
@@ -21,6 +21,7 @@
 #include "irscan_thread.h"
 
 #include <interfaces/RobotinoSensorInterface.h>
+
 #include <limits>
 
 using namespace fawkes;
@@ -41,25 +42,25 @@ ROS2IrScanThread::ROS2IrScanThread()
 void
 ROS2IrScanThread::init()
 {
-	sens_if_= blackboard->open_for_reading<RobotinoSensorInterface>("Robotino");
+	sens_if_ = blackboard->open_for_reading<RobotinoSensorInterface>("Robotino");
 
 	sens_if_->read();
 
 	std::string topname = "IrSensor_Scan";
 
-	pi.pub = node_handle->create_publisher<sensor_msgs::msg::LaserScan>(topname, 1);
+	pub = node_handle->create_publisher<sensor_msgs::msg::LaserScan>(topname, 1);
 
-	pi.msg.header.frame_id = config->get_string("/hardware/robotino/base_frame");
-	pi.msg.angle_min       = 0;
-	pi.msg.angle_max       = 2 * M_PI;
-	pi.msg.angle_increment = 0.68;
-	pi.msg.scan_time = 0.1;
-	pi.msg.range_min = 0.02;
-	pi.msg.range_max = 0.12;
+	msg.header.frame_id = config->get_string_or_default("/ros2/tf/tf_prefix", "") + "base_link";
+	msg.angle_min       = 0;
+	msg.angle_max       = 2 * M_PI;
+	msg.angle_increment = 0.68;
+	msg.scan_time       = 0.1;
+	msg.range_min       = 0.02;
+	msg.range_max       = 0.12;
 
+	bbil_add_data_interface(sens_if_);
 	blackboard->register_listener(this);
 }
-
 
 void
 ROS2IrScanThread::finalize()
@@ -68,22 +69,22 @@ ROS2IrScanThread::finalize()
 	blackboard->close(sens_if_);
 }
 
-
 void
-ROS2IrScanThread::bb_interface_data_refreshed(fawkes::Interface *interface) noexcept
+ROS2IrScanThread::bb_interface_data_refreshed(fawkes::Interface *interface) throw()
 {
-	RobotinoSensorInterface  *sensor_data_msg  = dynamic_cast<RobotinoSensorInterface *>(interface);
-	if(!sensor_data_msg)
-	return;
+	RobotinoSensorInterface *sensor_data_msg = dynamic_cast<RobotinoSensorInterface *>(interface);
+	if (!sensor_data_msg)
+		return;
 
 	sensor_data_msg->read();
 
-	PublisherInfo               &pi  = pubs_[interface->uid()];
-	sensor_msgs::msg::LaserScan &msg = pi.msg;
 	const Time *time = sensor_data_msg->timestamp();
-	msg.header.stamp    = rclcpp::Time(time->get_sec(), time->get_nsec());
-	memcpy(&msg.ranges[0], sensor_data_msg->distance(), 9 * sizeof(float));
-
-	pi.pub->publish(pi.msg);
-	
+	msg.header.stamp = rclcpp::Time(time->get_sec(), time->get_nsec());
+	msg.ranges.assign(sensor_data_msg->distance(), sensor_data_msg->distance() + 9);
+	for (uint8_t i = 0; i < 9; ++i) {
+		if (msg.ranges[i] < 1) {
+			msg.ranges[i] = msg.ranges[i] + 0.225f;
+		}
+	}
+	pub->publish(msg);
 }

--- a/src/plugins/ros2/irscan_thread.cpp
+++ b/src/plugins/ros2/irscan_thread.cpp
@@ -1,11 +1,10 @@
 
 /***************************************************************************
- *  laserscan_thread.cpp - Thread to exchange laser scans
+ *  laserscan_thread.cpp - Thread to exchange IR Sensor data
  *
- *  Created: Tue May 29 19:41:18 2012
- *  Copyright  2011-2012  Tim Niemueller [www.niemueller.de]
+ *  Created: Mon Jul 03 13:41:18 2012
+ *  Copyright  2023 Saurabh Borse, Tim Wendt
  ****************************************************************************/
-
 /*  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
@@ -42,26 +41,24 @@ ROS2IrScanThread::ROS2IrScanThread()
 void
 ROS2IrScanThread::init()
 {
-		sens_if_= blackboard->open_for_reading<RobotinoSensorInterface>("Robotino");
+	sens_if_= blackboard->open_for_reading<RobotinoSensorInterface>("Robotino");
 
-		sens_if_->read();
+	sens_if_->read();
 
-		std::string topname = "IrSensor_Scan";
+	std::string topname = "IrSensor_Scan";
 
-		pi.pub = node_handle->create_publisher<sensor_msgs::msg::LaserScan>(topname, 1);
+	pi.pub = node_handle->create_publisher<sensor_msgs::msg::LaserScan>(topname, 1);
 
-		// logger->log_info(name(), "Publishing laser scan %s at %s", (*i360)->uid(), topname.c_str());
+	pi.msg.header.frame_id = config->get_string("/hardware/robotino/base_frame");
+	pi.msg.angle_min       = 0;
+	pi.msg.angle_max       = 2 * M_PI;
+	pi.msg.angle_increment = 0.68;
+	pi.msg.scan_time = 0.1;
+	pi.msg.range_min = 0.02;
+	pi.msg.range_max = 0.12;
 
-		pi.msg.header.frame_id = config->get_string("/hardware/robotino/base_frame");
-		pi.msg.angle_min       = 0;
-		pi.msg.angle_max       = 2 * M_PI;
-		pi.msg.angle_increment = 0.68;
-		pi.msg.scan_time = 0.1;
-		pi.msg.range_min = 0.02;
-		pi.msg.range_max = 0.12;
-
-		blackboard->register_listener(this);
-	}
+	blackboard->register_listener(this);
+}
 
 
 void
@@ -69,15 +66,6 @@ ROS2IrScanThread::finalize()
 {
 	blackboard->unregister_listener(this);
 	blackboard->close(sens_if_);
-
-	// std::map<std::string, PublisherInfo>::iterator p;
-	// for (p = pubs_.begin(); p != pubs_.end(); ++p) {}
-
-	// std::list<Laser360Interface *>::iterator i360;
-	// for (i360 = ls360_ifs_.begin(); i360 != ls360_ifs_.end(); ++i360) {
-	// 	blackboard->close(*i360);
-	// }
-	// ls360_ifs_.clear();
 }
 
 
@@ -99,9 +87,3 @@ ROS2IrScanThread::bb_interface_data_refreshed(fawkes::Interface *interface) noex
 	pi.pub->publish(pi.msg);
 	
 }
-
-/** Callback function for ROS laser scan message subscription.
- * @param msg incoming message
- * std::shared_ptr<const sensor_msgs::msg::LaserScan>, const rclcpp::MessageInfo
- */
-

--- a/src/plugins/ros2/irscan_thread.cpp
+++ b/src/plugins/ros2/irscan_thread.cpp
@@ -1,0 +1,107 @@
+
+/***************************************************************************
+ *  laserscan_thread.cpp - Thread to exchange laser scans
+ *
+ *  Created: Tue May 29 19:41:18 2012
+ *  Copyright  2011-2012  Tim Niemueller [www.niemueller.de]
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "irscan_thread.h"
+
+#include <interfaces/RobotinoSensorInterface.h>
+#include <limits>
+
+using namespace fawkes;
+
+/** @class ROSirScanThread "pcl_thread.h"
+ * Thread to exchange ir sensor data between Fawkes and ROS.
+ * @author Tim Niemueller
+ */
+
+/** Constructor. */
+ROS2IrScanThread::ROS2IrScanThread()
+: Thread("ROS2IrScanThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_PROCESS),
+  BlackBoardInterfaceListener("ROS2IrScanThread")
+{
+}
+
+void
+ROS2IrScanThread::init()
+{
+		sens_if_= blackboard->open_for_reading<RobotinoSensorInterface>("Robotino");
+
+		sens_if_->read();
+
+		std::string topname = "IrSensor_Scan";
+
+		pi.pub = node_handle->create_publisher<sensor_msgs::msg::LaserScan>(topname, 1);
+
+		// logger->log_info(name(), "Publishing laser scan %s at %s", (*i360)->uid(), topname.c_str());
+
+		pi.msg.header.frame_id = config->get_string("/hardware/robotino/base_frame");
+		pi.msg.angle_min       = 0;
+		pi.msg.angle_max       = 2 * M_PI;
+		pi.msg.angle_increment = 0.68;
+		pi.msg.scan_time = 0.1;
+		pi.msg.range_min = 0.02;
+		pi.msg.range_max = 0.12;
+
+		blackboard->register_listener(this);
+	}
+
+
+void
+ROS2IrScanThread::finalize()
+{
+	blackboard->unregister_listener(this);
+	blackboard->close(sens_if_);
+
+	// std::map<std::string, PublisherInfo>::iterator p;
+	// for (p = pubs_.begin(); p != pubs_.end(); ++p) {}
+
+	// std::list<Laser360Interface *>::iterator i360;
+	// for (i360 = ls360_ifs_.begin(); i360 != ls360_ifs_.end(); ++i360) {
+	// 	blackboard->close(*i360);
+	// }
+	// ls360_ifs_.clear();
+}
+
+
+void
+ROS2IrScanThread::bb_interface_data_refreshed(fawkes::Interface *interface) noexcept
+{
+	RobotinoSensorInterface  *sensor_data_msg  = dynamic_cast<RobotinoSensorInterface *>(interface);
+	if(!sensor_data_msg)
+	return;
+
+	sensor_data_msg->read();
+
+	PublisherInfo               &pi  = pubs_[interface->uid()];
+	sensor_msgs::msg::LaserScan &msg = pi.msg;
+	const Time *time = sensor_data_msg->timestamp();
+	msg.header.stamp    = rclcpp::Time(time->get_sec(), time->get_nsec());
+	memcpy(&msg.ranges[0], sensor_data_msg->distance(), 9 * sizeof(float));
+
+	pi.pub->publish(pi.msg);
+	
+}
+
+/** Callback function for ROS laser scan message subscription.
+ * @param msg incoming message
+ * std::shared_ptr<const sensor_msgs::msg::LaserScan>, const rclcpp::MessageInfo
+ */
+

--- a/src/plugins/ros2/irscan_thread.h
+++ b/src/plugins/ros2/irscan_thread.h
@@ -1,9 +1,9 @@
 
 /***************************************************************************
- *  laserscan_thread.h - Thread to exchange laser scans
+ *  laserscan_thread.cpp - Thread to exchange IR Sensor data
  *
- *  Created: Tue May 29 19:32:39 2012
- *  Copyright  2011-2012  Tim Niemueller [www.niemueller.de]
+ *  Created: Mon Jul 03 13:41:18 2012
+ *  Copyright  2023 Saurabh Borse, Tim Wendt
  ****************************************************************************/
 
 /*  This program is free software; you can redistribute it and/or modify
@@ -19,8 +19,8 @@
  *  Read the full text in the LICENSE.GPL file in the doc directory.
  */
 
-#ifndef _PLUGINS_ROS_LASERSCAN_THREAD_H_
-#define _PLUGINS_ROS_LASERSCAN_THREAD_H_
+#ifndef _PLUGINS_ROS_IRSCANNER_THREAD_H_
+#define _PLUGINS_ROS_IRSCANNER_THREAD_H_
 
 #include <aspect/blackboard.h>
 #include <aspect/blocked_timing.h>
@@ -49,10 +49,8 @@ class ROS2IrScanThread : public fawkes::Thread,
 {
 public:
 	ROS2IrScanThread();
-	virtual ~ROS2IrScanThread();
 
 	virtual void init();
-	virtual void loop();
 	virtual void finalize();
 	// for BlackBoardInterfaceListener
 	void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept override;

--- a/src/plugins/ros2/irscan_thread.h
+++ b/src/plugins/ros2/irscan_thread.h
@@ -63,7 +63,7 @@ protected:
 	}
 
 private:
-	fawkes::RobotinoSensorInterface *sens_if_;
+	fawkes::RobotinoSensorInterface *sens_if_ = nullptr;
 
 	rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr pub;
 	sensor_msgs::msg::LaserScan                               msg;

--- a/src/plugins/ros2/irscan_thread.h
+++ b/src/plugins/ros2/irscan_thread.h
@@ -1,0 +1,83 @@
+
+/***************************************************************************
+ *  laserscan_thread.h - Thread to exchange laser scans
+ *
+ *  Created: Tue May 29 19:32:39 2012
+ *  Copyright  2011-2012  Tim Niemueller [www.niemueller.de]
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef _PLUGINS_ROS_LASERSCAN_THREAD_H_
+#define _PLUGINS_ROS_LASERSCAN_THREAD_H_
+
+#include <aspect/blackboard.h>
+#include <aspect/blocked_timing.h>
+#include <aspect/configurable.h>
+#include <blackboard/interface_listener.h>
+#include <core/threading/thread.h>
+#include <interfaces/RobotinoSensorInterface.h>
+#include <plugins/ros2/aspect/ros2.h>
+#include <utils/time/time.h>
+
+#include <list>
+#include <memory>
+#include <queue>
+using std::placeholders::_1;
+
+//ROS2
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
+class ROS2IrScanThread : public fawkes::Thread,
+                            public fawkes::ConfigurableAspect,
+                            public fawkes::BlockedTimingAspect,
+                            public fawkes::BlackBoardAspect,
+                            public fawkes::ROS2Aspect,
+                            public fawkes::BlackBoardInterfaceListener
+{
+public:
+	ROS2IrScanThread();
+	virtual ~ROS2IrScanThread();
+
+	virtual void init();
+	virtual void loop();
+	virtual void finalize();
+	// for BlackBoardInterfaceListener
+	void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept override;
+	
+protected:
+	virtual void
+	run()
+	{
+		Thread::run();
+	}
+
+private:
+	
+	fawkes::RobotinoSensorInterface *sens_if_;
+	
+	/// @cond INTERNALS
+	typedef struct
+	{
+		rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr pub;
+		sensor_msgs::msg::LaserScan                               msg;
+	} PublisherInfo;
+	/// @endcond
+	PublisherInfo pi;
+	std::map<std::string, PublisherInfo> pubs_;
+
+};
+
+#endif

--- a/src/plugins/ros2/irscan_thread.h
+++ b/src/plugins/ros2/irscan_thread.h
@@ -53,8 +53,8 @@ public:
 	virtual void init();
 	virtual void finalize();
 	// for BlackBoardInterfaceListener
-	void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept override;
-	
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) throw() override;
+
 protected:
 	virtual void
 	run()
@@ -63,19 +63,10 @@ protected:
 	}
 
 private:
-	
 	fawkes::RobotinoSensorInterface *sens_if_;
-	
-	/// @cond INTERNALS
-	typedef struct
-	{
-		rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr pub;
-		sensor_msgs::msg::LaserScan                               msg;
-	} PublisherInfo;
-	/// @endcond
-	PublisherInfo pi;
-	std::map<std::string, PublisherInfo> pubs_;
 
+	rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr pub;
+	sensor_msgs::msg::LaserScan                               msg;
 };
 
 #endif


### PR DESCRIPTION
Now publishing the IR_sensor distances to ros2 with the ros2-irscan plugin.

Fixed the conversion of the distances to meters.