### PR TITLE
various speedup

### DIFF
--- a/src/plugins/realsense2/realsense2_thread.cpp
+++ b/src/plugins/realsense2/realsense2_thread.cpp
@@ -35,9 +35,7 @@ using namespace fawkes;
  */
 
 Realsense2Thread::Realsense2Thread()
-: Thread("Realsense2Thread", Thread::OPMODE_WAITFORWAKEUP),
-  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_SENSOR_ACQUIRE),
-  switch_if_(NULL)
+: Thread("Realsense2Thread", Thread::OPMODE_CONTINUOUS), switch_if_(NULL)
 {
 }
 
@@ -52,8 +50,10 @@ Realsense2Thread::init()
 	  config->get_string_or_default((cfg_prefix + "switch_if_name").c_str(), "realsense2");
 	restart_after_num_errors_ =
 	  config->get_uint_or_default((cfg_prefix + "restart_after_num_errors").c_str(), 50);
-	frame_rate_  = config->get_uint_or_default((cfg_prefix + "frame_rate").c_str(), 30);
-	laser_power_ = config->get_float_or_default((cfg_prefix + "laser_power").c_str(), -1);
+	frame_rate_   = config->get_uint_or_default((cfg_prefix + "frame_rate").c_str(), 30);
+	laser_power_  = config->get_float_or_default((cfg_prefix + "laser_power").c_str(), -1);
+	int frequency = config->get_float_or_default((cfg_prefix + "loop_time").c_str(), 66333);
+	sleep_time_   = std::chrono::microseconds(frequency);
 
 	cfg_use_switch_ = config->get_bool_or_default((cfg_prefix + "use_switch").c_str(), true);
 
@@ -187,6 +187,7 @@ Realsense2Thread::loop()
 			start_camera();
 		}
 	}
+	std::this_thread::sleep_for(sleep_time_);
 }
 
 void

--- a/src/plugins/realsense2/realsense2_thread.h
+++ b/src/plugins/realsense2/realsense2_thread.h
@@ -48,7 +48,6 @@ class SwitchInterface;
 }
 
 class Realsense2Thread : public fawkes::Thread,
-                         public fawkes::BlockedTimingAspect,
                          public fawkes::LoggingAspect,
                          public fawkes::ConfigurableAspect,
                          public fawkes::BlackBoardAspect,
@@ -131,6 +130,8 @@ private:
 	size_t      name_it_;
 	uint        rgb_error_counter_ = 0;
 	std::string serial_no_;
+
+	std::chrono::microseconds sleep_time_;
 };
 
 #endif

--- a/src/plugins/ros2/motorinterface_thread.cpp
+++ b/src/plugins/ros2/motorinterface_thread.cpp
@@ -29,7 +29,7 @@ using namespace fawkes;
 
 /** Constructor. */
 ROS2MotorInterfaceThread::ROS2MotorInterfaceThread()
-: Thread("ROS2MotorInterfaceThread", Thread::OPMODE_CONTINUOUS),
+: Thread("ROS2MotorInterfaceThread", Thread::OPMODE_WAITFORWAKEUP),
   BlackBoardInterfaceListener("ROS2MotorInterfaceThread")
 {
 }

--- a/src/plugins/ros2/navigator_thread.cpp
+++ b/src/plugins/ros2/navigator_thread.cpp
@@ -32,8 +32,8 @@ using namespace fawkes;
  * @param cfg_prefix configuration prefix specific for the ros/navigator
  */
 ROS2NavigatorThread::ROS2NavigatorThread(std::string &cfg_prefix)
-: Thread("ROS2NavigatorThread", Thread::OPMODE_CONTINUOUS),
-  //  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT),
+: Thread("ROS2NavigatorThread", Thread::OPMODE_WAITFORWAKEUP),
+  BlockedTimingAspect(BlockedTimingAspect::WAKEUP_HOOK_ACT),
   cfg_prefix_(cfg_prefix)
 {
 }
@@ -524,7 +524,6 @@ ROS2NavigatorThread::loop()
 			nav_if_->msgq_pop();
 		} // while
 	}
-	usleep(100000);
 }
 
 void

--- a/src/plugins/ros2/navigator_thread.h
+++ b/src/plugins/ros2/navigator_thread.h
@@ -53,6 +53,7 @@ class ROS2NavigatorThread : public fawkes::Thread,
                             //                           public fawkes::BlockedTimingAspect,
                             public fawkes::LoggingAspect,
                             public fawkes::BlackBoardAspect,
+                            public fawkes::BlockedTimingAspect,
                             public fawkes::ConfigurableAspect,
                             public fawkes::ROS2Aspect,
                             public fawkes::TransformAspect


### PR DESCRIPTION
This PR fixes some crucial performance issues:
1. the ros2 motor interface was needlessly polling in the unused loop function, maxing out a thread
2. the realsense2 thread is generally quite slow and causes the desired loop time to constantly be crossed. Instead, put it in a separate thread at a more realistic rate.
3. Not really an issue, but the ros2 navigator on the other hand should probably be part of the managed loop hooks, as it can easily keep the desired loop rates. This gets rid of the arbitrary usleep function.

~TODOs:~
 - ~test more on real robots~
 - ~make realsense2 update rate a config value~
