### PR TITLE
better grounding cleanup

### DIFF
--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -1155,3 +1155,23 @@
                         " but has " (length$ ?param-names) " parameters,"
                         " should be 2."))))
 )
+
+(defrule domain-grounding-cleanup-predicates
+  (grounded-pddl-predicate (grounding ?g))
+  (not (pddl-grounding (id ?g)))
+  =>
+  (do-for-all-facts ((?precond grounded-pddl-predicate))
+                    (eq ?precond:grounding ?g)
+    (retract ?precond)
+  )
+)
+
+(defrule domain-grounding-cleanup-formulas
+  (grounded-pddl-formula (grounding ?g))
+  (not (pddl-grounding (id ?g)))
+  =>
+  (do-for-all-facts ((?precond grounded-pddl-formula))
+                    (eq ?precond:grounding ?g)
+    (retract ?precond)
+  )
+)

--- a/src/plugins/clips-executive/clips/domain.clp
+++ b/src/plugins/clips-executive/clips/domain.clp
@@ -477,9 +477,10 @@
     else
       (bind ?index (member$ ?param ?grounded-names))
       (if (not ?index) then
-        (assert (domain-error (error-type unknown-parameter) (error-msg
-          (str-cat "PDDL Predicate has unknown parameter " ?param)))
-        )
+        (printout error "PDDL Predicate has unknown parameter " ?param " (" ?grounded-names " vs " ?names  ") " crlf)
+        ; (assert (domain-error (error-type unknown-parameter) (error-msg
+        ;   (str-cat "PDDL Predicate has unknown parameter " ?param)))
+        ; )
         (return FALSE)
       else
         (bind ?values


### PR DESCRIPTION
This PR allows for more targeted cleanup of grounded pddl formulas.
Currently, all formulas get removed whenever one formula should be, which triggers a mass re-grounding of formulas. Depending on the number of grounded formulas, this can be quite expensive.
Hence, avoid this by actually only cleaning up groundings when needed.

Note that this can have side effects as potentially some pddl-groundings could dangle without ever being cleaned up (e.g., if a plan action is formulated but removed again before being executed).

Hence it is advisable to clean up pddl-groundings manually (or periodically).