### PR TITLE
add optional pose update to navgraph exec-time estimator

### DIFF
--- a/cfg/conf.d/execution-time-estimator.yaml
+++ b/cfg/conf.d/execution-time-estimator.yaml
@@ -41,6 +41,8 @@ plugins/execution-time-estimator:
   # Estimates exec times of driving skills by taking distances from NavGraph
   # as reference.
   navgraph:
+    # publish pose while skill execution
+    pose-update: true
     # misc options
     priority: 1
     speed: 0.5

--- a/src/libs/execution_time_estimator/execution_time_estimator.cpp
+++ b/src/libs/execution_time_estimator/execution_time_estimator.cpp
@@ -61,9 +61,13 @@ using Skill = ExecutionTimeEstimator::Skill;
  * @param skill The skill object to check.
  * @return true if this estimator can give an execution time estimate for the given skill.
  *
- * @fn std::pair<SkillerInterface::SkillStatusEnum, std::string> ExecutionTimeEstimator::execute(const Skill &skill) const
- * Let the estimator know that we are executing this skill, so it can apply
+ * @fn void ExecutionTimeEstimator::start_execute(const Skill &skill) const
+ * Let the estimator know that we start executing this skill, so it can apply
  * possible side effects.
+ * @param skill The skill to execute
+ *
+ * @fn std::pair<SkillerInterface::SkillStatusEnum, std::string> ExecutionTimeEstimator::end_execute(const Skill &skill) const
+ * Let the estimator know that we are ending the execution of this skill to determine the final status
  * @param skill The skill to execute
  * @return skill status after simulated execution along with an error description in case the skill fails
  *

--- a/src/libs/execution_time_estimator/execution_time_estimator.h
+++ b/src/libs/execution_time_estimator/execution_time_estimator.h
@@ -76,10 +76,11 @@ public:
 	virtual float get_execution_time(const Skill &skill) = 0;
 	virtual bool  can_execute(const Skill &skill);
 	virtual std::pair<SkillerInterface::SkillStatusEnum, std::string>
-	execute(const Skill &skill)
+	end_execute(const Skill &skill)
 	{
 		return std::make_pair(SkillerInterface::SkillStatusEnum::S_FINAL, "");
 	};
+	virtual void start_execute(const Skill &skill){};
 
 protected:
 	std::map<std::string, Skill> get_skills_from_config(const std::string &path) const;

--- a/src/libs/navgraph/navgraph_node.h
+++ b/src/libs/navgraph/navgraph_node.h
@@ -85,7 +85,7 @@ public:
    * @param n node to get distance to
    * @return distance */
 	float
-	distance(const NavGraphNode &n)
+	distance(const NavGraphNode &n) const
 	{
 		return sqrtf(powf(x_ - n.x_, 2) + powf(y_ - n.y_, 2));
 	}
@@ -95,7 +95,7 @@ public:
    * @param y point Y coordinate
    * @return distance */
 	float
-	distance(float x, float y)
+	distance(float x, float y) const
 	{
 		return sqrtf(powf(x_ - x, 2) + powf(y_ - y, 2));
 	}

--- a/src/plugins/execution-time-estimator-lookup/lookup_estimator.cpp
+++ b/src/plugins/execution-time-estimator-lookup/lookup_estimator.cpp
@@ -148,7 +148,7 @@ LookupEstimator::get_execution_time(const Skill &skill)
 }
 
 std::pair<SkillerInterface::SkillStatusEnum, std::string>
-LookupEstimator::execute(const Skill &skill)
+LookupEstimator::end_execute(const Skill &skill)
 {
 	return make_pair(outcome_, error_);
 }

--- a/src/plugins/execution-time-estimator-lookup/lookup_estimator.h
+++ b/src/plugins/execution-time-estimator-lookup/lookup_estimator.h
@@ -45,7 +45,8 @@ public:
 	                Logger             *logger);
 	float get_execution_time(const Skill &skill) override;
 	bool  can_provide_exec_time(const Skill &skill) const override;
-	std::pair<SkillerInterface::SkillStatusEnum, std::string> execute(const Skill &skill) override;
+	std::pair<SkillerInterface::SkillStatusEnum, std::string>
+	end_execute(const Skill &skill) override;
 
 private:
 	bsoncxx::builder::basic::document get_skill_query(const Skill &skill) const;

--- a/src/plugins/execution-time-estimator-navgraph/execution_time_estimator_navgraph_thread.cpp
+++ b/src/plugins/execution-time-estimator-navgraph/execution_time_estimator_navgraph_thread.cpp
@@ -40,7 +40,8 @@ ExecutionTimeEstimatorNavgraphThread::ExecutionTimeEstimatorNavgraphThread()
 void
 ExecutionTimeEstimatorNavgraphThread::init()
 {
-	estimator_ = std::make_shared<fawkes::NavGraphEstimator>(navgraph, config, cfg_prefix_);
+	estimator_ =
+	  std::make_shared<fawkes::NavGraphEstimator>(navgraph, config, cfg_prefix_, blackboard);
 	execution_time_estimator_manager_->register_provider(
 	  estimator_, config->get_int_or_default((std::string{cfg_prefix_} + "priority").c_str(), 0));
 }
@@ -50,4 +51,5 @@ void
 ExecutionTimeEstimatorNavgraphThread::finalize()
 {
 	execution_time_estimator_manager_->unregister_provider(estimator_);
+	estimator_.reset();
 }

--- a/src/plugins/execution-time-estimator-navgraph/navgraph_estimator.cpp
+++ b/src/plugins/execution-time-estimator-navgraph/navgraph_estimator.cpp
@@ -70,7 +70,7 @@ NavGraphEstimator::get_execution_time(const Skill &skill)
 }
 
 std::pair<SkillerInterface::SkillStatusEnum, std::string>
-NavGraphEstimator::execute(const Skill &skill)
+NavGraphEstimator::end_execute(const Skill &skill)
 {
 	auto node    = navgraph_->node(skill.skill_args.at("place"));
 	last_pose_x_ = node.x();

--- a/src/plugins/execution-time-estimator-navgraph/navgraph_estimator.h
+++ b/src/plugins/execution-time-estimator-navgraph/navgraph_estimator.h
@@ -22,10 +22,12 @@
 
 #include "interfaces/Position3DInterface.h"
 
+#include <aspect/blackboard.h>
 #include <config/config.h>
 #include <execution_time_estimator/aspect/execution_time_estimator.h>
 #include <navgraph/navgraph.h>
 
+#include <future>
 #include <string>
 #include <vector>
 
@@ -35,17 +37,26 @@ class NavGraphEstimator : public ExecutionTimeEstimator
 public:
 	NavGraphEstimator(LockPtr<NavGraph>  navgraph,
 	                  Configuration     *config,
-	                  const std::string &cfg_prefix);
+	                  const std::string &cfg_prefix,
+	                  BlackBoard        *blackboard);
+	~NavGraphEstimator();
 	float get_execution_time(const Skill &skill) override;
 	bool  can_provide_exec_time(const Skill &skill) const override;
+	void  start_execute(const Skill &skill) override;
+	void  update_pose_along_path(const Skill &skill);
 	std::pair<SkillerInterface::SkillStatusEnum, std::string>
 	end_execute(const Skill &skill) override;
 
 private:
-	LockPtr<NavGraph>           navgraph_;
-	float                       last_pose_x_;
-	float                       last_pose_y_;
-	const Property<std::string> source_names_;
-	const Property<std::string> dest_names_;
+	LockPtr<NavGraph>            navgraph_;
+	float                        last_pose_x_;
+	float                        last_pose_y_;
+	float                        curr_duration_;
+	const Property<std::string>  source_names_;
+	const Property<std::string>  dest_names_;
+	std::future<void>            pose_publisher_;
+	fawkes::Position3DInterface *pos3d_if_;
+	BlackBoard                  *blackboard_;
+	bool                         publish_pose_;
 };
 } // namespace fawkes

--- a/src/plugins/execution-time-estimator-navgraph/navgraph_estimator.h
+++ b/src/plugins/execution-time-estimator-navgraph/navgraph_estimator.h
@@ -38,7 +38,8 @@ public:
 	                  const std::string &cfg_prefix);
 	float get_execution_time(const Skill &skill) override;
 	bool  can_provide_exec_time(const Skill &skill) const override;
-	std::pair<SkillerInterface::SkillStatusEnum, std::string> execute(const Skill &skill) override;
+	std::pair<SkillerInterface::SkillStatusEnum, std::string>
+	end_execute(const Skill &skill) override;
 
 private:
 	LockPtr<NavGraph>           navgraph_;

--- a/src/plugins/skiller-simulator/exec_thread.cpp
+++ b/src/plugins/skiller-simulator/exec_thread.cpp
@@ -121,6 +121,7 @@ SkillerSimulatorExecutionThread::loop()
 			skiller_if_->set_error("");
 			skiller_if_->set_status(SkillerInterface::S_RUNNING);
 			current_skill_runtime_ = get_skill_runtime(m->skill_string());
+			start_execute_skill(m->skill_string());
 			logger->log_info(name(),
 			                 "Executing '%s', will take %.2f seconds",
 			                 m->skill_string(),
@@ -158,7 +159,7 @@ SkillerSimulatorExecutionThread::loop()
 			Time now = Time();
 			if (Time() > skill_starttime_ + current_skill_runtime_) {
 				logger->log_info(name(), "Skill '%s' is final", skiller_if_->skill_string());
-				auto [exec_status, error] = execute_skill(skiller_if_->skill_string());
+				auto [exec_status, error] = end_execute_skill(skiller_if_->skill_string());
 				skiller_if_->set_skill_string(skiller_if_->skill_string());
 				skiller_if_->set_error(error.c_str());
 				skiller_if_->set_status(exec_status);
@@ -185,9 +186,16 @@ SkillerSimulatorExecutionThread::get_skill_runtime(const std::string &skill) con
 	return provider->get_execution_time(skill);
 }
 
-std::pair<fawkes::SkillerInterface::SkillStatusEnum, std::string>
-SkillerSimulatorExecutionThread::execute_skill(const std::string &skill)
+void
+SkillerSimulatorExecutionThread::start_execute_skill(const std::string &skill)
 {
 	auto provider = execution_time_estimator_manager_->get_provider(skill);
-	return provider->execute(skill);
+	return provider->start_execute(skill);
+}
+
+std::pair<fawkes::SkillerInterface::SkillStatusEnum, std::string>
+SkillerSimulatorExecutionThread::end_execute_skill(const std::string &skill)
+{
+	auto provider = execution_time_estimator_manager_->get_provider(skill);
+	return provider->end_execute(skill);
 }

--- a/src/plugins/skiller-simulator/exec_thread.h
+++ b/src/plugins/skiller-simulator/exec_thread.h
@@ -55,7 +55,8 @@ protected:
 private:
 	float get_skill_runtime(const std::string &skill) const;
 	std::pair<fawkes::SkillerInterface::SkillStatusEnum, std::string>
-	                          execute_skill(const std::string &skill);
+	                          end_execute_skill(const std::string &skill);
+	void                      start_execute_skill(const std::string &skill);
 	fawkes::SkillerInterface *skiller_if_;
 	float                     current_skill_runtime_;
 	fawkes::Time              skill_starttime_;


### PR DESCRIPTION
This PR extends the execution-time-estimator-navgraph feature to consider navgraph paths instead of straight-line distances. Additionally, the plugin may act as writer to a Position3DInterface to update the Pose along the way, if configured.
This required changes to the execution-time-estimator interface, as the estimator now also needs to be notified when the skill simulation starts, not only when it ends.