### PR TITLE
Expose navgraph interfaces to ROS2

### DIFF
--- a/cfg/conf.d/meta_plugins.yaml
+++ b/cfg/conf.d/meta_plugins.yaml
@@ -13,6 +13,7 @@ fawkes/meta_plugins:
     - ros2
     - skiller
     - ros2-cx-skiller
+    - ros2-cx-navgraph
 
   # Meta plugin for the clips-executive without planner integration
   m-clips-executive-test:

--- a/cfg/conf.d/meta_plugins.yaml
+++ b/cfg/conf.d/meta_plugins.yaml
@@ -7,6 +7,12 @@ fawkes/meta_plugins:
 
   # Meta plugin with useful base plugins for the Robotino
   robotino_default: robotino,joystick,robotino-joystick,webview
+  # Meta plugin for running as client for the ros2 clips executive
+  m-ros2-skiller:
+    - flite
+    - ros2
+    - skiller
+    - ros2-cx-skiller
 
   # Meta plugin for the clips-executive without planner integration
   m-clips-executive-test:

--- a/cfg/conf.d/navgraph.yaml
+++ b/cfg/conf.d/navgraph.yaml
@@ -71,7 +71,7 @@ navgraph:
   # essentially means that no blackboard interfaces for path
   # instruction will be provided and the remaining API is kept
   # as-is.
-  path_execution: true
+  path_execution: false
 
   visualization:
 

--- a/src/lua/skiller/fawkes/init.lua
+++ b/src/lua/skiller/fawkes/init.lua
@@ -86,7 +86,7 @@ end
 function process_skiller_messages()
 	 local write_skiller_if = false
 	 local skill_enqueued = false
-	 
+
 	 while not skiller_if:msgq_empty() do
 			local m = skiller_if:msgq_first()
 			local mtype = m:type()
@@ -115,7 +115,7 @@ function process_skiller_messages()
 						write_skiller_if = true
 				 elseif skiller_if:exclusive_controller() ~= "" then
 						print_warn("%s tried to release exclusive control, but it's not the controller",
-											 m:sender_thread_name())						
+											 m:sender_thread_name())
 				 end
 
 			elseif mtype == "ExecSkillMessage" then
@@ -186,7 +186,7 @@ function process_skiller_messages()
 			skiller_if:msgq_pop()
 	 end
 
-	 if write_skiller_if then 
+	 if write_skiller_if then
 			skiller_if:write()
 	 end
 end

--- a/src/lua/skiller/fawkes/init.lua
+++ b/src/lua/skiller/fawkes/init.lua
@@ -194,6 +194,7 @@ end
 function publish_skill_status()
 	 local old_status = skiller_if:status()
 	 local new_status = skillenv.get_overall_status()
+	 skiller_if:set_status(old_status)
 
 	 if old_status ~= new_status then
       skiller_if:set_status(new_status)

--- a/src/plugins/ros2/CMakeLists.txt
+++ b/src/plugins/ros2/CMakeLists.txt
@@ -21,50 +21,53 @@
 # *****************************************************************************
 
 set(PLUGIN_ros2
-    ON
-    CACHE BOOL "Build ros2 plugin")
+  ON
+  CACHE BOOL "Build ros2 plugin")
 set(PLUGIN_ros2-cx-skiller
-    ON
-    CACHE BOOL "Build ros2 cx-skiller plugin")
+  ON
+  CACHE BOOL "Build ros2 cx-skiller plugin")
 set(PLUGIN_ros2-talkerpub
-    ON
-    CACHE BOOL "Build ros2-talkerpub plugin")
+  ON
+  CACHE BOOL "Build ros2-talkerpub plugin")
 set(PLUGIN_ros2-tf2
-    ON
-    CACHE BOOL "Build ros2-tf2 plugin")
+  ON
+  CACHE BOOL "Build ros2-tf2 plugin")
 set(PLUGIN_ros2-images
-    ON
-    CACHE BOOL "Build ros2-images plugin")
+  ON
+  CACHE BOOL "Build ros2-images plugin")
 set(PLUGIN_ros2-laserscan
-    ON
-    CACHE BOOL "Build ros2-laserscan plugin")
+  ON
+  CACHE BOOL "Build ros2-laserscan plugin")
 set(PLUGIN_ros2-irscan
-    ON
-    CACHE BOOL "Build ros2-irscan plugin")
+  ON
+  CACHE BOOL "Build ros2-irscan plugin")
 set(PLUGIN_ros2-odometry
-    ON
-    CACHE BOOL "Build ros2-odometry plugin")
+  ON
+  CACHE BOOL "Build ros2-odometry plugin")
 set(PLUGIN_ros2-cmdvel
-    ON
-    CACHE BOOL "Build ros2-cmdvel plugin")
+  ON
+  CACHE BOOL "Build ros2-cmdvel plugin")
 set(PLUGIN_ros2-navigator
-    ON
-    CACHE BOOL "Build ros2-navigator plugin")
+  ON
+  CACHE BOOL "Build ros2-navigator plugin")
 set(PLUGIN_ros2-dynamic-reconfigure
-    ON
-    CACHE BOOL "Build ros2-dynamic-reconfigure plugin")
+  ON
+  CACHE BOOL "Build ros2-dynamic-reconfigure plugin")
 set(PLUGIN_ros2-joint
-    ON
-    CACHE BOOL "Build ros2-joint plugin")
+  ON
+  CACHE BOOL "Build ros2-joint plugin")
 set(PLUGIN_ros2-robot-description
-    ON
-    CACHE BOOL "Build ros2-robot-description plugin")
+  ON
+  CACHE BOOL "Build ros2-robot-description plugin")
 set(PLUGIN_ros2-clock
-    ON
-    CACHE BOOL "Build ros2-clock plugin")
+  ON
+  CACHE BOOL "Build ros2-clock plugin")
 set(PLUGIN_ros2-imu
-    ON
-    CACHE BOOL "Build ros2-imu plugin")
+  ON
+  CACHE BOOL "Build ros2-imu plugin")
+set(PLUGIN_ros2-cx-navgraph
+  ON
+  CACHE BOOL "Build ros2 cx-navgraph plugin")
 add_subdirectory(aspect)
 
 if(PLUGIN_ros2)
@@ -85,7 +88,7 @@ endif()
 
 if(PLUGIN_ros2-cx-skiller)
   add_library(ros2-cx-skiller MODULE cx_skiller_plugin.cpp
-                                     cx_skiller_thread.cpp skill_node.cpp)
+    cx_skiller_thread.cpp skill_node.cpp)
   depend_on_ros2(ros2-cx-skiller)
   depend_on_ros2_libs(
     ros2-cx-skiller
@@ -277,7 +280,7 @@ endif()
 
 if(PLUGIN_ros2-dynamic-reconfigure)
   add_library(ros2-dynamic-reconfigure MODULE dynamic_reconfigure_plugin.cpp
-                                              dynamic_reconfigure_thread.cpp)
+    dynamic_reconfigure_thread.cpp)
   depend_on_ros2(ros2-dynamic-reconfigure)
   depend_on_ros2_libs(ros2-dynamic-reconfigure dynamic_reconfigure)
   target_link_libraries(
@@ -339,11 +342,33 @@ endif()
 
 if(PLUGIN_ros2-robot-description)
   add_library(ros2-robot-description MODULE robot_description_plugin.cpp
-                                            robot_description_thread.cpp)
+    robot_description_thread.cpp)
   depend_on_ros2(ros2-robot-description)
   target_link_libraries(ros2-robot-description fawkescore fawkesutils
-                        fawkesaspects fawkesros2aspect)
+    fawkesaspects fawkesros2aspect)
 
 else()
   plugin_disabled_message(ros2-robot-description)
+endif()
+
+if(PLUGIN_ros2-cx-navgraph)
+  add_library(ros2-cx-navgraph MODULE navgraph_plugin.cpp
+    navgraph_thread.cpp navgraph_node.cpp)
+  depend_on_ros2(ros2-cx-navgraph)
+  depend_on_ros2_libs(
+    ros2-cx-navgraph
+    "rmw;rosidl_typesupport_interface;rcl_interfaces;cx_msgs;lifecycle_msgs;rclcpp_lifecycle"
+  )
+  target_link_libraries(
+    ros2-cx-navgraph
+    fawkescore
+    fawkesutils
+    fawkesaspects
+    fawkesblackboard
+    fawkesinterface
+    NavGraphGeneratorInterface
+    NavGraphWithMPSGeneratorInterface
+    fawkesros2aspect)
+else()
+  plugin_disabled_message(ros2-cx-navgraph)
 endif()

--- a/src/plugins/ros2/CMakeLists.txt
+++ b/src/plugins/ros2/CMakeLists.txt
@@ -23,6 +23,9 @@
 set(PLUGIN_ros2
     ON
     CACHE BOOL "Build ros2 plugin")
+set(PLUGIN_ros2-cx-skiller
+    ON
+    CACHE BOOL "Build ros2 cx-skiller plugin")
 set(PLUGIN_ros2-talkerpub
     ON
     CACHE BOOL "Build ros2-talkerpub plugin")
@@ -78,6 +81,27 @@ if(PLUGIN_ros2)
     fawkesros2aspect)
 else()
   plugin_disabled_message(ros2)
+endif()
+
+if(PLUGIN_ros2-cx-skiller)
+  add_library(ros2-cx-skiller MODULE cx_skiller_plugin.cpp
+                                     cx_skiller_thread.cpp skill_node.cpp)
+  depend_on_ros2(ros2-cx-skiller)
+  depend_on_ros2_libs(
+    ros2-cx-skiller
+    "rmw;rosidl_typesupport_interface;rcl_interfaces;cx_msgs;cx_skill_execution"
+  )
+  target_link_libraries(
+    ros2-cx-skiller
+    fawkescore
+    fawkesutils
+    fawkesaspects
+    fawkesblackboard
+    fawkesinterface
+    SkillerInterface
+    fawkesros2aspect)
+else()
+  plugin_disabled_message(ros2-cx-skiller)
 endif()
 
 if(PLUGIN_ros2-talkerpub)

--- a/src/plugins/ros2/aspect/ros2.cpp
+++ b/src/plugins/ros2/aspect/ros2.cpp
@@ -59,9 +59,11 @@ ROS2Aspect::~ROS2Aspect()
  * @param node_handle ROS2 node handle
  */
 void
-ROS2Aspect::init_ROS2Aspect(rclcpp::Node::SharedPtr node_handle)
+ROS2Aspect::init_ROS2Aspect(rclcpp::Node::SharedPtr                                   node_handle,
+                            std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor)
 {
 	this->node_handle = node_handle;
+	this->executor    = executor;
 	//        cfg_tf_prefix_ = config->get_string_or_default("/ros2/tf/tf_prefix", "");
 	//        cfg_tf_prefix_exclusions_ = config->get_strings_or_defaults("/ros2/tf/tf_prefix_exclusions", std::vector<std::string>());
 	//

--- a/src/plugins/ros2/aspect/ros2.h
+++ b/src/plugins/ros2/aspect/ros2.h
@@ -47,10 +47,12 @@ public:
 	void add_tf_prefix(std::string &frame_id);
 
 protected:
-	rclcpp::Node::SharedPtr node_handle;
+	rclcpp::Node::SharedPtr                                   node_handle;
+	std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor;
 
 private:
-	void init_ROS2Aspect(rclcpp::Node::SharedPtr node_handle);
+	void init_ROS2Aspect(rclcpp::Node::SharedPtr                                   node_handle,
+	                     std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor);
 	void finalize_ROS2Aspect();
 	//	bool tf_prefix_enabled_;
 	//	std::string cfg_tf_prefix_;

--- a/src/plugins/ros2/aspect/ros2_inifin.cpp
+++ b/src/plugins/ros2/aspect/ros2_inifin.cpp
@@ -52,8 +52,11 @@ ROS2AspectIniFin::init(Thread *thread)
 	if (!node_handle_) {
 		throw CannotInitializeThreadException("ROS2 node handle has not been set.");
 	}
+	if (!executor_) {
+		throw CannotInitializeThreadException("ROS2 executor has not been set.");
+	}
 
-	ros2_thread->init_ROS2Aspect(node_handle_);
+	ros2_thread->init_ROS2Aspect(node_handle_, executor_);
 }
 
 void
@@ -77,6 +80,15 @@ void
 ROS2AspectIniFin::set_node_handle(rclcpp::Node::SharedPtr node_handle)
 {
 	node_handle_ = node_handle;
+}
+
+/** Set the ROS2 executor to use for aspect initialization.
+ * @param executor ROS2 executor to pass to threads with ROS2Aspect.
+ */
+void
+ROS2AspectIniFin::set_executor(std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor)
+{
+	executor_ = executor;
 }
 
 } // end namespace fawkes

--- a/src/plugins/ros2/aspect/ros2_inifin.h
+++ b/src/plugins/ros2/aspect/ros2_inifin.h
@@ -27,6 +27,7 @@
 #include <aspect/inifins/inifin.h>
 #include <plugins/ros2/aspect/ros2.h>
 
+#include <rclcpp/executors/multi_threaded_executor.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace fawkes {
@@ -40,10 +41,12 @@ public:
 	virtual void finalize(Thread *thread);
 
 	void set_node_handle(rclcpp::Node::SharedPtr node_handle);
+	void set_executor(std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor);
 
 private:
-	rclcpp::Node::SharedPtr node_handle_;
-	std::string             tf_prefix_;
+	rclcpp::Node::SharedPtr                                   node_handle_;
+	std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+	std::string                                               tf_prefix_;
 };
 
 } // end namespace fawkes

--- a/src/plugins/ros2/cx_skiller_plugin.cpp
+++ b/src/plugins/ros2/cx_skiller_plugin.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *  cx_skiller_plugin.cpp - Relay exec requests from ROS CX to the Skiller
+ *
+ *  Created: Oct 2023
+ *  Copyright  2023  Tarik Viehmann <viehmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "cx_skiller_thread.h"
+
+#include <core/plugin.h>
+
+using namespace fawkes;
+
+/** Plugin to publish IMU data to ROS.
+ * @author Till Hofmann
+ */
+class ROS2CXSkillerPlugin : public fawkes::Plugin
+{
+public:
+	/** Constructor.
+    * @param config Fawkes configuration
+    */
+	explicit ROS2CXSkillerPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new ROS2CXSkillerThread());
+	}
+};
+
+PLUGIN_DESCRIPTION("ROS CX Skiller Interface Plugin")
+EXPORT_PLUGIN(ROS2CXSkillerPlugin)

--- a/src/plugins/ros2/cx_skiller_thread.cpp
+++ b/src/plugins/ros2/cx_skiller_thread.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *  imu_thread.cpp - Thread to publish CXSkiller data to ROS
+ *
+ *  Created: oct 2023
+ *  Copyright  2023  Tarik Viehmann <viehmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "cx_skiller_thread.h"
+
+using namespace fawkes;
+
+/** @class ROS2CXSkillerThread "imu_thread.h"
+ * Thread to publish CXSkiller data to ROS.
+ * This thread reads data from the CXSkiller blackboard interface and publishes the
+ * data to ROS.
+ * @author Till Hofmann
+ */
+
+/** Constructor. */
+ROS2CXSkillerThread::ROS2CXSkillerThread()
+: Thread("ROS2CXSkillerThread", Thread::OPMODE_WAITFORWAKEUP)
+{
+}
+
+/** Destructor. */
+ROS2CXSkillerThread::~ROS2CXSkillerThread()
+{
+}
+
+/** Initialize the thread.
+ * Open the blackboard interface and advertise the ROS topic.
+ * Register as listener for the blackboard interface.
+ */
+void
+ROS2CXSkillerThread::init()
+{
+	skiller_iface_ = blackboard->open_for_reading<SkillerInterface>("Skiller");
+	//logger->log_info(name(),
+	//                 "Publishing CXSkiller '%s' to ROS topic '%s'.",
+	//                 skiller_iface_name.c_str(),
+	//                 ros2_topic.c_str());
+	std::string robot_name = config->get_string_or_default("fawkes/agent/name", "");
+	std::string executor_name =
+	  config->get_string_or_default("ros2/cx-skiller/executor-name", "fawkes_skiller");
+	skill_node_ = std::make_shared<SkillNode>(
+	  "FawkesSkillNode", robot_name, executor_name, std::chrono::nanoseconds(5000), skiller_iface_);
+	skill_node_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+	executor->add_node(skill_node_->get_node_base_interface());
+	//ros2_pub_ = node_handle->create_publisher<sensor_msgs::msg::Imu>(ros2_topic, 100);
+
+	blackboard->register_listener(skill_node_.get());
+}
+
+/** Close all interfaces and ROS handles. */
+void
+ROS2CXSkillerThread::finalize()
+{
+	blackboard->unregister_listener(skill_node_.get());
+	// call destructor before closing interface to release skiller control
+	executor->remove_node(skill_node_->get_node_base_interface());
+	skill_node_.reset();
+	blackboard->close(skiller_iface_);
+}

--- a/src/plugins/ros2/cx_skiller_thread.h
+++ b/src/plugins/ros2/cx_skiller_thread.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *  imu_thread.h - Thread to publish IMU data to ROS
+ *
+ *  Created: Oct 2023
+ *  Copyright  2023  Tarik Viehmann <viehmann@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef _PLUGINS_ROS2_IMU_THREAD_H_
+#define _PLUGINS_ROS2_IMU_THREAD_H_
+
+#include "skill_node.h"
+
+#include <aspect/blackboard.h>
+#include <aspect/configurable.h>
+#include <aspect/logging.h>
+#include <blackboard/interface_listener.h>
+#include <core/threading/thread.h>
+#include <interfaces/SkillerInterface.h>
+#include <plugins/ros2/aspect/ros2.h>
+
+#include <rclcpp/rclcpp.hpp>
+class ROS2CXSkillerThread : public fawkes::Thread,
+                            public fawkes::ConfigurableAspect,
+                            public fawkes::LoggingAspect,
+                            public fawkes::ROS2Aspect,
+                            public fawkes::BlackBoardAspect
+{
+public:
+	ROS2CXSkillerThread();
+	virtual ~ROS2CXSkillerThread();
+
+	virtual void init();
+	virtual void finalize();
+
+private:
+	std::shared_ptr<fawkes::SkillNode> skill_node_;
+	fawkes::SkillerInterface          *skiller_iface_;
+};
+
+#endif /* PLUGINS_ROS_CXSkiller_THREAD_H__ */

--- a/src/plugins/ros2/navgraph_node.cpp
+++ b/src/plugins/ros2/navgraph_node.cpp
@@ -1,0 +1,174 @@
+/***************************************************************************
+ *  navgraph_node.cpp
+ *
+ *  Created: Dec 2023
+ *  Copyright  2023 Daniel Swoboda <swoboda@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "navgraph_node.h"
+
+#include "lifecycle_msgs/msg/state.hpp"
+
+#include <interfaces/NavGraphGeneratorInterface.h>
+#include <interfaces/NavGraphWithMPSGeneratorInterface.h>
+namespace fawkes {
+
+using namespace std::chrono_literals;
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+ROS2NavgraphNode::ROS2NavgraphNode(const std::string                 &id,
+                                   const std::chrono::nanoseconds    &rate,
+                                   NavGraphGeneratorInterface        *navgraph_interface,
+                                   NavGraphWithMPSGeneratorInterface *navgraph_mps_interface)
+: rclcpp_lifecycle::LifecycleNode(id), BlackBoardInterfaceListener("NavgraphNode")
+{
+	navgraph_interface_     = navgraph_interface;
+	navgraph_mps_interface_ = navgraph_mps_interface;
+	bbil_add_data_interface(navgraph_interface);
+	bbil_add_data_interface(navgraph_mps_interface);
+}
+
+ROS2NavgraphNode::~ROS2NavgraphNode()
+{
+}
+
+CallbackReturn
+ROS2NavgraphNode::on_activate(const rclcpp_lifecycle::State &state)
+{
+	RCLCPP_INFO(rclcpp::get_logger(get_name()), "Starting execution!");
+
+	navgraph_interface_service_ = this->create_service<cx_msgs::srv::NavGraphInterfaceCompute>(
+	  "navgraph_compute",
+	  [=](const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceCompute::Request> request,
+	      std::shared_ptr<cx_msgs::srv::NavGraphInterfaceCompute::Response>      response) {
+		  navgraph_compute_received(request, response);
+	  });
+
+	navgraph_generate_waitzones_service_ =
+	  this->create_service<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones>(
+	    "navgraph_compute",
+	    [=](const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones::Request> request,
+	        std::shared_ptr<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones::Response> response) {
+		    navgraph_generate_waitzones_received(request, response);
+	    });
+
+	navgraph_generate_waitzones_service_ =
+	  this->create_service<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones>(
+	    "navgraph_compute",
+	    [=](const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones::Request> request,
+	        std::shared_ptr<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones::Response> response) {
+		    navgraph_generate_waitzones_received(request, response);
+	    });
+
+	navgraph_set_bounding_box_service_ =
+	  this->create_service<cx_msgs::srv::NavGraphInterfaceSetBoundingBox>(
+	    "navgraph_compute",
+	    [=](const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceSetBoundingBox::Request> request,
+	        std::shared_ptr<cx_msgs::srv::NavGraphInterfaceSetBoundingBox::Response>      response) {
+		    navgraph_set_bounding_box_received(request, response);
+	    });
+
+	navgraph_update_station_by_tag_service_ =
+	  this->create_service<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag>(
+	    "navgraph_compute",
+	    [=](const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag::Request> request,
+	        std::shared_ptr<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag::Response> response) {
+		    navgraph_update_station_by_tag_received(request, response);
+	    });
+
+	return rclcpp_lifecycle::LifecycleNode::on_activate(state);
+}
+
+void
+ROS2NavgraphNode::navgraph_compute_received(
+  const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceCompute::Request> request,
+  std::shared_ptr<cx_msgs::srv::NavGraphInterfaceCompute::Response>      response)
+{
+	RCLCPP_INFO(rclcpp::get_logger(get_name()), "Received NavGraphComputeInterface");
+	NavGraphGeneratorInterface::ComputeMessage *cm = new NavGraphGeneratorInterface::ComputeMessage();
+	navgraph_interface_->msgq_enqueue(cm);
+	response->success = true;
+}
+
+void
+ROS2NavgraphNode::navgraph_generate_waitzones_received(
+  const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones::Request> request,
+  std::shared_ptr<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones::Response>      response)
+{
+	RCLCPP_INFO(rclcpp::get_logger(get_name()), "Received NavGraphGenerateWaitzones");
+	NavGraphWithMPSGeneratorInterface::GenerateWaitZonesMessage *gwzm =
+	  new NavGraphWithMPSGeneratorInterface::GenerateWaitZonesMessage();
+	navgraph_mps_interface_->msgq_enqueue(gwzm);
+	response->success = true;
+}
+
+void
+ROS2NavgraphNode::navgraph_set_bounding_box_received(
+  const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceSetBoundingBox::Request> request,
+  std::shared_ptr<cx_msgs::srv::NavGraphInterfaceSetBoundingBox::Response>      response)
+{
+	RCLCPP_INFO(rclcpp::get_logger(get_name()), "Received NavGraphSetBoundingBox");
+
+	NavGraphGeneratorInterface::SetBoundingBoxMessage *sbbm =
+	  new NavGraphGeneratorInterface::SetBoundingBoxMessage(request->p1_x,
+	                                                        request->p1_y,
+	                                                        request->p2_x,
+	                                                        request->p2_y);
+	navgraph_interface_->msgq_enqueue(sbbm);
+	response->success = true;
+}
+
+void
+ROS2NavgraphNode::navgraph_update_station_by_tag_received(
+  const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag::Request> request,
+  std::shared_ptr<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag::Response>      response)
+{
+	RCLCPP_INFO(rclcpp::get_logger(get_name()), "Received NavGraphUpdateStationByTag");
+
+	NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage *usbtm =
+	  new NavGraphWithMPSGeneratorInterface::UpdateStationByTagMessage();
+
+	usbtm->set_name(request->name.c_str());
+	if (request->side == "INPUT")
+		usbtm->set_side(NavGraphWithMPSGeneratorInterface::Side::INPUT);
+	else if (request->side == "OUTPUT")
+		usbtm->set_side(NavGraphWithMPSGeneratorInterface::Side::OUTPUT);
+	usbtm->set_frame(request->frame.c_str());
+	usbtm->set_tag_translation(0, request->tag_translation[0]);
+	usbtm->set_tag_translation(1, request->tag_translation[1]);
+	usbtm->set_tag_translation(2, request->tag_translation[2]);
+	usbtm->set_tag_rotation(0, request->tag_rotation[0]);
+	usbtm->set_tag_rotation(1, request->tag_rotation[1]);
+	usbtm->set_tag_rotation(2, request->tag_rotation[2]);
+	usbtm->set_tag_rotation(3, request->tag_rotation[3]);
+	usbtm->set_zone_coords(0, request->zone_coords[0]);
+	usbtm->set_zone_coords(1, request->zone_coords[1]);
+
+	navgraph_mps_interface_->msgq_enqueue(usbtm);
+	response->success = true;
+}
+
+/** Handle interface changes.
+ * If the Skiller interface changes, publish updated data to ROS.
+ * @param interface interface instance that you supplied to bbil_add_data_interface()
+ */
+void
+ROS2NavgraphNode::bb_interface_data_refreshed(Interface *interface) noexcept
+{
+	RCLCPP_INFO(rclcpp::get_logger(get_name()), "GOT MESSAGE FROM INTERFACE '%s'", interface->type());
+}
+
+} // namespace fawkes

--- a/src/plugins/ros2/navgraph_node.h
+++ b/src/plugins/ros2/navgraph_node.h
@@ -27,6 +27,8 @@
 #include <interfaces/NavGraphWithMPSGeneratorInterface.h>
 
 #include <chrono>
+#include <cx_msgs/msg/nav_graph_interface_message.hpp>
+#include <cx_msgs/msg/nav_graph_with_mps_interface_message.hpp>
 #include <cx_msgs/srv/nav_graph_interface_compute.hpp>
 #include <cx_msgs/srv/nav_graph_interface_generate_waitzones.hpp>
 #include <cx_msgs/srv/nav_graph_interface_set_bounding_box.hpp>
@@ -86,6 +88,9 @@ private:
 	  navgraph_set_bounding_box_service_;
 	rclcpp::Service<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag>::SharedPtr
 	  navgraph_update_station_by_tag_service_;
+	rclcpp::Publisher<cx_msgs::msg::NavGraphInterfaceMessage>::SharedPtr nav_graph_publisher_;
+	rclcpp::Publisher<cx_msgs::msg::NavGraphWithMPSInterfaceMessage>::SharedPtr
+	  nav_graph_with_mps_publisher_;
 };
 } // namespace fawkes
 #endif // !NAVGRAPH_NODE_H

--- a/src/plugins/ros2/navgraph_node.h
+++ b/src/plugins/ros2/navgraph_node.h
@@ -1,0 +1,91 @@
+/***************************************************************************
+ *  navgraph_node.h
+ *
+ *  Created: Dec 2023
+ *  Copyright  2023 Daniel Swoboda <swoboda@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef NAVGRAPH_NODE_H
+#define NAVGRAPH_NODE_H
+
+#include <aspect/blackboard.h>
+#include <blackboard/interface_listener.h>
+#include <interfaces/NavGraphGeneratorInterface.h>
+#include <interfaces/NavGraphWithMPSGeneratorInterface.h>
+
+#include <chrono>
+#include <cx_msgs/srv/nav_graph_interface_compute.hpp>
+#include <cx_msgs/srv/nav_graph_interface_generate_waitzones.hpp>
+#include <cx_msgs/srv/nav_graph_interface_set_bounding_box.hpp>
+#include <cx_msgs/srv/nav_graph_interface_update_station_by_tag.hpp>
+#include <fstream>
+#include <iostream>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <map>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <regex>
+#include <string>
+
+namespace fawkes {
+using namespace std::chrono_literals;
+
+class ROS2NavgraphNode : public rclcpp_lifecycle::LifecycleNode,
+                         public fawkes::BlackBoardInterfaceListener
+{
+	using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+public:
+	ROS2NavgraphNode(const std::string                         &id,
+	                 const std::chrono::nanoseconds            &rate,
+	                 fawkes::NavGraphGeneratorInterface        *navgraph_interface,
+	                 fawkes::NavGraphWithMPSGeneratorInterface *navgraph_mps_interface);
+	~ROS2NavgraphNode();
+
+	CallbackReturn on_activate(const rclcpp_lifecycle::State &state);
+
+	void navgraph_compute_received(
+	  const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceCompute::Request> request,
+	  std::shared_ptr<cx_msgs::srv::NavGraphInterfaceCompute::Response>      response);
+
+	void navgraph_generate_waitzones_received(
+	  const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones::Request> request,
+	  std::shared_ptr<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones::Response>      response);
+
+	void navgraph_set_bounding_box_received(
+	  const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceSetBoundingBox::Request> request,
+	  std::shared_ptr<cx_msgs::srv::NavGraphInterfaceSetBoundingBox::Response>      response);
+
+	void navgraph_update_station_by_tag_received(
+	  const std::shared_ptr<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag::Request> request,
+	  std::shared_ptr<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag::Response>      response);
+
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept override;
+
+private:
+	fawkes::NavGraphGeneratorInterface                                *navgraph_interface_;
+	fawkes::NavGraphWithMPSGeneratorInterface                         *navgraph_mps_interface_;
+	rclcpp::Service<cx_msgs::srv::NavGraphInterfaceCompute>::SharedPtr navgraph_interface_service_;
+	rclcpp::Service<cx_msgs::srv::NavGraphInterfaceGenerateWaitzones>::SharedPtr
+	  navgraph_generate_waitzones_service_;
+	rclcpp::Service<cx_msgs::srv::NavGraphInterfaceSetBoundingBox>::SharedPtr
+	  navgraph_set_bounding_box_service_;
+	rclcpp::Service<cx_msgs::srv::NavGraphInterfaceUpdateStationByTag>::SharedPtr
+	  navgraph_update_station_by_tag_service_;
+};
+} // namespace fawkes
+#endif // !NAVGRAPH_NODE_H

--- a/src/plugins/ros2/navgraph_plugin.cpp
+++ b/src/plugins/ros2/navgraph_plugin.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *  navgraph_plugin.cpp - Relay messages between Navgraph Blackboard Interfaces
+ *                        and ROS2
+ *
+ *  Created: Dec 2023
+ *  Copyright  2023  Daniel Swoboda <swoboda@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "navgraph_thread.h"
+
+#include <core/plugin.h>
+
+using namespace fawkes;
+
+/** Plugin to relay messages between Navgraph Blackboard Interfaces and ROS2
+ */
+class ROS2NavgraphPlugin : public fawkes::Plugin
+{
+public:
+	/** Constructor.
+    * @param config Fawkes configuration
+    */
+	explicit ROS2NavgraphPlugin(Configuration *config) : Plugin(config)
+	{
+		thread_list.push_back(new ROS2NavgraphThread());
+	}
+};
+
+PLUGIN_DESCRIPTION("ROS CX Navgraph Blackboard Plugin")
+EXPORT_PLUGIN(ROS2NavgraphPlugin)

--- a/src/plugins/ros2/navgraph_thread.cpp
+++ b/src/plugins/ros2/navgraph_thread.cpp
@@ -1,0 +1,71 @@
+/***************************************************************************
+ *  navgraph_thread.cpp - Thread to relay between Navgraph Blackboard Interfaces
+ *                        and ROS2
+ *
+ *  Created: Dec 2023
+ *  Copyright  2023  Daniel Swoboda <swoboda@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#include "navgraph_thread.h"
+
+using namespace fawkes;
+
+/** @class ROS2NavgraphThread "navgraph_thread.h"
+ * Thread to relay between Navgraph Blackboard Interfaces and ROS2
+ * @author Daniel Swoboda
+ */
+
+/** Constructor. */
+ROS2NavgraphThread::ROS2NavgraphThread()
+: Thread("ROS2CXSkillerThread", Thread::OPMODE_WAITFORWAKEUP)
+{
+}
+
+/** Destructor. */
+ROS2NavgraphThread::~ROS2NavgraphThread()
+{
+}
+
+/** Initialize the thread.
+ * Open the blackboard interface and advertise the ROS topic.
+ * Register as listener for the blackboard interface.
+ */
+void
+ROS2NavgraphThread::init()
+{
+	navgraph_interface_ =
+	  blackboard->open_for_reading<NavGraphGeneratorInterface>("NavGraphGeneratorInterface",
+	                                                           "/navgraph-generator");
+	navgraph_mps_interface_ = blackboard->open_for_reading<NavGraphWithMPSGeneratorInterface>(
+	  "NavGraphWithMPSGeneratorInterface", "/navgraph-generator-mps");
+	navgraph_node_ = std::make_shared<ROS2NavgraphNode>("FawkesNavgraphNode",
+	                                                    std::chrono::nanoseconds(5000),
+	                                                    navgraph_interface_,
+	                                                    navgraph_mps_interface_);
+	navgraph_node_->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+	blackboard->register_listener(navgraph_node_.get());
+}
+
+/** Close all interfaces and ROS handles. */
+void
+ROS2NavgraphThread::finalize()
+{
+	blackboard->unregister_listener(navgraph_node_.get());
+	navgraph_node_.reset();
+	blackboard->close(navgraph_interface_);
+	blackboard->close(navgraph_mps_interface_);
+}

--- a/src/plugins/ros2/navgraph_thread.h
+++ b/src/plugins/ros2/navgraph_thread.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *  navgraph_thread.h - Thread to relay between Navgraph Blackboard Interfaces
+ *                      and ROS2
+ *
+ *  Created: Dec 2023
+ *  Copyright  2023  Daniel Swoboda <swoboda@kbsg.rwth-aachen.de>
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef _PLUGINS_ROS2_NAVGRAPH_THREAD_H_
+#define _PLUGINS_ROS2_NAVGRAPH_THREAD_H_
+
+#include "navgraph_node.h"
+
+#include <aspect/blackboard.h>
+#include <aspect/configurable.h>
+#include <aspect/logging.h>
+#include <blackboard/interface_listener.h>
+#include <core/threading/thread.h>
+#include <interfaces/NavGraphGeneratorInterface.h>
+#include <interfaces/NavGraphWithMPSGeneratorInterface.h>
+#include <plugins/ros2/aspect/ros2.h>
+
+#include <rclcpp/rclcpp.hpp>
+class ROS2NavgraphThread : public fawkes::Thread,
+                           public fawkes::ConfigurableAspect,
+                           public fawkes::LoggingAspect,
+                           public fawkes::ROS2Aspect,
+                           public fawkes::BlackBoardAspect
+{
+public:
+	ROS2NavgraphThread();
+	virtual ~ROS2NavgraphThread();
+
+	virtual void init();
+	virtual void finalize();
+
+private:
+	std::shared_ptr<fawkes::ROS2NavgraphNode>  navgraph_node_;
+	fawkes::NavGraphGeneratorInterface        *navgraph_interface_;
+	fawkes::NavGraphWithMPSGeneratorInterface *navgraph_mps_interface_;
+};
+
+#endif /* PLUGINS_ROS2_NAVGRAPH_THREAD_H__ */

--- a/src/plugins/ros2/node_thread.cpp
+++ b/src/plugins/ros2/node_thread.cpp
@@ -88,6 +88,7 @@ ROS2NodeThread::init()
 
 		ros_namespace = std::string("/") + ros_namespace;
 	}
+	logger->log_warn(name(), ros_namespace.c_str());
 
 	if (node_handle == NULL || !node_handle->get_node_options().context()->is_valid()) {
 		node_handle = rclcpp::Node::make_shared(node_name, ros_namespace);

--- a/src/plugins/ros2/node_thread.cpp
+++ b/src/plugins/ros2/node_thread.cpp
@@ -99,15 +99,13 @@ ROS2NodeThread::init()
 
 	bool yield_before_execute = true;
 
-	mult_executor = new rclcpp::executors::MultiThreadedExecutor(rclcpp::ExecutorOptions(),
+	mult_executor =
+	  std::make_shared<rclcpp::executors::MultiThreadedExecutor>(rclcpp::ExecutorOptions(),
 	                                                             2u,
 	                                                             yield_before_execute);
+	ros2_aspect_inifin_.set_executor(mult_executor);
 
-	if (cfg_async_spinning_) {
-		mult_executor->add_node(node_handle);
-		std::thread executor_thread(
-		  std::bind(&rclcpp::executors::MultiThreadedExecutor::spin, mult_executor));
-	}
+	mult_executor->add_node(node_handle);
 }
 
 void
@@ -120,7 +118,7 @@ ROS2NodeThread::finalize()
 void
 ROS2NodeThread::loop()
 {
-	if (!cfg_async_spinning_) {
-		rclcpp::spin_some(node_handle);
+	if (!mult_executor->is_spinning()) {
+		mult_executor->spin();
 	}
 }

--- a/src/plugins/ros2/node_thread.h
+++ b/src/plugins/ros2/node_thread.h
@@ -72,8 +72,8 @@ private:
 
 	//	rclcpp::executors::MultiThreadedExecutor executor;
 	//	rclcpp::executors::SingleThreadedExecutor executor;
-	rclcpp::executors::MultiThreadedExecutor *mult_executor;
-	std::chrono::duration<double>             period = std::chrono::milliseconds(10);
+	std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> mult_executor;
+	std::chrono::duration<double>                             period = std::chrono::milliseconds(10);
 };
 
 #endif

--- a/src/plugins/ros2/skill_node.cpp
+++ b/src/plugins/ros2/skill_node.cpp
@@ -1,0 +1,96 @@
+/***************************************************************************
+ *  skill_node.cpp
+ *
+ *  Created: 04 August 2023
+ *  Copyright  2023 Daniel Swoboda
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+#include "skill_node.h"
+
+#include "lifecycle_msgs/msg/state.hpp"
+
+#include <interfaces/SkillerInterface.h>
+namespace fawkes {
+
+using namespace std::chrono_literals;
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+SkillNode::SkillNode(const std::string              &id,
+                     const std::string              &robot,
+                     const std::string              &executor,
+                     const std::chrono::nanoseconds &rate,
+                     fawkes::SkillerInterface       *skiller_if)
+: SkillExecution(id, rate), BlackBoardInterfaceListener("SkillNode"), skiller_if_(skiller_if)
+{
+	robot_id_    = robot;
+	executor_id_ = executor;
+	bbil_add_data_interface(skiller_if);
+	SkillerInterface::AcquireControlMessage *aqm = new SkillerInterface::AcquireControlMessage();
+	skiller_if->msgq_enqueue(aqm);
+}
+
+SkillNode::~SkillNode()
+{
+	SkillerInterface::ReleaseControlMessage *rcm = new SkillerInterface::ReleaseControlMessage();
+	skiller_if_->msgq_enqueue(rcm);
+}
+
+CallbackReturn
+SkillNode::on_activate(const rclcpp_lifecycle::State &state)
+{
+	sent_command_ = false;
+	SkillerInterface::ExecSkillMessage *esm =
+	  new SkillerInterface::ExecSkillMessage(mapped_action_.c_str());
+
+	skiller_if_->msgq_enqueue(esm);
+	RCLCPP_INFO_STREAM(get_logger(), "Starting execution!");
+
+	return SkillExecution::on_activate(state);
+}
+
+void
+SkillNode::perform_execution()
+{
+	RCLCPP_INFO_STREAM(get_logger(), "Polling");
+}
+
+/** Handle interface changes.
+ * If the Skiller interface changes, publish updated data to ROS.
+ * @param interface interface instance that you supplied to bbil_add_data_interface()
+ */
+void
+SkillNode::bb_interface_data_refreshed(Interface *interface) noexcept
+{
+	SkillerInterface *skiller_if = dynamic_cast<SkillerInterface *>(interface);
+	if (!skiller_if)
+		return;
+	skiller_if->read();
+	if (skiller_if->serial().get_string() != std::string(skiller_if->exclusive_controller())) {
+		finish_execution(false, 0.0, "Skiller Control Lost");
+		return;
+	}
+	if (!sent_command_) {
+		switch (skiller_if->status()) {
+		case fawkes::SkillerInterface::SkillStatusEnum::S_INACTIVE: send_feedback(0.0, "inactive");
+		case fawkes::SkillerInterface::SkillStatusEnum::S_FINAL:
+			finish_execution(true, 1.0, "completed");
+		case fawkes::SkillerInterface::SkillStatusEnum::S_RUNNING: send_feedback(0.0, "running");
+		case fawkes::SkillerInterface::SkillStatusEnum::S_FAILED:
+			finish_execution(true, 1.0, skiller_if->error());
+		}
+	}
+}
+
+} // namespace fawkes

--- a/src/plugins/ros2/skill_node.h
+++ b/src/plugins/ros2/skill_node.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+ *  skill_node.hp
+ *
+ *  Created: 04 August 2023
+ *  Copyright  2023 Daniel Swoboda
+ ****************************************************************************/
+
+/*  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Library General Public License for more details.
+ *
+ *  Read the full text in the LICENSE.GPL file in the doc directory.
+ */
+
+#ifndef SKILL_NODE_H
+#define SKILL_NODE_H
+
+#include <aspect/blackboard.h>
+#include <blackboard/interface_listener.h>
+#include <interfaces/SkillerInterface.h>
+
+#include <chrono>
+#include <cx_msgs/msg/skill_action_exec_info.hpp>
+#include <cx_msgs/msg/skill_execution.hpp>
+#include <cx_skill_execution/SkillExecution.hpp>
+#include <fstream>
+#include <iostream>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <map>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <regex>
+#include <string>
+
+namespace fawkes {
+using namespace std::chrono_literals;
+
+class SkillNode : public cx::SkillExecution, public fawkes::BlackBoardInterfaceListener
+{
+	using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+public:
+	SkillNode(const std::string              &id,
+	          const std::string              &robot,
+	          const std::string              &executor,
+	          const std::chrono::nanoseconds &rate,
+	          fawkes::SkillerInterface       *skiller_if);
+	~SkillNode();
+
+	CallbackReturn on_activate(const rclcpp_lifecycle::State &state);
+
+	void         perform_execution() override;
+	virtual void bb_interface_data_refreshed(fawkes::Interface *interface) noexcept override;
+
+private:
+	fawkes::SkillerInterface *skiller_if_;
+
+	bool sent_command_ = false;
+	bool executing_    = false;
+};
+} // namespace fawkes
+#endif // !SKILL_NAODE_H


### PR DESCRIPTION
Depends on #370

This PR exposes the interfaces for the Navgraph Generator and NavgraphWithMPSGenerator plugin to ROS2 via a mixture of service calls and publishers.