### PR TITLE
switch to f40

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fawkesrobotics/fawkes-builder:f39-ros2
+FROM quay.io/fawkesrobotics/fawkes-builder:f40-ros2
 
 COPY . /workdir
 WORKDIR /workdir/build

--- a/src/libs/syncpoint/tests/test_syncpoint.cpp
+++ b/src/libs/syncpoint/tests/test_syncpoint.cpp
@@ -347,7 +347,7 @@ struct waiter_thread_params
 	/** timeout in nsec */
 	uint timeout_nsec = 0;
 	/** current status of the thread */
-	atomic<ThreadStatus> status;
+	atomic<ThreadStatus> status = ThreadStatus::PENDING ;
 	/** Mutex to protect cond_running */
 	Mutex mutex_running;
 	/** WaitCondition to indicate that the thread is running */
@@ -1055,7 +1055,7 @@ struct emitter_thread_data
 	RefPtr<SyncPointManager> manager;
 	std::string              name;
 	std::string              sp_name;
-	atomic<ThreadStatus>     status;
+	atomic<ThreadStatus>     status = ThreadStatus::PENDING;
 	Mutex                    mutex_running;
 	WaitCondition            cond_running = WaitCondition(&mutex_running);
 	Mutex                    mutex_finished;

--- a/src/plugins/clips-pddl-parser/precondition_visitor.cpp
+++ b/src/plugins/clips-pddl-parser/precondition_visitor.cpp
@@ -24,6 +24,8 @@
 
 #include <pddl_parser/pddl_exception.h>
 
+#include <sstream>
+
 /** @class PreconditionToCLIPSFactVisitor "precondition_visitor.h"
  * Translate a PDDL precondition into CLIPS facts.
  * @author Till Hofmann

--- a/src/plugins/rrd/CMakeLists.txt
+++ b/src/plugins/rrd/CMakeLists.txt
@@ -21,7 +21,7 @@
 # *****************************************************************************
 
 set(PLUGIN_rrd
-    ON
+    OFF
     CACHE BOOL "Build rrd plugin")
 add_subdirectory(aspect)
 

--- a/src/plugins/rrd/rrd_thread.cpp
+++ b/src/plugins/rrd/rrd_thread.cpp
@@ -101,7 +101,7 @@ RRDThread::generate_graphs()
 		//}
 
 		rrd_clear_error();
-		rrd_info_t *i = rrd_graph_v(argc, (char **)argv);
+		rrd_info_t *i = rrd_graph_v(argc, (const char **)argv);
 		if (i == NULL) {
 			throw Exception("Creating graph %s (for RRD %s) failed: %s",
 			                (*g)->get_name(),
@@ -155,7 +155,7 @@ RRDThread::add_rrd(RRDDefinition *rrd_def)
 
 		// Create RRD file
 		rrd_clear_error();
-		if (rrd_create(i, (char **)rrd_argv) == -1) {
+		if (rrd_create(i, (const char **)rrd_argv) == -1) {
 			throw Exception("Creating RRD %s failed: %s", rrd_def->get_name(), rrd_get_error());
 		}
 	}
@@ -253,7 +253,7 @@ RRDThread::add_data(const char *rrd_name, const char *format, ...)
 			//}
 
 			rrd_clear_error();
-			if (rrd_update(i, (char **)rrd_argv) == -1) {
+			if (rrd_update(i, (const char **)rrd_argv) == -1) {
 				free(data);
 				throw Exception("Failed to update RRD %s: %s", rrd_name, rrd_get_error());
 			}


### PR DESCRIPTION
There is an issue with rrdtool-devel, which has a changed interface despite not having a version change (at least according to pkg-config, dnf actually shows that it was bumped a few times in f40).
This causes incompatibilities with f39, hence I opted to disable the plugin for now, despite the fixes supplied here.
